### PR TITLE
124 enhancement loading spinner placement

### DIFF
--- a/explorer/app/streamlit/app.py
+++ b/explorer/app/streamlit/app.py
@@ -32,11 +32,11 @@ Streamlit does not expose the browser language to Python.
 ``checklist_stats_streamlit_tab_sections_html``). ``sync_checklist_stats_tab_session_inputs`` + ``@st.fragment``
 match Country / Yearly (refs #70).
 
-**Prep vs Map spinners:** Each full rerun, ``cached_checklist_stats_payload(work_df, taxonomy_locale)``, full-export prep
-(Maintenance / Rankings as needed), and sync helpers run in one **prep** ``st.spinner(...)`` **above** the main
-tab row (with the same bird-emoji strip as the Map tab). The **Map** tab Folium build + ``st_folium`` use a
-**second** ``st.spinner`` inside the Map panel so loading stays visible while that tab’s content runs; other main
-tab bodies render after the prep spinner exits.
+**Prep vs Map load:** One **sidebar** ``st.spinner`` in a **dedicated bottom slot** (reserved height + same styling as the
+footer band) wraps the full synchronous dashboard load for each full rerun: checklist prep, tab sync helpers, **and**
+Folium build (bird-emoji strip under the spinner). The Map tab embeds ``st_folium`` from that pass. Export HTML + footer
+links render in that same bottom region after the spinner phase. Partial ``@st.fragment`` reruns do not use this spinner
+(refs #124).
 
 **Country:** Per-country yearly table uses the same ``CHECKLIST_STATS_*`` HTML/CSS as Checklist Statistics
 (``country_stats_streamlit_html``). The tab runs inside ``@st.fragment`` so changing the country selectbox
@@ -55,8 +55,9 @@ triggers a **partial rerun** (not the whole map/checklist pipeline) (refs #75).
 recent year columns** (default 10). ``sync_yearly_summary_session_inputs`` + ``run_yearly_summary_streamlit_fragment``
 match the Country tab fragment pattern (refs #85).
 
-**Main tabs + sidebar:** Prep work runs in a spinner above the tab row; the Map tab body uses an inner ``st.spinner`` each full rerun. Data tabs use ``@st.fragment`` where possible. One always-on
-sidebar for map controls plus footer links (refs #70). Settings use a keyed container with
+**Main tabs + sidebar:** Primary ``st.tabs`` first (empty panels until filled). Prep + ``st_folium`` run inside a sidebar
+bottom ``st.spinner`` so the main column is not displaced. Data tabs use ``@st.fragment`` where possible. One sidebar
+for map controls, export, and footer links (refs #70). Settings use a keyed container with
 ``max-width: min(100%, 40rem)`` on wide viewports. **Tables & lists** controls are batched in a form (one rerun on **Apply**).
 """
 
@@ -167,6 +168,8 @@ from explorer.app.streamlit.app_map_ui import (  # noqa: E402
     ensure_streamlit_map_basemap_height_keys,
     inject_spinner_theme_css,
     place_spinner_emoji_strip,
+    sidebar_bottom_slot_end,
+    sidebar_bottom_slot_start,
     sidebar_footer_links,
     species_searchbox_fragment,
 )
@@ -367,6 +370,17 @@ def main() -> None:
     with st.sidebar:
         st.header("Map")
 
+        map_style = st.selectbox(
+            "Basemap",
+            options=list(MAP_BASEMAP_OPTIONS),
+            format_func=lambda k: MAP_BASEMAP_LABELS.get(k, k),
+            key=STREAMLIT_MAP_BASEMAP_KEY,
+        )
+        st.markdown(
+            '<div style="height:0.65rem" aria-hidden="true"></div>',
+            unsafe_allow_html=True,
+        )
+
         map_view_label = st.selectbox(
             "Map view",
             list(MAP_VIEW_LABELS),
@@ -502,16 +516,6 @@ def main() -> None:
 
     with st.sidebar:
         st.divider()
-        map_style = st.selectbox(
-            "Basemap",
-            options=list(MAP_BASEMAP_OPTIONS),
-            format_func=lambda k: MAP_BASEMAP_LABELS.get(k, k),
-            key=STREAMLIT_MAP_BASEMAP_KEY,
-        )
-        st.markdown(
-            '<div style="height:0.65rem" aria-hidden="true"></div>',
-            unsafe_allow_html=True,
-        )
         map_height = st.slider(
             "Map height (px)",
             min_value=MAP_HEIGHT_PX_MIN,
@@ -549,50 +553,9 @@ def main() -> None:
     _title_with_logo()
     st.markdown("Your eBird data, made visible, navigable, and ready to explore")
 
-    # Spinner before tabs so loading shows above tab content (not below the tab panel; refs #74).
-    # Same emoji strip as Map tab: prep used to omit it, so first paint showed spinner-only until Map ran.
-    with st.spinner(CHECKLIST_STATS_SPINNER_TEXT):
-        _prep_spinner_emoji_placeholder = place_spinner_emoji_strip()
-        checklist_payload = cached_checklist_stats_payload(work_df, tax_locale_effective)
-        top_n = int(st.session_state.streamlit_rankings_top_n)
-        hc_sort = str(st.session_state.streamlit_high_count_sort)
-        hc_tb = str(st.session_state.streamlit_high_count_tie_break)
-        if df_full is not None and not df_full.empty:
-            maint_full_payload = cached_full_export_checklist_stats_payload(
-                df_full, top_n, hc_sort, hc_tb, tax_locale_effective
-            )
-            rankings_bundle = build_rankings_tab_bundle(
-                df_full,
-                country_sort=st.session_state.streamlit_country_tab_sort,
-                taxonomy_locale=tax_locale_effective,
-                high_count_sort=hc_sort,
-                high_count_tie_break=hc_tb,
-            )
-        else:
-            maint_full_payload = None
-            rankings_bundle = {}
-        # Sex notation is scanned from the raw export (not from maint payload). Same empty path as no
-        # ``maint_full_payload`` — skip cache call; ``get_sex_notation_by_year`` would return {} anyway.
-        sex_notation_by_year: dict = (
-            {} if df_full.empty else cached_sex_notation_by_year(df_full)
-        )
-
-        sync_checklist_stats_tab_session_inputs(checklist_payload)
-        sync_rankings_tab_session_inputs(rankings_bundle)
-        loc_maint = full_location_data_for_maintenance(df_full)
-        incomplete_maint: dict = {}
-        if maint_full_payload is not None:
-            incomplete_maint = maint_full_payload.incomplete_by_year or {}
-        sync_maintenance_tab_session_inputs(
-            loc_maint,
-            close_location_meters=int(st.session_state.streamlit_close_location_meters),
-            incomplete_by_year=incomplete_maint,
-            sex_notation_by_year=sex_notation_by_year,
-        )
-        sync_yearly_summary_session_inputs(checklist_payload)
-        sync_country_tab_session_inputs(checklist_payload)
-
-    _prep_spinner_emoji_placeholder.empty()
+    map_warning_text: str | None = None
+    map_for_folium = None
+    folium_st_key: str | None = None
 
     # Main tabs: plain ``st.tabs`` (no ``key`` / ``on_change``). Keyed lazy tabs existed only for Family Lists
     # “main tab” session bookkeeping; the Families flow now relies on dataframe selection only (refs #73).
@@ -606,9 +569,48 @@ def main() -> None:
         tab_settings,
     ) = st.tabs(NOTEBOOK_MAIN_TAB_LABELS)
 
-    with tab_map:
+    # Sidebar bottom slot: spinner + emoji; prep + Folium through ``st_folium`` (refs #124).
+    with st.sidebar:
+        sidebar_bottom_slot_start()
         with st.spinner(CHECKLIST_STATS_SPINNER_TEXT):
             _spinner_emoji_placeholder = place_spinner_emoji_strip()
+            checklist_payload = cached_checklist_stats_payload(work_df, tax_locale_effective)
+            top_n = int(st.session_state.streamlit_rankings_top_n)
+            hc_sort = str(st.session_state.streamlit_high_count_sort)
+            hc_tb = str(st.session_state.streamlit_high_count_tie_break)
+            if df_full is not None and not df_full.empty:
+                maint_full_payload = cached_full_export_checklist_stats_payload(
+                    df_full, top_n, hc_sort, hc_tb, tax_locale_effective
+                )
+                rankings_bundle = build_rankings_tab_bundle(
+                    df_full,
+                    country_sort=st.session_state.streamlit_country_tab_sort,
+                    taxonomy_locale=tax_locale_effective,
+                    high_count_sort=hc_sort,
+                    high_count_tie_break=hc_tb,
+                )
+            else:
+                maint_full_payload = None
+                rankings_bundle = {}
+            sex_notation_by_year: dict = (
+                {} if df_full.empty else cached_sex_notation_by_year(df_full)
+            )
+
+            sync_checklist_stats_tab_session_inputs(checklist_payload)
+            sync_rankings_tab_session_inputs(rankings_bundle)
+            loc_maint = full_location_data_for_maintenance(df_full)
+            incomplete_maint: dict = {}
+            if maint_full_payload is not None:
+                incomplete_maint = maint_full_payload.incomplete_by_year or {}
+            sync_maintenance_tab_session_inputs(
+                loc_maint,
+                close_location_meters=int(st.session_state.streamlit_close_location_meters),
+                incomplete_by_year=incomplete_maint,
+                sex_notation_by_year=sex_notation_by_year,
+            )
+            sync_yearly_summary_session_inputs(checklist_payload)
+            sync_country_tab_session_inputs(checklist_payload)
+
             prov_plain = provenance or ""
             sig = data_signature_for_caches(df_full, prov_plain)
             if st.session_state.get(EBIRD_DATA_SIG_KEY) != sig:
@@ -620,7 +622,7 @@ def main() -> None:
             try:
                 ctx = prepare_all_locations_map_context(work_df, full_df=df_full)
             except ValueError as e:
-                st.warning(str(e))
+                map_warning_text = str(e)
                 st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
             else:
                 overlay_common = (
@@ -657,8 +659,6 @@ def main() -> None:
                             MAP_CLUSTER_ALL_LOCATIONS_DEFAULT,
                         )
                     ),
-                    # For lifer mode we already communicate the “not date-filtered” behaviour in the
-                    # side panel. Avoid repeating "all-time data" text in the banner.
                     "date_filter_status": "" if is_lifer_view else date_filter_banner,
                     "species_url_fn": species_url_fn,
                     "base_species_fn": base_species_for_lifer,
@@ -692,9 +692,6 @@ def main() -> None:
                     bool(st.session_state.get(STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY, False)),
                     int(map_height),
                 )
-                # ``build_species_overlay_map`` treats **Species** with no species picked as the same
-                # geometry as **All locations** (``map_controller`` coerces mode to ``all``). Match that here
-                # so static Folium reuse applies when switching Map view All ↔ Species before a selection.
                 _species_selected = bool(overlay_sci)
                 _cache_map_view_mode = map_view_mode
                 if map_view_mode == "species" and not _species_selected:
@@ -710,8 +707,6 @@ def main() -> None:
                     species_selected_common=overlay_common if _species_selected else "",
                     hide_non_matching_locations=bool(hide_nm),
                 )
-                # One Folium map in session; key includes species + hide toggle so Selected species
-                # maps reuse on identical full reruns (e.g. switching tabs) without a multi-species LRU.
                 _use_static_cache = True
                 _cached = st.session_state.get(FOLIUM_STATIC_MAP_CACHE_KEY)
                 if (
@@ -733,13 +728,23 @@ def main() -> None:
                         }
 
                 if result_warning:
-                    st.warning(result_warning)
+                    map_warning_text = result_warning
                     st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
                 elif result_map is None:
-                    st.warning("Map could not be built.")
+                    map_warning_text = "Map could not be built."
                     st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
                 else:
                     st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = folium_map_to_html_bytes(result_map)
+                    map_for_folium = result_map
+                    folium_st_key = (
+                        f"explorer_folium_{abs(hash(_ck))}_h{map_height}_mv{map_view_mode}_n"
+                        f"{int(st.session_state.get(FOLIUM_MAP_MOUNT_NONCE_KEY, 0))}"
+                    )
+
+            with tab_map:
+                if map_warning_text is not None:
+                    st.warning(map_warning_text)
+                elif map_for_folium is not None and folium_st_key is not None:
                     try:
                         from streamlit_folium import st_folium
                     except ImportError:
@@ -751,22 +756,35 @@ def main() -> None:
                         )
                         st.stop()
                     st_folium(
-                        result_map,
+                        map_for_folium,
                         use_container_width=True,
                         height=map_height,
                         # ``_ck`` coerces **Species** with no pick to ``all`` so we reuse one Folium build
                         # when the cache is valid. *map_view_mode* + *FOLIUM_MAP_MOUNT_NONCE_KEY* force a
                         # distinct streamlit-folium component identity when the sidebar layout changes
                         # (All↔Species); see invalidation block above.
-                        key=(
-                            f"explorer_folium_{abs(hash(_ck))}_h{map_height}_mv{map_view_mode}_n"
-                            f"{int(st.session_state.get(FOLIUM_MAP_MOUNT_NONCE_KEY, 0))}"
-                        ),
+                        key=folium_st_key,
                         returned_objects=[],
                         return_on_hover=False,
                     )
 
-            _spinner_emoji_placeholder.empty()  # Drop emoji iframe once load finishes (refs #74).
+        _spinner_emoji_placeholder.empty()
+        _has_map_export = bool(st.session_state.get(EXPLORER_MAP_HTML_BYTES_KEY))
+        if _has_map_export:
+            st.divider()
+            _ex1, _ex2, _ex3 = st.columns([1, 3, 1])
+            with _ex2:
+                st.download_button(
+                    "Export map HTML",
+                    data=st.session_state[EXPLORER_MAP_HTML_BYTES_KEY],
+                    file_name=MAP_EXPORT_HTML_FILENAME,
+                    mime="text/html",
+                    key=EXPORT_MAP_HTML_BTN_KEY,
+                    help="Standalone HTML for the current map.",
+                    use_container_width=True,
+                )
+        sidebar_footer_links(leading_divider=not _has_map_export)
+        sidebar_bottom_slot_end()
 
     with tab_checklist:
         run_checklist_stats_streamlit_fragment()
@@ -1081,21 +1099,6 @@ def main() -> None:
                 ),
                 unsafe_allow_html=True,
             )
-
-    if st.session_state.get(EXPLORER_MAP_HTML_BYTES_KEY):
-        with st.sidebar:
-            st.divider()
-            st.download_button(
-                "Export map HTML",
-                data=st.session_state[EXPLORER_MAP_HTML_BYTES_KEY],
-                file_name=MAP_EXPORT_HTML_FILENAME,
-                mime="text/html",
-                key=EXPORT_MAP_HTML_BTN_KEY,
-                help="Standalone HTML for the current map.",
-            )
-
-    sidebar_footer_links()
-
 
 if __name__ == "__main__":
     main()

--- a/explorer/app/streamlit/app.py
+++ b/explorer/app/streamlit/app.py
@@ -166,6 +166,7 @@ from explorer.app.streamlit.app_constants import (  # noqa: E402
 from explorer.app.streamlit.app_data_loading import load_dataframe  # noqa: E402
 from explorer.app.streamlit.app_map_ui import (  # noqa: E402
     ensure_streamlit_map_basemap_height_keys,
+    inject_sidebar_control_label_css,
     inject_spinner_theme_css,
     place_spinner_emoji_strip,
     sidebar_bottom_slot_end,
@@ -367,6 +368,10 @@ def main() -> None:
     # sidebar toggle (same key); stash and apply here before the sidebar instantiates that widget.
     apply_pending_map_cluster_toggle(st.session_state)
 
+    # Spinner + sidebar **control** label CSS before Map sidebar so first paint matches later reruns (refs #124).
+    inject_spinner_theme_css()
+    inject_sidebar_control_label_css()
+
     with st.sidebar:
         st.header("Map")
 
@@ -547,8 +552,6 @@ def main() -> None:
     popup_scroll_hint = st.session_state.streamlit_popup_scroll_hint
     mark_lifer = bool(st.session_state.streamlit_mark_lifer)
     mark_last_seen = bool(st.session_state.streamlit_mark_last_seen)
-
-    inject_spinner_theme_css()
 
     _title_with_logo()
     st.markdown("Your eBird data, made visible, navigable, and ready to explore")

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -228,11 +228,23 @@ SPINNER_THEME_CSS_INJECTED_KEY = f"_ebird_spinner_theme_css_injected_{SPINNER_TH
 SPINNER_THEME_CSS = f"""
 <style>
 /* Hoisted ``st.spinner`` — theme greens (refs #74); bump SPINNER_THEME_CSS_CACHE_KEY_SUFFIX when CSS changes. */
+/* In-flow pill (no position:fixed): avoids covering the title; spinner sits in script order after the subtitle. */
 /* Modern Streamlit uses an icon spinner (``iconValue: spinner``), not a CSS border ring. */
 div[data-testid="stSpinner"],
 div[data-testid="stSpinner"].stSpinner {{
   color: {THEME_PRIMARY_HEX};
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  display: inline-flex !important;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.4rem 0.95rem !important;
+  margin: 0.15rem 0 0.35rem 0 !important;
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
+  border: 1px solid rgba(31, 111, 84, 0.14);
+  max-width: min(96vw, 42rem);
 }}
 /* Graphic: ``currentColor`` on the SVG so the arc tracks primary (not default grey). */
 div[data-testid="stSpinner"] svg {{
@@ -261,6 +273,35 @@ div[data-testid="stSpinner"] label {{
 div[data-testid="stSpinner"] div[class*="Spinner"] {{
   border-color: {THEME_SECONDARY_BG_HEX} !important;
   border-top-color: {THEME_PRIMARY_HEX} !important;
+}}
+
+/* Bird-emoji strip (only ``components.html`` in Explorer uses height 52): tuck under spinner, centered. */
+[data-testid="stAppViewContainer"] main iframe[height="52"],
+[data-testid="stSidebar"] iframe[height="52"] {{
+  display: block !important;
+  margin: 0.1rem auto 0.4rem auto !important;
+  border: none !important;
+  max-width: 100%;
+}}
+[data-testid="stSidebar"] div[data-testid="stSpinner"],
+[data-testid="stSidebar"] div[data-testid="stSpinner"].stSpinner {{
+  max-width: 100%;
+  box-sizing: border-box;
+  /* Keep spinner in normal sidebar flow (no viewport-fixed “floating pill” glitches). */
+  position: relative !important;
+  left: auto !important;
+  top: auto !important;
+  transform: none !important;
+  display: flex !important;
+  width: 100%;
+}}
+/* Reserve a stable bottom band: spinner + emoji share the same footprint as the footer links. */
+[data-testid="stSidebar"] .ebird-sidebar-bottom-slot {{
+  min-height: 7.5rem;
+  padding-top: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
 }}
 </style>
 """

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -20,7 +20,6 @@ from explorer.core.settings_schema_defaults import (
 )
 from explorer.app.streamlit.defaults import (
     SETTINGS_PANEL_MAX_WIDTH_REM,
-    SPINNER_THEME_CSS_CACHE_KEY_SUFFIX,
     THEME_PRIMARY_HEX,
     THEME_SECONDARY_BG_HEX,
     THEME_TEXT_HEX,
@@ -222,8 +221,6 @@ SETTINGS_SESSION_KEYS = (
     STREAMLIT_COUNTRY_TAB_SORT_KEY,
     STREAMLIT_CLOSE_LOCATION_METERS_KEY,
 )
-
-SPINNER_THEME_CSS_INJECTED_KEY = f"_ebird_spinner_theme_css_injected_{SPINNER_THEME_CSS_CACHE_KEY_SUFFIX}"
 
 SPINNER_THEME_CSS = f"""
 <style>

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -224,8 +224,7 @@ SETTINGS_SESSION_KEYS = (
 
 SPINNER_THEME_CSS = f"""
 <style>
-/* Hoisted ``st.spinner`` — theme greens (refs #74); bump SPINNER_THEME_CSS_CACHE_KEY_SUFFIX when CSS changes. */
-/* In-flow pill (no position:fixed): avoids covering the title; spinner sits in script order after the subtitle. */
+/* ``st.spinner`` — text-style (no pill): theme greens on icon + label only (refs #74). */
 /* Modern Streamlit uses an icon spinner (``iconValue: spinner``), not a CSS border ring. */
 div[data-testid="stSpinner"],
 div[data-testid="stSpinner"].stSpinner {{
@@ -235,12 +234,12 @@ div[data-testid="stSpinner"].stSpinner {{
   align-items: center;
   flex-wrap: wrap;
   gap: 0.5rem;
-  padding: 0.4rem 0.95rem !important;
-  margin: 0.15rem 0 0.35rem 0 !important;
-  border-radius: 0.5rem;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
-  border: 1px solid rgba(31, 111, 84, 0.14);
+  padding: 0 !important;
+  margin: 0.15rem 0 0.25rem 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  border: none !important;
   max-width: min(96vw, 42rem);
 }}
 /* Graphic: ``currentColor`` on the SVG so the arc tracks primary (not default grey). */
@@ -284,7 +283,7 @@ div[data-testid="stSpinner"] div[class*="Spinner"] {{
 [data-testid="stSidebar"] div[data-testid="stSpinner"].stSpinner {{
   max-width: 100%;
   box-sizing: border-box;
-  /* Keep spinner in normal sidebar flow (no viewport-fixed “floating pill” glitches). */
+  /* In-flow only (no fixed positioning). */
   position: relative !important;
   left: auto !important;
   top: auto !important;

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -292,24 +292,21 @@ div[data-testid="stSpinner"] div[class*="Spinner"] {{
   display: flex !important;
   width: 100%;
 }}
-/* Bottom band (spinner, export, footer): sticky to the visible sidebar so it stays on-screen while
-   map controls above scroll (refs #124). Solid bg + edge shadow so content does not show through. */
+/* Bottom region (spinner, export, footer): sticky within the sidebar scroll area only — no separate
+   “panel” colour or min-height (those read as an empty box when idle; refs #124). */
 [data-testid="stSidebar"] .ebird-sidebar-bottom-slot {{
   position: sticky;
   bottom: 0;
-  z-index: 5;
+  z-index: 2;
   width: 100%;
   box-sizing: border-box;
-  min-height: 7.5rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.25rem;
-  margin-top: 0.35rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.15rem;
+  margin-top: 0.15rem;
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
-  background: {THEME_SECONDARY_BG_HEX};
-  box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.06);
-  border-top: 1px solid rgba(31, 111, 84, 0.12);
+  background: transparent;
 }}
 </style>
 """

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -292,13 +292,24 @@ div[data-testid="stSpinner"] div[class*="Spinner"] {{
   display: flex !important;
   width: 100%;
 }}
-/* Reserve a stable bottom band: spinner + emoji share the same footprint as the footer links. */
+/* Bottom band (spinner, export, footer): sticky to the visible sidebar so it stays on-screen while
+   map controls above scroll (refs #124). Solid bg + edge shadow so content does not show through. */
 [data-testid="stSidebar"] .ebird-sidebar-bottom-slot {{
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  width: 100%;
+  box-sizing: border-box;
   min-height: 7.5rem;
-  padding-top: 0.35rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.25rem;
+  margin-top: 0.35rem;
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
+  background: {THEME_SECONDARY_BG_HEX};
+  box-shadow: 0 -4px 14px rgba(0, 0, 0, 0.06);
+  border-top: 1px solid rgba(31, 111, 84, 0.12);
 }}
 </style>
 """

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -305,3 +305,37 @@ div[data-testid="stSpinner"] div[class*="Spinner"] {{
 }}
 </style>
 """
+
+# Sidebar **control** labels only (selectbox, slider, toggles) — not the loading spinner. Injected separately
+# and early so typography matches on first paint; bump SPINNER_THEME_CSS_CACHE_KEY_SUFFIX when this changes.
+SIDEBAR_CONTROL_LABEL_CSS = f"""
+<style>
+[data-testid="stSidebar"] [data-testid="stWidgetLabel"],
+[data-testid="stSidebar"] [data-testid="stWidgetLabel"] span,
+[data-testid="stSidebar"] [data-testid="stWidgetLabel"] p {{
+  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important;
+  font-size: 0.875rem !important;
+  font-weight: 500 !important;
+  line-height: 1.45 !important;
+  letter-spacing: normal !important;
+  color: {THEME_TEXT_HEX};
+  color: color-mix(in srgb, {THEME_PRIMARY_HEX} 22%, {THEME_TEXT_HEX}) !important;
+}}
+[data-testid="stSidebar"] label[data-baseweb="checkbox"] > div:first-of-type {{
+  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important;
+  font-size: 0.875rem !important;
+  font-weight: 500 !important;
+  line-height: 1.45 !important;
+  letter-spacing: normal !important;
+  color: {THEME_TEXT_HEX};
+  color: color-mix(in srgb, {THEME_PRIMARY_HEX} 22%, {THEME_TEXT_HEX}) !important;
+}}
+[data-testid="stSidebar"] label[data-baseweb="checkbox"] > div:first-of-type span {{
+  font-family: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  line-height: inherit !important;
+  color: inherit !important;
+}}
+</style>
+"""

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -16,7 +16,6 @@ from explorer.app.streamlit.app_constants import (
     SESSION_SPECIES_SEARCH_KEY,
     SIDEBAR_CONTROL_LABEL_CSS,
     SPINNER_THEME_CSS,
-    SPINNER_THEME_CSS_INJECTED_KEY,
 )
 from explorer.app.streamlit.defaults import (
     MAP_BASEMAP_DEFAULT,
@@ -42,16 +41,17 @@ from explorer.app.streamlit.streamlit_ui_constants import (
 
 
 def inject_spinner_theme_css() -> None:
-    """Tweak hoisted checklist-stats spinner to match our theme (refs #70).
+    """Tweak ``st.spinner`` (pill, greens, emoji iframe) to match our theme (refs #70, #124).
 
     Use :func:`streamlit.html` for **style-only** blocks: ``st.markdown(..., unsafe_allow_html)``
     sanitizes or scopes HTML so global ``<style>`` may not affect the spinner; style-only
     ``st.html`` is applied via Streamlit’s event container (see Streamlit ``HtmlMixin.html``).
+
+    **Must run on every rerun:** if injection is skipped after the first run, the ``<style>`` node is
+    omitted from Streamlit output and spinners revert to default styling (same issue as sidebar
+    control labels — see :func:`inject_sidebar_control_label_css`).
     """
-    if st.session_state.get(SPINNER_THEME_CSS_INJECTED_KEY):
-        return
     st.html(SPINNER_THEME_CSS.strip())
-    st.session_state[SPINNER_THEME_CSS_INJECTED_KEY] = True
 
 
 def inject_sidebar_control_label_css() -> None:

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -41,7 +41,7 @@ from explorer.app.streamlit.streamlit_ui_constants import (
 
 
 def inject_spinner_theme_css() -> None:
-    """Tweak ``st.spinner`` (pill, greens, emoji iframe) to match our theme (refs #70, #124).
+    """Tweak ``st.spinner`` (text-style, theme greens, emoji iframe layout) to match our theme (refs #70, #124).
 
     Use :func:`streamlit.html` for **style-only** blocks: ``st.markdown(..., unsafe_allow_html)``
     sanitizes or scopes HTML so global ``<style>`` may not affect the spinner; style-only

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -14,6 +14,7 @@ from explorer.app.streamlit.app_constants import (
     SESSION_SPECIES_IX_KEY,
     SESSION_SPECIES_PICK_KEY,
     SESSION_SPECIES_SEARCH_KEY,
+    SIDEBAR_CONTROL_LABEL_CSS,
     SPINNER_THEME_CSS,
     SPINNER_THEME_CSS_INJECTED_KEY,
 )
@@ -51,6 +52,18 @@ def inject_spinner_theme_css() -> None:
         return
     st.html(SPINNER_THEME_CSS.strip())
     st.session_state[SPINNER_THEME_CSS_INJECTED_KEY] = True
+
+
+def inject_sidebar_control_label_css() -> None:
+    """Unify Map sidebar **control** label typography (selectbox, slider, ``st.toggle``), not spinners (refs #124).
+
+    Separate from :func:`inject_spinner_theme_css` so loading-spinner styling stays clearly scoped.
+    Call before ``with st.sidebar``.
+
+    **Must run on every rerun:** if we skip ``st.html`` after the first run, Streamlit omits that node from the
+    new output and the global ``<style>`` block disappears — controls then revert to default Streamlit fonts.
+    """
+    st.html(SIDEBAR_CONTROL_LABEL_CSS.strip())
 
 
 def inject_spinner_emoji_animation() -> None:

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -26,7 +26,6 @@ from explorer.app.streamlit.defaults import (
 from explorer.app.streamlit.streamlit_ui_constants import (
     CHECKLIST_STATS_SPINNER_EMOJI_BATCH_MS,
     CHECKLIST_STATS_SPINNER_EMOJI_BATCH_SIZE,
-    CHECKLIST_STATS_SPINNER_EMOJI_INDENT_REM,
     CHECKLIST_STATS_SPINNER_EMOJIS,
     EBIRD_PROFILE_URL,
     GITHUB_REPO_URL,
@@ -55,20 +54,20 @@ def inject_spinner_theme_css() -> None:
 
 
 def inject_spinner_emoji_animation() -> None:
-    """Animate bird emoji in batches below the checklist-stats spinner (refs #74).
+    """Animate bird emoji in batches under the checklist-stats spinner text (refs #74).
 
     ``st.spinner`` cannot update its label mid-run; this uses a small ``components.html`` iframe and
     client-side ``setInterval`` to advance non-overlapping batches while Python is blocked.
+    Theme CSS centers this iframe under the spinner row in normal document flow (refs #124).
     """
     emojis = list(CHECKLIST_STATS_SPINNER_EMOJIS)
     batch = max(1, int(CHECKLIST_STATS_SPINNER_EMOJI_BATCH_SIZE))
     ms = max(100, int(CHECKLIST_STATS_SPINNER_EMOJI_BATCH_MS))
-    indent = float(CHECKLIST_STATS_SPINNER_EMOJI_INDENT_REM)
     emojis_js = json.dumps(emojis, ensure_ascii=False)
     html = f"""<!DOCTYPE html><html><head><meta charset="utf-8"><style>
 html,body{{margin:0;padding:0;overflow:hidden;background:transparent;font-family:system-ui,sans-serif;}}
-#row{{display:flex;align-items:center;justify-content:flex-start;flex-wrap:wrap;gap:0.35em 0.5em;
-box-sizing:border-box;width:100%;padding-left:{indent}rem;min-height:2.25rem;font-size:1.35rem;line-height:1.2;
+#row{{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:0.35em 0.5em;
+box-sizing:border-box;width:100%;padding:0 0.35rem;min-height:2.25rem;font-size:1.35rem;line-height:1.2;
 letter-spacing:0.02em;color:{THEME_PRIMARY_HEX};}}
 </style></head><body><div id="row" aria-hidden="true"></div>
 <script>
@@ -94,7 +93,7 @@ letter-spacing:0.02em;color:{THEME_PRIMARY_HEX};}}
 
 
 def place_spinner_emoji_strip() -> Any:
-    """Show the animated bird-emoji strip under the current ``st.spinner`` (refs #74).
+    """Show the animated bird-emoji strip for the current ``st.spinner`` (refs #74, #124).
 
     Uses ``st.empty()`` + ``container()`` + :func:`inject_spinner_emoji_animation`. Returns the
     placeholder; call ``.empty()`` on it when the spinner phase ends so the iframe is dropped.
@@ -103,6 +102,18 @@ def place_spinner_emoji_strip() -> Any:
     with placeholder.container():
         inject_spinner_emoji_animation()
     return placeholder
+
+
+def sidebar_bottom_slot_start() -> None:
+    """Open a reserved bottom sidebar region (spinner + emoji, then footer); keeps layout stable (refs #124)."""
+    st.markdown(
+        '<div class="ebird-sidebar-bottom-slot" aria-live="polite">',
+        unsafe_allow_html=True,
+    )
+
+
+def sidebar_bottom_slot_end() -> None:
+    st.markdown("</div>", unsafe_allow_html=True)
 
 
 def ensure_streamlit_map_basemap_height_keys() -> None:
@@ -115,9 +126,10 @@ def ensure_streamlit_map_basemap_height_keys() -> None:
         st.session_state.streamlit_map_height_px = MAP_HEIGHT_PX_DEFAULT
 
 
-def sidebar_footer_links() -> None:
+def sidebar_footer_links(*, leading_divider: bool = True) -> None:
     """Small centred sidebar footer: GitHub, eBird, Instagram + Explorer README on GitHub (text links)."""
-    st.sidebar.divider()
+    if leading_divider:
+        st.sidebar.divider()
     link_style = "color:#868e96;text-decoration:none;"
     sep = '<span style="opacity:0.45;margin:0 0.55em;" aria-hidden="true">·</span>'
     st.sidebar.markdown(

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -118,7 +118,11 @@ def place_spinner_emoji_strip() -> Any:
 
 
 def sidebar_bottom_slot_start() -> None:
-    """Open a reserved bottom sidebar region (spinner + emoji, then footer); keeps layout stable (refs #124)."""
+    """Open the bottom sidebar region (spinner + emoji, export, footer).
+
+    CSS (``ebird-sidebar-bottom-slot``) makes this band ``position: sticky; bottom: 0`` so it stays in the
+    visible sidebar while controls above scroll (refs #124).
+    """
     st.markdown(
         '<div class="ebird-sidebar-bottom-slot" aria-live="polite">',
         unsafe_allow_html=True,

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -120,8 +120,8 @@ def place_spinner_emoji_strip() -> Any:
 def sidebar_bottom_slot_start() -> None:
     """Open the bottom sidebar region (spinner + emoji, export, footer).
 
-    CSS (``ebird-sidebar-bottom-slot``) makes this band ``position: sticky; bottom: 0`` so it stays in the
-    visible sidebar while controls above scroll (refs #124).
+    Wrapper is ``position: sticky`` with a transparent background so it does not look like a separate
+    empty panel when idle (refs #124).
     """
     st.markdown(
         '<div class="ebird-sidebar-bottom-slot" aria-live="polite">',

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -72,7 +72,7 @@ THEME_TEXT_HEX = "#1A2E22"
 THEME_PRIMARY_HEX = "#1F6F54"
 THEME_SECONDARY_BG_HEX = "#EEF4F0"
 
-SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v14"
+SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v15"
 
 # ---------------------------------------------------------------------------
 # Ranking & Lists HTML (``rankings_streamlit_html``)

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -72,7 +72,7 @@ THEME_TEXT_HEX = "#1A2E22"
 THEME_PRIMARY_HEX = "#1F6F54"
 THEME_SECONDARY_BG_HEX = "#EEF4F0"
 
-SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v17"
+SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v18"
 
 # ---------------------------------------------------------------------------
 # Ranking & Lists HTML (``rankings_streamlit_html``)

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -72,7 +72,7 @@ THEME_TEXT_HEX = "#1A2E22"
 THEME_PRIMARY_HEX = "#1F6F54"
 THEME_SECONDARY_BG_HEX = "#EEF4F0"
 
-SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v16"
+SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v17"
 
 # ---------------------------------------------------------------------------
 # Ranking & Lists HTML (``rankings_streamlit_html``)

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -72,7 +72,7 @@ THEME_TEXT_HEX = "#1A2E22"
 THEME_PRIMARY_HEX = "#1F6F54"
 THEME_SECONDARY_BG_HEX = "#EEF4F0"
 
-SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v15"
+SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v16"
 
 # ---------------------------------------------------------------------------
 # Ranking & Lists HTML (``rankings_streamlit_html``)

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -72,7 +72,7 @@ THEME_TEXT_HEX = "#1A2E22"
 THEME_PRIMARY_HEX = "#1F6F54"
 THEME_SECONDARY_BG_HEX = "#EEF4F0"
 
-SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v4"
+SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v10"
 
 # ---------------------------------------------------------------------------
 # Ranking & Lists HTML (``rankings_streamlit_html``)

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -72,7 +72,7 @@ THEME_TEXT_HEX = "#1A2E22"
 THEME_PRIMARY_HEX = "#1F6F54"
 THEME_SECONDARY_BG_HEX = "#EEF4F0"
 
-SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v10"
+SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v14"
 
 # ---------------------------------------------------------------------------
 # Ranking & Lists HTML (``rankings_streamlit_html``)

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -78,7 +78,6 @@ CHECKLIST_STATS_SPINNER_EMOJIS: tuple[str, ...] = (
 
 CHECKLIST_STATS_SPINNER_EMOJI_BATCH_SIZE = 5
 CHECKLIST_STATS_SPINNER_EMOJI_BATCH_MS = 750
-CHECKLIST_STATS_SPINNER_EMOJI_INDENT_REM = 2.75
 
 # ---------------------------------------------------------------------------
 # Sidebar footer

--- a/tests/explorer/test_streamlit_ui_helpers.py
+++ b/tests/explorer/test_streamlit_ui_helpers.py
@@ -366,8 +366,8 @@ def test_ensure_streamlit_map_basemap_height_keys_seeds_and_repairs(streamlit_st
     assert st.session_state["streamlit_map_basemap"] == MAP_BASEMAP_DEFAULT
 
 
-def test_inject_spinner_theme_css_idempotent(streamlit_stub) -> None:
-    from explorer.app.streamlit.app_constants import SPINNER_THEME_CSS, SPINNER_THEME_CSS_INJECTED_KEY
+def test_inject_spinner_theme_css_emits_every_run(streamlit_stub) -> None:
+    from explorer.app.streamlit.app_constants import SPINNER_THEME_CSS
     from explorer.app.streamlit.app_map_ui import inject_spinner_theme_css
 
     st = streamlit_stub
@@ -375,10 +375,10 @@ def test_inject_spinner_theme_css_idempotent(streamlit_stub) -> None:
     inject_spinner_theme_css()
     assert len(st.html_calls) == 1
     assert st.html_calls[0] == SPINNER_THEME_CSS.strip()
-    assert st.session_state[SPINNER_THEME_CSS_INJECTED_KEY] is True
     st.html_calls.clear()
     inject_spinner_theme_css()
-    assert st.html_calls == []
+    assert len(st.html_calls) == 1
+    assert st.html_calls[0] == SPINNER_THEME_CSS.strip()
 
 
 def test_inject_spinner_emoji_animation_html_includes_theme_and_emojis(streamlit_stub) -> None:


### PR DESCRIPTION
Work on spinner improvements/replacement and associate sidebar work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it restructures the Streamlit run order (prep + Folium build + `st_folium` embedding) and sidebar rendering, which could cause subtle UI/layout regressions or component remount issues across reruns.
> 
> **Overview**
> Moves the full dashboard load indicator from the main column into a **sticky bottom sidebar slot**, wrapping checklist/rankings/maintenance prep, tab-session sync, and the Folium map build under one themed `st.spinner` with the emoji strip.
> 
> Refactors map rendering so warnings and `st_folium` embedding happen after the spinner phase, and relocates **Export map HTML** + footer links into the same bottom sidebar region.
> 
> Updates injected CSS to restyle `st.spinner`, center the emoji iframe, add sidebar control-label typography CSS, and removes the prior “inject once” behavior (CSS is now emitted every rerun); tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dad5cfb27e826453003486fbb309004abbf7a76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->