### PR TITLE
[#128] Reorder yearly summary static rows for clearer grouping …

### DIFF
--- a/explorer/core/stats.py
+++ b/explorer/core/stats.py
@@ -788,6 +788,8 @@ def yearly_summary_stats(df, cl, dur_col, dist_col, *, taxonomy_locale: str | No
 
     *taxonomy_locale* selects the eBird taxonomy locale for **Total bird families**
     (species-group names); defaults to the app default (e.g. ``en_AU``).
+
+    Static row order matches issue #128 (core outcomes → checklist activity → effort → coverage).
     """
     cl = cl.dropna(subset=["Date"])
     if cl.empty:
@@ -822,14 +824,16 @@ def yearly_summary_stats(df, cl, dur_col, dist_col, *, taxonomy_locale: str | No
     df_with_yr["_base"] = sp_series
     df_with_yr["_count"] = df_with_yr["Count"].apply(safe_count)
 
-    rows = []
+    rows: list[tuple[str, list[str]]] = []
 
-    # 1. Total species
+    # --- Computations (order here is arbitrary; static table order is set below, refs #128) ---
+
+    # Total species
     by_yr_sp = df_with_yr.dropna(subset=["_base"]).groupby("_year")["_base"].nunique()
-    vals = [int(by_yr_sp.get(y, 0)) for y in years_sorted]
-    rows.append(("Total species", [f"{v:,}" for v in vals]))
+    vals_sp = [int(by_yr_sp.get(y, 0)) for y in years_sorted]
+    row_total_species = ("Total species", [f"{v:,}" for v in vals_sp])
 
-    # 2. Total bird families (eBird species groups; same mapping as Rankings → Families)
+    # Total bird families (eBird species groups; same mapping as Rankings → Families)
     loc = (taxonomy_locale or "").strip() or TAXONOMY_LOCALE_DEFAULT
     base_to_family = build_base_species_to_family_map(loc)
     if base_to_family:
@@ -838,98 +842,69 @@ def yearly_summary_stats(df, cl, dur_col, dist_col, *, taxonomy_locale: str | No
         fam = dfb.dropna(subset=["_family"])
         by_yr_fam = fam.groupby("_year")["_family"].nunique()
         vals_f = [int(by_yr_fam.get(y, 0)) for y in years_sorted]
-        rows.append(("Total bird families", [f"{v:,}" for v in vals_f]))
+        row_total_bird_families = ("Total bird families", [f"{v:,}" for v in vals_f])
     else:
-        rows.append(("Total bird families", ["—"] * len(years_sorted)))
+        row_total_bird_families = ("Total bird families", ["—"] * len(years_sorted))
 
-    # 3. Total individuals
+    # Total individuals
     by_yr_ind = df_with_yr.groupby("_year")["_count"].sum()
-    vals = [int(by_yr_ind.get(y, 0)) for y in years_sorted]
-    rows.append(("Total individuals", [f"{v:,}" for v in vals]))
+    vals_ind = [int(by_yr_ind.get(y, 0)) for y in years_sorted]
+    row_total_individuals = ("Total individuals", [f"{v:,}" for v in vals_ind])
 
-    # 4. Lifers
+    # Lifers
     first_seen = df_with_yr.dropna(subset=["_base"]).groupby("_base")["Date"].min()
     first_seen_year = first_seen.dt.year
     lifers_per_year = first_seen_year.value_counts()
-    vals = [int(lifers_per_year.get(y, 0)) for y in years_sorted]
-    rows.append(("Lifers", [f"{v:,}" for v in vals]))
+    vals_lifers = [int(lifers_per_year.get(y, 0)) for y in years_sorted]
+    row_lifers = ("Lifers", [f"{v:,}" for v in vals_lifers])
 
-    # 5. Traveling checklists (complete only)
-    if has_protocol:
-        trav_count = cl[traveling_complete].groupby("_year").size()
-        vals = [int(trav_count.get(y, 0)) for y in years_sorted]
-        rows.append((f"Traveling checklists{info_icon}", [f"{v:,}" for v in vals]))
-    else:
-        rows.append(("Traveling checklists", ["—"] * len(years_sorted)))
-
-    # 6. Stationary checklists (complete only)
-    if has_protocol:
-        stat_count = cl[stationary_complete].groupby("_year").size()
-        vals = [int(stat_count.get(y, 0)) for y in years_sorted]
-        rows.append((f"Stationary checklists{info_icon}", [f"{v:,}" for v in vals]))
-    else:
-        rows.append(("Stationary checklists", ["—"] * len(years_sorted)))
-
-    # 7. Incidental checklists
-    if has_protocol:
-        inc_count = cl[incidental_mask].groupby("_year").size()
-        vals = [int(inc_count.get(y, 0)) for y in years_sorted]
-        rows.append(("Incidental checklists", [f"{v:,}" for v in vals]))
-    else:
-        rows.append(("Incidental checklists", ["—"] * len(years_sorted)))
-
-    # 8. Total checklists
+    # Total checklists
     by_yr_cl = cl.groupby("_year").size()
-    vals = [int(by_yr_cl.get(y, 0)) for y in years_sorted]
-    rows.append(("Total checklists", [f"{v:,}" for v in vals]))
+    vals_tcl = [int(by_yr_cl.get(y, 0)) for y in years_sorted]
+    row_total_checklists = ("Total checklists", [f"{v:,}" for v in vals_tcl])
 
-    # 9. Completed checklists
+    # Completed checklists
     if has_all_obs:
         completed = cl[completed_mask]
         by_yr = completed.groupby("_year").size()
-        vals = [int(by_yr.get(y, 0)) for y in years_sorted]
-        rows.append(("Completed checklists", [f"{v:,}" for v in vals]))
+        vals_comp = [int(by_yr.get(y, 0)) for y in years_sorted]
+        row_completed_checklists = ("Completed checklists", [f"{v:,}" for v in vals_comp])
     else:
-        rows.append(("Completed checklists", ["—"] * len(years_sorted)))
+        row_completed_checklists = ("Completed checklists", ["—"] * len(years_sorted))
 
-    # 10. Incomplete checklists (not incidental)
+    # Incomplete checklists (not incidental)
     if has_all_obs and has_protocol:
         inc_count = cl[incomplete_not_incidental].groupby("_year").size()
-        vals = [int(inc_count.get(y, 0)) for y in years_sorted]
-        rows.append(("Incomplete checklists", [f"{v:,}" for v in vals]))
+        vals_inc = [int(inc_count.get(y, 0)) for y in years_sorted]
+        row_incomplete_checklists = ("Incomplete checklists", [f"{v:,}" for v in vals_inc])
     else:
-        rows.append(("Incomplete checklists", ["—"] * len(years_sorted)))
+        row_incomplete_checklists = ("Incomplete checklists", ["—"] * len(years_sorted))
 
-    # 11. Days with checklist
-    by_yr_dates = cl.groupby("_year")["Date"].apply(lambda s: s.dt.normalize().nunique())
-    vals = [int(by_yr_dates.get(y, 0)) for y in years_sorted]
-    rows.append(("Days with checklist", [f"{v:,}" for v in vals]))
-
-    # 12. Cumulative days eBird on
-    all_dates = cl["Date"].dt.normalize()
-    cum = [int(all_dates[all_dates.dt.year <= y].nunique()) for y in years_sorted]
-    rows.append(("Cumulative days eBird on", [f"{v:,}" for v in cum]))
-
-    # 13. Total birding hours
-    if dur_col:
-        timed = cl.dropna(subset=[dur_col]).copy()
-        timed["_dur"] = pd.to_numeric(timed[dur_col], errors="coerce").fillna(0)
-        timed["_year"] = timed["Date"].dt.year
-        if has_protocol:
-            excl = timed["Protocol"].astype(str).str.strip().str.lower().str.contains("incidental|historical|casual observation", na=False, regex=True)
-            timed = timed[~excl]
-        by_yr_min = timed.groupby("_year")["_dur"].sum()
-        vals = [by_yr_min.get(y, 0) / 60 for y in years_sorted]
-        rows.append(("Total birding hours", [f"{v:.1f}" if v else "—" for v in vals]))
+    # Traveling checklists (complete only)
+    if has_protocol:
+        trav_count = cl[traveling_complete].groupby("_year").size()
+        vals_trav = [int(trav_count.get(y, 0)) for y in years_sorted]
+        row_traveling_checklists = (f"Traveling checklists{info_icon}", [f"{v:,}" for v in vals_trav])
     else:
-        rows.append(("Total birding hours", ["—"] * len(years_sorted)))
+        row_traveling_checklists = ("Traveling checklists", ["—"] * len(years_sorted))
 
-    # 14. Unique locations
-    by_yr_loc = cl.groupby("_year")["Location ID"].nunique()
-    vals = [int(by_yr_loc.get(y, 0)) for y in years_sorted]
-    rows.append(("Unique locations", [f"{v:,}" for v in vals]))
+    # Stationary checklists (complete only)
+    if has_protocol:
+        stat_count = cl[stationary_complete].groupby("_year").size()
+        vals_stat = [int(stat_count.get(y, 0)) for y in years_sorted]
+        row_stationary_checklists = (f"Stationary checklists{info_icon}", [f"{v:,}" for v in vals_stat])
+    else:
+        row_stationary_checklists = ("Stationary checklists", ["—"] * len(years_sorted))
 
-    # 15–16. Shared checklists / Days birding with others
+    # Incidental checklists
+    if has_protocol:
+        inc_count = cl[incidental_mask].groupby("_year").size()
+        vals_inc2 = [int(inc_count.get(y, 0)) for y in years_sorted]
+        row_incidental_checklists = ("Incidental checklists", [f"{v:,}" for v in vals_inc2])
+    else:
+        row_incidental_checklists = ("Incidental checklists", ["—"] * len(years_sorted))
+
+    # Shared checklists / Days birding with others
     if "Number of Observers" in cl.columns:
         shared_cl = cl.dropna(subset=["Number of Observers"]).copy()
         shared_cl["_nobs"] = pd.to_numeric(shared_cl["Number of Observers"], errors="coerce").fillna(0)
@@ -938,27 +913,78 @@ def yearly_summary_stats(df, cl, dur_col, dist_col, *, taxonomy_locale: str | No
         if not shared_sub.empty:
             by_yr_shared = shared_sub.groupby("_year").size()
             vals_shared = [int(by_yr_shared.get(y, 0)) for y in years_sorted]
-            rows.append(("Shared checklists", [f"{v:,}" for v in vals_shared]))
+            row_shared_checklists = ("Shared checklists", [f"{v:,}" for v in vals_shared])
             shared_sub = shared_sub.copy()
             shared_sub["_date"] = shared_sub["Date"].dt.normalize()
             by_yr_days = shared_sub.groupby("_year")["_date"].nunique()
-            vals_days = [int(by_yr_days.get(y, 0)) for y in years_sorted]
-            rows.append(("Days birding with others", [f"{v:,}" for v in vals_days]))
+            vals_days_bo = [int(by_yr_days.get(y, 0)) for y in years_sorted]
+            row_days_birding_with_others = ("Days birding with others", [f"{v:,}" for v in vals_days_bo])
         else:
-            rows.append(("Shared checklists", ["—"] * len(years_sorted)))
-            rows.append(("Days birding with others", ["—"] * len(years_sorted)))
+            row_shared_checklists = ("Shared checklists", ["—"] * len(years_sorted))
+            row_days_birding_with_others = ("Days birding with others", ["—"] * len(years_sorted))
     else:
-        rows.append(("Shared checklists", ["—"] * len(years_sorted)))
-        rows.append(("Days birding with others", ["—"] * len(years_sorted)))
+        row_shared_checklists = ("Shared checklists", ["—"] * len(years_sorted))
+        row_days_birding_with_others = ("Days birding with others", ["—"] * len(years_sorted))
 
-    # 16. Total distance (km)
+    # Days with checklist
+    by_yr_dates = cl.groupby("_year")["Date"].apply(lambda s: s.dt.normalize().nunique())
+    vals_dwc = [int(by_yr_dates.get(y, 0)) for y in years_sorted]
+    row_days_with_checklist = ("Days with checklist", [f"{v:,}" for v in vals_dwc])
+
+    # Cumulative days eBird on
+    all_dates = cl["Date"].dt.normalize()
+    cum = [int(all_dates[all_dates.dt.year <= y].nunique()) for y in years_sorted]
+    row_cumulative_days_ebird_on = ("Cumulative days eBird on", [f"{v:,}" for v in cum])
+
+    # Total birding hours
+    if dur_col:
+        timed = cl.dropna(subset=[dur_col]).copy()
+        timed["_dur"] = pd.to_numeric(timed[dur_col], errors="coerce").fillna(0)
+        timed["_year"] = timed["Date"].dt.year
+        if has_protocol:
+            excl = timed["Protocol"].astype(str).str.strip().str.lower().str.contains("incidental|historical|casual observation", na=False, regex=True)
+            timed = timed[~excl]
+        by_yr_min = timed.groupby("_year")["_dur"].sum()
+        vals_hours = [by_yr_min.get(y, 0) / 60 for y in years_sorted]
+        row_total_birding_hours = ("Total birding hours", [f"{v:.1f}" if v else "—" for v in vals_hours])
+    else:
+        row_total_birding_hours = ("Total birding hours", ["—"] * len(years_sorted))
+
+    # Total distance (km) — sets ``cl["_dist"]`` for any downstream use
     if dist_col:
         cl["_dist"] = pd.to_numeric(cl[dist_col], errors="coerce").fillna(0)
         by_yr_km = cl.groupby("_year")["_dist"].sum()
-        vals = [by_yr_km.get(y, 0) for y in years_sorted]
-        rows.append(("Total distance (km)", [f"{v:,.1f}" if v else "—" for v in vals]))
+        vals_km_tot = [by_yr_km.get(y, 0) for y in years_sorted]
+        row_total_distance_km = ("Total distance (km)", [f"{v:,.1f}" if v else "—" for v in vals_km_tot])
     else:
-        rows.append(("Total distance (km)", ["—"] * len(years_sorted)))
+        row_total_distance_km = ("Total distance (km)", ["—"] * len(years_sorted))
+
+    # Unique locations
+    by_yr_loc = cl.groupby("_year")["Location ID"].nunique()
+    vals_loc = [int(by_yr_loc.get(y, 0)) for y in years_sorted]
+    row_unique_locations = ("Unique locations", [f"{v:,}" for v in vals_loc])
+
+    rows.extend(
+        [
+            row_lifers,
+            row_total_bird_families,
+            row_total_species,
+            row_total_individuals,
+            row_total_checklists,
+            row_completed_checklists,
+            row_incomplete_checklists,
+            row_traveling_checklists,
+            row_stationary_checklists,
+            row_incidental_checklists,
+            row_shared_checklists,
+            row_days_with_checklist,
+            row_days_birding_with_others,
+            row_cumulative_days_ebird_on,
+            row_total_birding_hours,
+            row_total_distance_km,
+            row_unique_locations,
+        ]
+    )
 
     # 17–18. Traveling checklist: Total distance, Average distance
     if dist_col and has_protocol:

--- a/tests/explorer/test_stats.py
+++ b/tests/explorer/test_stats.py
@@ -453,6 +453,37 @@ class TestYearlySummaryStats:
         assert "Total bird families" in labels
         assert "Total checklists" in labels
 
+    def test_yearly_summary_static_row_order(self):
+        """Main yearly table row order (refs #128); protocol detail rows follow separately."""
+        expected_static = [
+            "Lifers",
+            "Total bird families",
+            "Total species",
+            "Total individuals",
+            "Total checklists",
+            "Completed checklists",
+            "Incomplete checklists",
+            "Traveling checklists",
+            "Stationary checklists",
+            "Incidental checklists",
+            "Shared checklists",
+            "Days with checklist",
+            "Days birding with others",
+            "Cumulative days eBird on",
+            "Total birding hours",
+            "Total distance (km)",
+            "Unique locations",
+        ]
+        df, cl = self._minimal_data()
+        _, rows, _ = yearly_summary_stats(df, cl, "Duration (Min)", "Distance Traveled (km)")
+        static = []
+        for label, _ in rows:
+            ls = label.strip()
+            if ls.startswith("Traveling checklist:") or ls.startswith("Stationary checklist:"):
+                break
+            static.append(ls.split(" <span")[0].strip())
+        assert static == expected_static
+
     def test_total_bird_families_uses_taxonomy_map(self, monkeypatch):
         """Per-year distinct family names match a stub base_species → family map (no network)."""
         df, cl = self._minimal_data()


### PR DESCRIPTION
…(#128)

Present core outcomes first (Lifers, families, species, individuals), then checklist activity, effort, and location coverage. Same computations; Travelling/Stationary protocol detail rows unchanged.

Add regression test for static label order.

Resolves #128
Implemented in #126

Made-with: Cursor