### PR TITLE
Align sidebar support and export with muted footer link colour

### DIFF
--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import html as html_module
 import json
+import os
 from typing import Any
 
 import streamlit as st
@@ -24,6 +26,7 @@ from explorer.app.streamlit.defaults import (
     THEME_PRIMARY_HEX,
 )
 from explorer.app.streamlit.streamlit_ui_constants import (
+    BUY_ME_A_COFFEE_URL,
     CHECKLIST_STATS_SPINNER_EMOJI_BATCH_MS,
     CHECKLIST_STATS_SPINNER_EMOJI_BATCH_SIZE,
     CHECKLIST_STATS_SPINNER_EMOJIS,
@@ -31,6 +34,7 @@ from explorer.app.streamlit.streamlit_ui_constants import (
     GITHUB_REPO_URL,
     explorer_readme_github_url,
     INSTAGRAM_PROFILE_URL,
+    SIDEBAR_FOOTER_LINK_HEX,
     SPECIES_SEARCH_DEBOUNCE_MS,
     SPECIES_SEARCH_EDIT_AFTER_SUBMIT,
     SPECIES_SEARCH_MAX_OPTIONS,
@@ -149,6 +153,66 @@ def sidebar_bottom_slot_end() -> None:
     st.markdown("</div>", unsafe_allow_html=True)
 
 
+def inject_sidebar_outline_download_button_css(outline_hex: str) -> None:
+    """Style the map **Export HTML** ``st.download_button`` like the outline support link (refs #127).
+
+    Streamlit widgets are not plain ``<a>`` tags; we align them visually with scoped CSS on
+    ``.ebird-sidebar-bottom-slot`` (see :func:`sidebar_bottom_slot_start`).
+    Uses the same colour as the footer text links (see :data:`SIDEBAR_FOOTER_LINK_HEX`).
+    """
+    h = outline_hex.strip()
+    if not h.startswith("#") or len(h) not in (4, 7, 9):
+        h = SIDEBAR_FOOTER_LINK_HEX
+    st.html(
+        f"""<style>
+.ebird-sidebar-bottom-slot [data-testid="stDownloadButton"] button {{
+  background: transparent !important;
+  color: {h} !important;
+  border: 1px solid {h} !important;
+  border-radius: 6px !important;
+  font-size: 0.78rem !important;
+  font-weight: 500 !important;
+  box-shadow: none !important;
+}}
+.ebird-sidebar-bottom-slot [data-testid="stDownloadButton"] button:hover {{
+  background: color-mix(in srgb, {h} 14%, transparent) !important;
+}}
+@supports not (color: color-mix(in srgb, black 50%, transparent)) {{
+  .ebird-sidebar-bottom-slot [data-testid="stDownloadButton"] button:hover {{
+    background: rgba(134, 142, 150, 0.12) !important;
+  }}
+}}
+</style>"""
+    )
+
+
+def _support_project_url() -> str | None:
+    """Buy Me a Coffee (or other) URL.
+
+    If env ``STREAMLIT_BUYMEACOFFEE_URL`` is **set** (including to empty), it wins: use the trimmed
+    value, or hide the block when empty. If unset, use :data:`~explorer.app.streamlit.streamlit_ui_constants.BUY_ME_A_COFFEE_URL`.
+    """
+    raw = os.environ.get("STREAMLIT_BUYMEACOFFEE_URL")
+    if raw is not None:
+        u = raw.strip()
+        return u or None
+    u2 = (BUY_ME_A_COFFEE_URL or "").strip()
+    return u2 or None
+
+
+def _support_buy_me_a_coffee_outline_html(url: str, *, outline_hex: str) -> str:
+    """Outline pill using the same colour as the footer text links (:data:`SIDEBAR_FOOTER_LINK_HEX`)."""
+    esc = html_module.escape(url, quote=True)
+    return (
+        '<div style="text-align:center;margin-top:0.45rem;">'
+        f'<a href="{esc}" target="_blank" rel="noopener noreferrer" '
+        f'style="display:inline-block;padding:0.26rem 0.6rem;background:transparent;'
+        f'color:{outline_hex};border:1px solid {outline_hex};border-radius:6px;'
+        f'font-size:0.78rem;text-decoration:none;font-weight:500;" '
+        'title="Optional — helps with hosting">Buy me a coffee</a></div>'
+    )
+
+
 def ensure_streamlit_map_basemap_height_keys() -> None:
     """Seed basemap + map height in session state (keyed widgets; refs #70)."""
     if "streamlit_map_basemap" not in st.session_state:
@@ -160,10 +224,10 @@ def ensure_streamlit_map_basemap_height_keys() -> None:
 
 
 def sidebar_footer_links(*, leading_divider: bool = True) -> None:
-    """Small centred sidebar footer: GitHub, eBird, Instagram + Explorer README on GitHub (text links)."""
+    """Small centred sidebar footer: GitHub, eBird, Instagram + Explorer README + optional support (refs #127)."""
     if leading_divider:
         st.sidebar.divider()
-    link_style = "color:#868e96;text-decoration:none;"
+    link_style = f"color:{SIDEBAR_FOOTER_LINK_HEX};text-decoration:none;"
     sep = '<span style="opacity:0.45;margin:0 0.55em;" aria-hidden="true">·</span>'
     st.sidebar.markdown(
         f'<div style="text-align:center;font-size:0.8rem;">'
@@ -183,6 +247,12 @@ def sidebar_footer_links(*, leading_divider: bool = True) -> None:
         "</div>",
         unsafe_allow_html=True,
     )
+    support_url = _support_project_url()
+    if support_url:
+        st.sidebar.markdown(
+            _support_buy_me_a_coffee_outline_html(support_url, outline_hex=SIDEBAR_FOOTER_LINK_HEX),
+            unsafe_allow_html=True,
+        )
 
 
 @st.fragment

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -30,6 +30,7 @@ from explorer.app.streamlit.app_constants import (
 )
 from explorer.app.streamlit.app_map_ui import (
     inject_map_folium_iframe_min_height_css,
+    inject_sidebar_outline_download_button_css,
     place_spinner_emoji_strip,
     sidebar_bottom_slot_end,
     sidebar_bottom_slot_start,
@@ -48,6 +49,7 @@ from explorer.app.streamlit.rankings_streamlit_html import (
 from explorer.app.streamlit.streamlit_ui_constants import (
     CHECKLIST_STATS_SPINNER_TEXT,
     MAP_EXPORT_HTML_FILENAME,
+    SIDEBAR_FOOTER_LINK_HEX,
 )
 from explorer.app.streamlit.yearly_summary_streamlit_html import sync_yearly_summary_session_inputs
 from explorer.core.map_controller import build_species_overlay_map
@@ -286,6 +288,8 @@ def render_prep_spinner_and_map_tab(
             st.divider()
             _ex1, _ex2, _ex3 = st.columns([1, 3, 1])
             with _ex2:
+                # Match outline “Buy me a coffee” pill (``st.download_button`` is a real widget, not an ``<a>``).
+                inject_sidebar_outline_download_button_css(SIDEBAR_FOOTER_LINK_HEX)
                 st.download_button(
                     "Export map HTML",
                     data=st.session_state[EXPLORER_MAP_HTML_BYTES_KEY],
@@ -294,6 +298,7 @@ def render_prep_spinner_and_map_tab(
                     key=EXPORT_MAP_HTML_BTN_KEY,
                     help="Standalone HTML for the current map.",
                     use_container_width=True,
+                    type="secondary",
                 )
         sidebar_footer_links(leading_divider=not _has_map_export)
         sidebar_bottom_slot_end()

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -83,6 +83,9 @@ CHECKLIST_STATS_SPINNER_EMOJI_BATCH_MS = 750
 # Sidebar footer
 # ---------------------------------------------------------------------------
 
+# GitHub / eBird / Instagram / Explorer docs — outline pill + export button use the same (refs #127).
+SIDEBAR_FOOTER_LINK_HEX = "#868e96"
+
 GITHUB_REPO_URL = "https://github.com/jimchurches/myebirdstuff"
 EBIRD_PROFILE_URL = "https://ebird.org/profile/MjkxNDYyNQ"
 
@@ -97,3 +100,7 @@ def explorer_readme_github_url() -> str:
 
     return explorer_readme_github_page_url(GITHUB_REPO_URL)
 INSTAGRAM_PROFILE_URL = "https://www.instagram.com/jimchurches/"
+
+# Optional “Support this project” (Buy Me a Coffee). Override or hide with env ``STREAMLIT_BUYMEACOFFEE_URL``
+# (set to ``""`` in the environment to hide the block when the constant would otherwise show; refs #127).
+BUY_ME_A_COFFEE_URL = "https://buymeacoffee.com/jimchurches"

--- a/tests/explorer/test_streamlit_ui_helpers.py
+++ b/tests/explorer/test_streamlit_ui_helpers.py
@@ -25,14 +25,28 @@ class _StubSessionState(dict):
 class _SidebarStub:
     """Capture ``st.sidebar`` divider/markdown used by map chrome tests."""
 
-    def __init__(self) -> None:
+    def __init__(self, stub_session) -> None:
+        self._stub_session = stub_session
         self.markdown_calls: list[tuple[tuple, dict]] = []
+        self.caption_calls: list[str] = []
+        self.radio_calls: list[tuple] = []
 
     def divider(self) -> None:
         return None
 
+    def caption(self, label: str) -> None:
+        self.caption_calls.append(label)
+
     def markdown(self, *args, **kwargs):
         self.markdown_calls.append((args, kwargs))
+
+    def radio(self, label: str, options, key=None, horizontal: bool = False, **kwargs):
+        self.radio_calls.append((label, tuple(options), key, horizontal, kwargs))
+        if key is not None and key in self._stub_session:
+            v = self._stub_session[key]
+            if v in options:
+                return v
+        return options[0] if options else None
 
 
 def _install_streamlit_stub(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -64,7 +78,7 @@ def _install_streamlit_stub(monkeypatch: pytest.MonkeyPatch) -> None:
         stub.error_calls.append(msg)
 
     stub.error = error
-    stub.sidebar = _SidebarStub()
+    stub.sidebar = _SidebarStub(stub.session_state)
 
     def fragment(fn):
         return fn
@@ -433,6 +447,7 @@ def test_inject_streamlit_checklist_css_appends_extra_css(streamlit_stub) -> Non
 def test_sidebar_footer_links_include_profile_urls(streamlit_stub, monkeypatch) -> None:
     from explorer.app.streamlit.app_map_ui import sidebar_footer_links
     from explorer.app.streamlit.streamlit_ui_constants import (
+        BUY_ME_A_COFFEE_URL,
         EBIRD_PROFILE_URL,
         GITHUB_REPO_URL,
         INSTAGRAM_PROFILE_URL,
@@ -451,3 +466,5 @@ def test_sidebar_footer_links_include_profile_urls(streamlit_stub, monkeypatch) 
     assert EBIRD_PROFILE_URL in combined
     assert INSTAGRAM_PROFILE_URL in combined
     assert fixed_docs in combined
+    assert BUY_ME_A_COFFEE_URL in combined
+    assert "Buy me a coffee</a>" in combined


### PR DESCRIPTION
Introduce SIDEBAR_FOOTER_LINK_HEX (#868e96) so GitHub/eBird/Instagram/Explorer links, the Buy me a coffee outline pill, and the Export map HTML download button share one grey. Scoped CSS styles the download widget to match the outline; hover fallback uses the same RGB. Tests updated for the simplified footer.

Refs #127
Implemented in #126

Made-with: Cursor