### PR TITLE
Add family map to mapping options [#138]

### DIFF
--- a/explorer/app/streamlit/app.py
+++ b/explorer/app/streamlit/app.py
@@ -234,6 +234,7 @@ def main() -> None:
         species_pick_sci=mw.species_pick_sci,
         family_name=mw.family_name,
         family_highlight_base=mw.family_highlight_base,
+        family_colour_scheme=mw.family_colour_scheme,
         hide_non_matching_locations=mw.hide_non_matching_locations,
         popup_sort_order=popup_sort_order,
         popup_scroll_hint=popup_scroll_hint,

--- a/explorer/app/streamlit/app.py
+++ b/explorer/app/streamlit/app.py
@@ -56,7 +56,7 @@ triggers a **partial rerun** (not the whole map/checklist pipeline) (refs #75).
 recent year columns** (default 10). ``sync_yearly_summary_session_inputs`` + ``run_yearly_summary_streamlit_fragment``
 match the Country tab fragment pattern (refs #85).
 
-**Main tabs + sidebar:** Primary ``st.tabs`` first (empty panels until filled). Prep + Folium embed run in a sidebar
+**Main tabs + sidebar:** Primary ``st.tabs`` first (``Map``, ``Families``, …; empty panels until filled). Prep + Folium embed run in a sidebar
 bottom ``st.spinner`` (Map tab content is nested in script order so loading indicators stay aligned). Data tabs use
 ``@st.fragment`` where possible. One sidebar
 for map controls, export, and footer links (refs #70). Map sidebar + working set: :mod:`explorer.app.streamlit.app_map_working_ui`
@@ -232,6 +232,8 @@ def main() -> None:
         date_filter_banner=mw.date_filter_banner,
         species_pick_common=mw.species_pick_common,
         species_pick_sci=mw.species_pick_sci,
+        family_name=mw.family_name,
+        family_highlight_base=mw.family_highlight_base,
         hide_non_matching_locations=mw.hide_non_matching_locations,
         popup_sort_order=popup_sort_order,
         popup_scroll_hint=popup_scroll_hint,

--- a/explorer/app/streamlit/app_caches.py
+++ b/explorer/app/streamlit/app_caches.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any
+
 import pandas as pd
 import streamlit as st
 
@@ -58,6 +60,49 @@ def full_location_data_for_maintenance(df: pd.DataFrame) -> pd.DataFrame:
     if not all(c in df.columns for c in cols):
         return pd.DataFrame(columns=cols)
     return df[cols].drop_duplicates()
+
+
+@st.cache_data(show_spinner=False)
+def cached_family_map_bundle(df_full: pd.DataFrame, taxonomy_locale: str) -> dict[str, Any]:
+    """Taxonomy merge + countable work frame for the **Families** map tab (refs #138).
+
+    On fetch/parse failure returns empty structures so the UI can show a warning without crashing.
+    """
+    from explorer.core.family_map_compute import (
+        base_species_to_common_from_taxonomy,
+        families_recorded_alphabetically,
+        merge_taxonomy_detail_for_family_map,
+        prepare_family_map_work_frame,
+    )
+    from explorer.core.species_family import (
+        build_base_species_to_family_map,
+        load_taxonomy_groups,
+        load_taxonomy_species_rows,
+    )
+
+    loc = (taxonomy_locale or "").strip()
+    try:
+        base_to_family = build_base_species_to_family_map(loc)
+        tax = load_taxonomy_species_rows(loc)
+        groups = load_taxonomy_groups(loc)
+        tax_merged = merge_taxonomy_detail_for_family_map(tax, groups)
+    except Exception:
+        return {
+            "work": pd.DataFrame(),
+            "tax_merged": pd.DataFrame(),
+            "base_to_common": {},
+            "families": (),
+        }
+
+    work = prepare_family_map_work_frame(df_full, base_to_family)
+    base_to_common = base_species_to_common_from_taxonomy(tax_merged)
+    families = families_recorded_alphabetically(work)
+    return {
+        "work": work,
+        "tax_merged": tax_merged,
+        "base_to_common": base_to_common,
+        "families": families,
+    }
 
 
 @st.cache_resource(show_spinner="Loading eBird taxonomy…")

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -127,6 +127,7 @@ EXPORT_MAP_HTML_BTN_KEY = "export_map_html_btn"
 # Family map tab widget keys (refs #138). Highlight key is suffixed with selected family in the UI.
 STREAMLIT_FAMILY_MAP_FAMILY_KEY = "streamlit_family_map_family"
 STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY = "streamlit_family_map_highlight"
+STREAMLIT_FAMILY_MAP_COLOUR_SCHEME_KEY = "streamlit_family_map_colour_scheme"
 
 # Checklist stats payload keys (used by fragments).
 YEARLY_SUMMARY_TAB_CHECKLIST_PAYLOAD_KEY = "_streamlit_yearly_summary_checklist_payload"

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -35,6 +35,7 @@ MAP_VIEW_LABEL_TO_MODE = {
     "All locations": "all",
     "Selected species": "species",
     "Lifer locations": "lifers",
+    "Family map": "families",
 }
 
 SETTINGS_PANEL_CSS = f"""
@@ -122,6 +123,10 @@ STREAMLIT_RESET_SETTINGS_BTN_KEY = "streamlit_reset_settings_btn"
 
 # Download/export button keys.
 EXPORT_MAP_HTML_BTN_KEY = "export_map_html_btn"
+
+# Family map tab widget keys (refs #138). Highlight key is suffixed with selected family in the UI.
+STREAMLIT_FAMILY_MAP_FAMILY_KEY = "streamlit_family_map_family"
+STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY = "streamlit_family_map_highlight"
 
 # Checklist stats payload keys (used by fragments).
 YEARLY_SUMMARY_TAB_CHECKLIST_PAYLOAD_KEY = "_streamlit_yearly_summary_checklist_payload"

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -35,7 +35,7 @@ MAP_VIEW_LABEL_TO_MODE = {
     "All locations": "all",
     "Selected species": "species",
     "Lifer locations": "lifers",
-    "Family map": "families",
+    "Family locations": "families",
 }
 
 SETTINGS_PANEL_CSS = f"""

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import pandas as pd
 import streamlit as st
 
 from explorer.app.streamlit.app_constants import (
@@ -31,6 +32,9 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_MAP_VIEW_LABEL_KEY,
     STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY,
     STREAMLIT_SPECIES_HIDE_ONLY_KEY,
+    STREAMLIT_FAMILY_MAP_FAMILY_KEY,
+    STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY,
+    DEFAULT_TAXONOMY_LOCALE,
 )
 from explorer.app.streamlit.app_map_ui import (
     ensure_streamlit_map_basemap_height_keys,
@@ -78,6 +82,8 @@ class MapWorkingContext:
     species_pick_common: str | None
     species_pick_sci: str
     map_height: int
+    family_name: str
+    family_highlight_base: str
 
 
 def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
@@ -111,6 +117,7 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         )
         map_view_mode = MAP_VIEW_LABEL_TO_MODE[map_view_label]
         is_lifer_view = map_view_mode == "lifers"
+        is_family_view = map_view_mode == "families"
 
         if is_lifer_view:
             st.caption("Lifer locations are not date-filtered.")
@@ -122,6 +129,11 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             )
             date_filter_on_effective = False
             date_range_sel: tuple | None = None
+        elif is_family_view:
+            # Family map view (v1): keep UI minimal; ignore date filter and clustering controls.
+            # We do **not** clear persisted date filter state; switching back restores prior picks.
+            date_filter_on_effective = False
+            date_range_sel = None
         else:
             if STREAMLIT_MAP_DATE_FILTER_KEY not in st.session_state:
                 st.session_state.streamlit_map_date_filter = bool(
@@ -171,15 +183,19 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             if date_filter_on_effective and date_range_sel is not None:
                 st.session_state[PERSIST_MAP_DATE_RANGE_KEY] = date_range_sel
 
-        st.toggle(
-            "Group nearby pins",
-            key=STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
-            help="Clusters nearby pins at low zoom. Session-only (save in Settings to persist).",
-        )
+        if not is_family_view:
+            st.toggle(
+                "Group nearby pins",
+                key=STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
+                help="Clusters nearby pins at low zoom. Session-only (save in Settings to persist).",
+            )
 
+    # Working set is still date-filtered for checklist stats and other tabs.
+    # Family map ignores date filtering (v1), but we preserve the date filter controls and state.
+    _ws_mode = "all" if is_family_view else map_view_mode
     ws, date_filter_banner = streamlit_working_set_and_status(
         df_full,
-        map_view_mode=map_view_mode,
+        map_view_mode=_ws_mode,
         date_filter_on=date_filter_on_effective,
         date_range=date_range_sel,
         map_caches=(st.session_state.popup_html_cache, st.session_state.filtered_by_loc_cache),
@@ -198,6 +214,8 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
     hide_non_matching_locations = False
     species_pick_common: str | None = None
     species_pick_sci = ""
+    family_name = ""
+    family_highlight_base = ""
 
     _prev_mv = st.session_state.get(SESSION_PREV_MAP_VIEW_KEY)
     if map_view_mode == "species" and _prev_mv is not None and _prev_mv != "species":
@@ -236,6 +254,50 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
     else:
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
 
+    if map_view_mode == "families":
+        from explorer.app.streamlit.app_caches import cached_family_map_bundle
+        from explorer.core.family_map_compute import (
+            filter_work_to_family,
+            highlight_species_choices_alphabetical,
+        )
+
+        with st.sidebar:
+
+            tax_loc = (
+                str(st.session_state.get("streamlit_taxonomy_locale", "")).strip()
+                or DEFAULT_TAXONOMY_LOCALE
+            )
+            bundle = cached_family_map_bundle(df_full, tax_loc)
+            fams = list(bundle.get("families") or ())
+            work = bundle.get("work")
+            base_to_common = bundle.get("base_to_common") or {}
+
+            family_name = st.selectbox(
+                "Family",
+                options=[""] + fams,
+                format_func=lambda x: "— Select a family —" if x == "" else x,
+                key=STREAMLIT_FAMILY_MAP_FAMILY_KEY,
+            )
+
+            if family_name and isinstance(work, pd.DataFrame) and not work.empty:
+                wf = filter_work_to_family(work, family_name)
+                pairs = highlight_species_choices_alphabetical(wf, base_to_common)
+                bases = [b for _lab, b in pairs]
+                family_highlight_base = st.selectbox(
+                    "Highlight species (optional)",
+                    options=[""] + bases,
+                    format_func=lambda b: "— None —" if b == "" else (base_to_common.get(b) or b),
+                    key=STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY,
+                )
+            else:
+                st.selectbox(
+                    "Highlight species (optional)",
+                    options=["— None —"],
+                    disabled=True,
+                    key=f"{STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY}__disabled",
+                )
+                family_highlight_base = ""
+
     with st.sidebar:
         st.divider()
         map_height = st.slider(
@@ -246,11 +308,7 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             key=STREAMLIT_MAP_HEIGHT_PX_KEY,
         )
 
-    if (
-        _prev_mv is not None
-        and _prev_mv != map_view_mode
-        and {_prev_mv, map_view_mode} == {"all", "species"}
-    ):
+    if _prev_mv is not None and _prev_mv != map_view_mode:
         st.session_state.pop(FOLIUM_STATIC_MAP_CACHE_KEY, None)
         st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
         st.session_state[FOLIUM_MAP_MOUNT_NONCE_KEY] = int(
@@ -269,4 +327,6 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         species_pick_common=species_pick_common,
         species_pick_sci=species_pick_sci,
         map_height=map_height,
+        family_name=str(family_name or ""),
+        family_highlight_base=str(family_highlight_base or ""),
     )

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -32,6 +32,7 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_MAP_VIEW_LABEL_KEY,
     STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY,
     STREAMLIT_SPECIES_HIDE_ONLY_KEY,
+    STREAMLIT_FAMILY_MAP_COLOUR_SCHEME_KEY,
     STREAMLIT_FAMILY_MAP_FAMILY_KEY,
     STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY,
     DEFAULT_TAXONOMY_LOCALE,
@@ -44,6 +45,8 @@ from explorer.app.streamlit.app_map_ui import (
 )
 from explorer.app.streamlit.app_settings_state import apply_pending_map_cluster_toggle
 from explorer.app.streamlit.defaults import (
+    FAMILY_MAP_COLOUR_SCHEME_1,
+    FAMILY_MAP_COLOUR_SCHEME_2,
     MAP_BASEMAP_LABELS,
     MAP_BASEMAP_OPTIONS,
     MAP_DATE_FILTER_DEFAULT,
@@ -60,13 +63,18 @@ from explorer.app.streamlit.streamlit_ui_constants import SPECIES_SEARCH_CAPTION
 from explorer.core.species_search import build_ram_species_whoosh_index
 
 
-def _on_basemap_changed() -> None:
-    """Invalidate Folium cache + remount iframe when the basemap **value** changes (refs #124)."""
+def invalidate_folium_map_embed_cache() -> None:
+    """Bump Folium mount nonce and drop cached map HTML (basemap, family colours, etc.)."""
     st.session_state[FOLIUM_MAP_MOUNT_NONCE_KEY] = int(
         st.session_state.get(FOLIUM_MAP_MOUNT_NONCE_KEY, 0)
     ) + 1
     st.session_state.pop(FOLIUM_STATIC_MAP_CACHE_KEY, None)
     st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
+
+
+def _on_basemap_changed() -> None:
+    """Invalidate Folium cache + remount iframe when the basemap **value** changes (refs #124)."""
+    invalidate_folium_map_embed_cache()
 
 
 @dataclass(frozen=True)
@@ -84,6 +92,7 @@ class MapWorkingContext:
     map_height: int
     family_name: str
     family_highlight_base: str
+    family_colour_scheme: int
 
 
 def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
@@ -216,6 +225,7 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
     species_pick_sci = ""
     family_name = ""
     family_highlight_base = ""
+    family_colour_scheme = 1
 
     _prev_mv = st.session_state.get(SESSION_PREV_MAP_VIEW_KEY)
     if map_view_mode == "species" and _prev_mv is not None and _prev_mv != "species":
@@ -298,6 +308,22 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 )
                 family_highlight_base = ""
 
+            family_colour_scheme = int(
+                st.radio(
+                    "Colour scheme",
+                    options=[1, 2],
+                    format_func=lambda n: (
+                        FAMILY_MAP_COLOUR_SCHEME_1.display_name
+                        if n == 1
+                        else FAMILY_MAP_COLOUR_SCHEME_2.display_name
+                    ),
+                    horizontal=True,
+                    key=STREAMLIT_FAMILY_MAP_COLOUR_SCHEME_KEY,
+                    index=0,
+                    on_change=invalidate_folium_map_embed_cache,
+                )
+            )
+
     with st.sidebar:
         st.divider()
         map_height = st.slider(
@@ -329,4 +355,5 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         map_height=map_height,
         family_name=str(family_name or ""),
         family_highlight_base=str(family_highlight_base or ""),
+        family_colour_scheme=int(family_colour_scheme),
     )

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -62,6 +62,7 @@ from explorer.core.family_map_compute import (
     compute_family_map_banner_metrics,
     filter_work_to_family,
 )
+from explorer.app.streamlit.defaults import active_family_map_colour_scheme
 from explorer.core.family_map_folium import (
     build_family_composition_folium_map,
     build_family_map_banner_overlay_html,
@@ -85,6 +86,7 @@ def render_prep_spinner_and_map_tab(
     species_pick_sci: str,
     family_name: str,
     family_highlight_base: str,
+    family_colour_scheme: int,
     hide_non_matching_locations: bool,
     popup_sort_order: Any,
     popup_scroll_hint: Any,
@@ -165,6 +167,7 @@ def render_prep_spinner_and_map_tab(
                             (),
                             map_style=map_style,
                             height_px=int(map_height),
+                            colour_scheme_index=int(family_colour_scheme),
                         )
                         result_warning = "Select a family in the sidebar to load the map."
                     elif fam not in fams or work is None or getattr(work, "empty", True):
@@ -172,6 +175,7 @@ def render_prep_spinner_and_map_tab(
                             (),
                             map_style=map_style,
                             height_px=int(map_height),
+                            colour_scheme_index=int(family_colour_scheme),
                         )
                         result_warning = "No family data available (taxonomy may not have loaded)."
                     else:
@@ -188,9 +192,16 @@ def render_prep_spinner_and_map_tab(
                         banner = build_family_map_banner_overlay_html(metrics) if metrics else ""
                         base_to_common = bundle.get("base_to_common") or {}
                         hl_label = (base_to_common.get(hl) or hl) if hl else ""
+                        hl_species_url = None
+                        if hl and hl_label:
+                            _u = species_url_fn(hl_label)
+                            hl_species_url = _u if _u else None
+                        _sch = active_family_map_colour_scheme(int(family_colour_scheme))
                         legend = build_family_map_legend_overlay_html_for_pins(
                             pins,
                             highlight_label=hl_label or None,
+                            highlight_species_url=hl_species_url,
+                            style=_sch,
                         )
                         result_map = build_family_composition_folium_map(
                             pins,
@@ -201,6 +212,7 @@ def render_prep_spinner_and_map_tab(
                             location_page_url_fn=lambda lid: f"https://ebird.org/lifelist/{lid}" if lid else None,
                             species_url_fn=species_url_fn,
                             fit_bounds_highlight_only=bool(hl),
+                            colour_scheme_index=int(family_colour_scheme),
                         )
                         result_warning = None
 
@@ -209,7 +221,7 @@ def render_prep_spinner_and_map_tab(
                         "families",
                         date_filter_banner,
                         map_style,
-                        (fam, hl, int(map_height)),
+                        (fam, hl, int(map_height), int(family_colour_scheme)),
                         taxonomy_locale=tax_locale_effective,
                     )
                     st.session_state[FOLIUM_STATIC_MAP_CACHE_KEY] = {

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -200,6 +200,7 @@ def render_prep_spinner_and_map_tab(
                             height_px=int(map_height),
                             location_page_url_fn=lambda lid: f"https://ebird.org/lifelist/{lid}" if lid else None,
                             species_url_fn=species_url_fn,
+                            fit_bounds_highlight_only=bool(hl),
                         )
                         result_warning = None
 

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -14,6 +14,7 @@ import streamlit as st
 
 from explorer.app.streamlit.app_caches import (
     cached_checklist_stats_payload,
+    cached_family_map_bundle,
     cached_full_export_checklist_stats_payload,
     cached_sex_notation_by_year,
     full_location_data_for_maintenance,
@@ -56,6 +57,16 @@ from explorer.core.map_controller import build_species_overlay_map
 from explorer.core.map_prep import data_signature_for_caches, prepare_all_locations_map_context
 from explorer.core.settings_schema_defaults import MAP_CLUSTER_ALL_LOCATIONS_DEFAULT
 from explorer.core.species_logic import base_species_for_lifer
+from explorer.core.family_map_compute import (
+    build_family_location_pins,
+    compute_family_map_banner_metrics,
+    filter_work_to_family,
+)
+from explorer.core.family_map_folium import (
+    build_family_composition_folium_map,
+    build_family_map_banner_overlay_html,
+    build_family_map_legend_overlay_html_for_pins,
+)
 
 
 def render_prep_spinner_and_map_tab(
@@ -72,6 +83,8 @@ def render_prep_spinner_and_map_tab(
     date_filter_banner: str,
     species_pick_common: str | None,
     species_pick_sci: str,
+    family_name: str,
+    family_highlight_base: str,
     hide_non_matching_locations: bool,
     popup_sort_order: Any,
     popup_scroll_hint: Any,
@@ -138,107 +151,173 @@ def render_prep_spinner_and_map_tab(
                 map_warning_text = str(e)
                 st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
             else:
-                overlay_common = (
-                    (species_pick_common or "").strip() if map_view_mode == "species" else ""
-                )
-                overlay_sci = (species_pick_sci or "").strip() if map_view_mode == "species" else ""
-                hide_nm = (
-                    map_view_mode == "species"
-                    and bool(overlay_sci)
-                    and hide_non_matching_locations
-                )
-                _map_kw = {
-                    **ctx,
-                    "selected_species": overlay_sci,
-                    "selected_common_name": overlay_common,
-                    "map_style": map_style,
-                    "popup_sort_order": popup_sort_order,
-                    "popup_scroll_hint": popup_scroll_hint,
-                    "lifer_color": st.session_state.streamlit_lifer_color,
-                    "lifer_fill": st.session_state.streamlit_lifer_fill,
-                    "last_seen_color": st.session_state.streamlit_last_seen_color,
-                    "last_seen_fill": st.session_state.streamlit_last_seen_fill,
-                    "species_color": st.session_state.streamlit_species_color,
-                    "species_fill": st.session_state.streamlit_species_fill,
-                    "default_color": st.session_state.streamlit_default_color,
-                    "default_fill": st.session_state.streamlit_default_fill,
-                    "mark_lifer": mark_lifer,
-                    "mark_last_seen": mark_last_seen,
-                    "cluster_all_locations": bool(
-                        st.session_state.get(
-                            STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
-                            MAP_CLUSTER_ALL_LOCATIONS_DEFAULT,
+                if map_view_mode == "families":
+                    fam = (family_name or "").strip()
+                    hl = (family_highlight_base or "").strip().lower()
+
+                    bundle = cached_family_map_bundle(df_full, tax_locale_effective)
+                    fams = set(bundle.get("families") or ())
+                    work = bundle.get("work")
+                    tax_merged = bundle.get("tax_merged")
+
+                    if not fam:
+                        result_map = build_family_composition_folium_map(
+                            (),
+                            map_style=map_style,
+                            height_px=int(map_height),
                         )
-                    ),
-                    "date_filter_status": "" if is_lifer_view else date_filter_banner,
-                    "species_url_fn": species_url_fn,
-                    "base_species_fn": base_species_for_lifer,
-                    "taxonomy_locale": tax_locale_effective,
-                    "popup_html_cache": st.session_state.popup_html_cache,
-                    "filtered_by_loc_cache": st.session_state.filtered_by_loc_cache,
-                    "map_view_mode": map_view_mode,
-                    "hide_non_matching_locations": hide_nm,
-                    "show_subspecies_lifers": bool(
-                        st.session_state.get(STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY, False)
-                    ),
-                    "map_height_px": int(map_height),
-                }
-                _render_opts_sig = (
-                    popup_sort_order,
-                    popup_scroll_hint,
-                    st.session_state.streamlit_lifer_color,
-                    st.session_state.streamlit_lifer_fill,
-                    st.session_state.streamlit_last_seen_color,
-                    st.session_state.streamlit_last_seen_fill,
-                    st.session_state.streamlit_species_color,
-                    st.session_state.streamlit_species_fill,
-                    st.session_state.streamlit_default_color,
-                    st.session_state.streamlit_default_fill,
-                    mark_lifer,
-                    mark_last_seen,
-                    bool(
-                        st.session_state.get(
-                            STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
-                            MAP_CLUSTER_ALL_LOCATIONS_DEFAULT,
+                        result_warning = "Select a family in the sidebar to load the map."
+                    elif fam not in fams or work is None or getattr(work, "empty", True):
+                        result_map = build_family_composition_folium_map(
+                            (),
+                            map_style=map_style,
+                            height_px=int(map_height),
                         )
-                    ),
-                    bool(st.session_state.get(STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY, False)),
-                    int(map_height),
-                )
-                _species_selected = bool(overlay_sci)
-                _cache_map_view_mode = map_view_mode
-                if map_view_mode == "species" and not _species_selected:
-                    _cache_map_view_mode = "all"
-                _ck = static_map_cache_key(
-                    work_df,
-                    _cache_map_view_mode,
-                    date_filter_banner,
-                    map_style,
-                    _render_opts_sig,
-                    taxonomy_locale=tax_locale_effective,
-                    species_selected_sci=overlay_sci if _species_selected else "",
-                    species_selected_common=overlay_common if _species_selected else "",
-                    hide_non_matching_locations=bool(hide_nm),
-                )
-                _use_static_cache = True
-                _cached = st.session_state.get(FOLIUM_STATIC_MAP_CACHE_KEY)
-                if (
-                    isinstance(_cached, dict)
-                    and _cached.get("key") == _ck
-                    and _cached.get("map") is not None
-                ):
-                    result_map = _cached["map"]
-                    result_warning = _cached.get("warning")
+                        result_warning = "No family data available (taxonomy may not have loaded)."
+                    else:
+                        wf = filter_work_to_family(work, fam)
+                        metrics = (
+                            compute_family_map_banner_metrics(work, fam, tax_merged)
+                            if tax_merged is not None
+                            else None
+                        )
+                        pins = build_family_location_pins(
+                            wf,
+                            highlight_base_species=hl or None,
+                        )
+                        banner = build_family_map_banner_overlay_html(metrics) if metrics else ""
+                        base_to_common = bundle.get("base_to_common") or {}
+                        hl_label = (base_to_common.get(hl) or hl) if hl else ""
+                        legend = build_family_map_legend_overlay_html_for_pins(
+                            pins,
+                            highlight_label=hl_label or None,
+                        )
+                        result_map = build_family_composition_folium_map(
+                            pins,
+                            banner_html=banner,
+                            legend_html=legend,
+                            map_style=map_style,
+                            height_px=int(map_height),
+                            location_page_url_fn=lambda lid: f"https://ebird.org/lifelist/{lid}" if lid else None,
+                            species_url_fn=species_url_fn,
+                        )
+                        result_warning = None
+
+                    _ck = static_map_cache_key(
+                        work_df,
+                        "families",
+                        date_filter_banner,
+                        map_style,
+                        (fam, hl, int(map_height)),
+                        taxonomy_locale=tax_locale_effective,
+                    )
+                    st.session_state[FOLIUM_STATIC_MAP_CACHE_KEY] = {
+                        "key": _ck,
+                        "map": result_map,
+                        "warning": result_warning,
+                    }
                 else:
-                    result = build_species_overlay_map(**_map_kw)
-                    result_map = result.map
-                    result_warning = result.warning
-                    if _use_static_cache and result_map is not None:
-                        st.session_state[FOLIUM_STATIC_MAP_CACHE_KEY] = {
-                            "key": _ck,
-                            "map": result_map,
-                            "warning": result_warning,
-                        }
+                    overlay_common = (
+                        (species_pick_common or "").strip() if map_view_mode == "species" else ""
+                    )
+                    overlay_sci = (species_pick_sci or "").strip() if map_view_mode == "species" else ""
+                    hide_nm = (
+                        map_view_mode == "species"
+                        and bool(overlay_sci)
+                        and hide_non_matching_locations
+                    )
+                    _map_kw = {
+                        **ctx,
+                        "selected_species": overlay_sci,
+                        "selected_common_name": overlay_common,
+                        "map_style": map_style,
+                        "popup_sort_order": popup_sort_order,
+                        "popup_scroll_hint": popup_scroll_hint,
+                        "lifer_color": st.session_state.streamlit_lifer_color,
+                        "lifer_fill": st.session_state.streamlit_lifer_fill,
+                        "last_seen_color": st.session_state.streamlit_last_seen_color,
+                        "last_seen_fill": st.session_state.streamlit_last_seen_fill,
+                        "species_color": st.session_state.streamlit_species_color,
+                        "species_fill": st.session_state.streamlit_species_fill,
+                        "default_color": st.session_state.streamlit_default_color,
+                        "default_fill": st.session_state.streamlit_default_fill,
+                        "mark_lifer": mark_lifer,
+                        "mark_last_seen": mark_last_seen,
+                        "cluster_all_locations": bool(
+                            st.session_state.get(
+                                STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
+                                MAP_CLUSTER_ALL_LOCATIONS_DEFAULT,
+                            )
+                        ),
+                        "date_filter_status": "" if is_lifer_view else date_filter_banner,
+                        "species_url_fn": species_url_fn,
+                        "base_species_fn": base_species_for_lifer,
+                        "taxonomy_locale": tax_locale_effective,
+                        "popup_html_cache": st.session_state.popup_html_cache,
+                        "filtered_by_loc_cache": st.session_state.filtered_by_loc_cache,
+                        "map_view_mode": map_view_mode,
+                        "hide_non_matching_locations": hide_nm,
+                        "show_subspecies_lifers": bool(
+                            st.session_state.get(STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY, False)
+                        ),
+                        "map_height_px": int(map_height),
+                    }
+                    _render_opts_sig = (
+                        popup_sort_order,
+                        popup_scroll_hint,
+                        st.session_state.streamlit_lifer_color,
+                        st.session_state.streamlit_lifer_fill,
+                        st.session_state.streamlit_last_seen_color,
+                        st.session_state.streamlit_last_seen_fill,
+                        st.session_state.streamlit_species_color,
+                        st.session_state.streamlit_species_fill,
+                        st.session_state.streamlit_default_color,
+                        st.session_state.streamlit_default_fill,
+                        mark_lifer,
+                        mark_last_seen,
+                        bool(
+                            st.session_state.get(
+                                STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
+                                MAP_CLUSTER_ALL_LOCATIONS_DEFAULT,
+                            )
+                        ),
+                        bool(st.session_state.get(STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY, False)),
+                        int(map_height),
+                    )
+                    _species_selected = bool(overlay_sci)
+                    _cache_map_view_mode = map_view_mode
+                    if map_view_mode == "species" and not _species_selected:
+                        _cache_map_view_mode = "all"
+                    _ck = static_map_cache_key(
+                        work_df,
+                        _cache_map_view_mode,
+                        date_filter_banner,
+                        map_style,
+                        _render_opts_sig,
+                        taxonomy_locale=tax_locale_effective,
+                        species_selected_sci=overlay_sci if _species_selected else "",
+                        species_selected_common=overlay_common if _species_selected else "",
+                        hide_non_matching_locations=bool(hide_nm),
+                    )
+                    _use_static_cache = True
+                    _cached = st.session_state.get(FOLIUM_STATIC_MAP_CACHE_KEY)
+                    if (
+                        isinstance(_cached, dict)
+                        and _cached.get("key") == _ck
+                        and _cached.get("map") is not None
+                    ):
+                        result_map = _cached["map"]
+                        result_warning = _cached.get("warning")
+                    else:
+                        result = build_species_overlay_map(**_map_kw)
+                        result_map = result.map
+                        result_warning = result.warning
+                        if _use_static_cache and result_map is not None:
+                            st.session_state[FOLIUM_STATIC_MAP_CACHE_KEY] = {
+                                "key": _ck,
+                                "map": result_map,
+                                "warning": result_warning,
+                            }
 
                 if result_warning:
                     map_warning_text = result_warning

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -62,10 +62,10 @@ MAP_HEIGHT_PX_STEP = 20
 
 MAP_DATE_FILTER_DEFAULT = False
 
-MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Selected species", "Lifer locations", "Family map")
+MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Selected species", "Lifer locations", "Family locations")
 
 # ---------------------------------------------------------------------------
-# Family map (Map view → **Family map**; refs #138)
+# Family map (Map view → **Family locations**; refs #138)
 #
 # Two preset **colour schemes** (same structure); flip ``FAMILY_MAP_ACTIVE_COLOUR_SCHEME``
 # between ``1`` and ``2``. Not exposed in the UI yet — edit here and reload the app.

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -63,6 +63,26 @@ MAP_DATE_FILTER_DEFAULT = False
 MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Selected species", "Lifer locations", "Family map")
 
 # ---------------------------------------------------------------------------
+# Family map (Map view → **Family map**; refs #138)
+#
+# Folium ``CircleMarker`` + palette; tweak here without editing ``family_map_folium.py``.
+# ---------------------------------------------------------------------------
+FAMILY_MAP_CIRCLE_MARKER_RADIUS_PX = 7
+FAMILY_MAP_CIRCLE_MARKER_FILL_OPACITY = 0.88
+FAMILY_MAP_BASE_STROKE_WEIGHT = 2
+FAMILY_MAP_HIGHLIGHT_STROKE_HEX = "#FF7F11"
+FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT = 3
+# One fill + stroke per density band index (1 / 2–3 / 4–5 / 6+ species at location).
+FAMILY_MAP_DENSITY_FILL_HEX: tuple[str, ...] = ("#3A86FF", "#5E60CE", "#9D4EDD", "#C9184A")
+FAMILY_MAP_DENSITY_STROKE_HEX: tuple[str, ...] = ("#2F6FD1", "#4A4DA6", "#7E3EAF", "#A1143A")
+FAMILY_MAP_POPUP_MAX_WIDTH_PX = 320
+# Initial viewport: ``fit_bounds`` padding (px) and max zoom when fitting (never start closer than this).
+FAMILY_MAP_FIT_BOUNDS_PADDING_PX = 48
+FAMILY_MAP_FIT_BOUNDS_MAX_ZOOM = 6
+# Legend “highlight” swatch uses this band’s fill next to the orange ring.
+FAMILY_MAP_LEGEND_HIGHLIGHT_SWATCH_FILL_INDEX = 0
+
+# ---------------------------------------------------------------------------
 # Layout / theme (Streamlit-only)
 # ---------------------------------------------------------------------------
 

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -85,7 +85,9 @@ class FamilyMapColourScheme:
     density_stroke_hex: tuple[str, ...]
     popup_max_width_px: int
     fit_bounds_padding_px: int
+    # Max zoom for fit_bounds: full family vs species-highlight framing (see values below).
     fit_bounds_max_zoom: int
+    fit_bounds_max_zoom_highlight: int
     legend_highlight_swatch_fill_index: int
 
 
@@ -111,6 +113,7 @@ _FAMILY_MAP_SCHEME_VALUES = dict(
     popup_max_width_px=320,
     fit_bounds_padding_px=48,
     fit_bounds_max_zoom=6,
+    fit_bounds_max_zoom_highlight=8,
     legend_highlight_swatch_fill_index=0,
 )
 

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -20,6 +20,8 @@ Map code under ``explorer/`` imports cluster/pin/theme values from this module w
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 # ---------------------------------------------------------------------------
 # Marker cluster — default “all locations” map (Leaflet.markercluster via Folium)
 # ---------------------------------------------------------------------------
@@ -65,22 +67,68 @@ MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Selected species", "Lifer 
 # ---------------------------------------------------------------------------
 # Family map (Map view → **Family map**; refs #138)
 #
-# Folium ``CircleMarker`` + palette; tweak here without editing ``family_map_folium.py``.
+# Two preset **colour schemes** (same structure); flip ``FAMILY_MAP_ACTIVE_COLOUR_SCHEME``
+# between ``1`` and ``2``. Not exposed in the UI yet — edit here and reload the app.
 # ---------------------------------------------------------------------------
-FAMILY_MAP_CIRCLE_MARKER_RADIUS_PX = 7
-FAMILY_MAP_CIRCLE_MARKER_FILL_OPACITY = 0.88
-FAMILY_MAP_BASE_STROKE_WEIGHT = 2
-FAMILY_MAP_HIGHLIGHT_STROKE_HEX = "#FF7F11"
-FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT = 3
-# One fill + stroke per density band index (1 / 2–3 / 4–5 / 6+ species at location).
-FAMILY_MAP_DENSITY_FILL_HEX: tuple[str, ...] = ("#3A86FF", "#5E60CE", "#9D4EDD", "#C9184A")
-FAMILY_MAP_DENSITY_STROKE_HEX: tuple[str, ...] = ("#2F6FD1", "#4A4DA6", "#7E3EAF", "#A1143A")
-FAMILY_MAP_POPUP_MAX_WIDTH_PX = 320
-# Initial viewport: ``fit_bounds`` padding (px) and max zoom when fitting (never start closer than this).
-FAMILY_MAP_FIT_BOUNDS_PADDING_PX = 48
-FAMILY_MAP_FIT_BOUNDS_MAX_ZOOM = 6
-# Legend “highlight” swatch uses this band’s fill next to the orange ring.
-FAMILY_MAP_LEGEND_HIGHLIGHT_SWATCH_FILL_INDEX = 0
+
+
+@dataclass(frozen=True)
+class FamilyMapColourScheme:
+    """All Folium family-map tunables (colours, sizes, strokes, viewport, legend)."""
+
+    circle_marker_radius_px: int
+    circle_marker_fill_opacity: float
+    base_stroke_weight: int
+    highlight_stroke_hex: str
+    highlight_stroke_weight: int
+    density_fill_hex: tuple[str, ...]
+    density_stroke_hex: tuple[str, ...]
+    popup_max_width_px: int
+    fit_bounds_padding_px: int
+    fit_bounds_max_zoom: int
+    legend_highlight_swatch_fill_index: int
+
+
+# Scheme 1 — current default look (edit freely).
+_FAMILY_MAP_SCHEME_VALUES = dict(
+    circle_marker_radius_px=6,
+    circle_marker_fill_opacity=0.9,
+    base_stroke_weight=2,
+    highlight_stroke_hex="#2EC4B6",
+    highlight_stroke_weight=2,
+    density_fill_hex=(
+        "#E57373",
+        "#C62828",
+        "#8B0000",
+        "#4A0000",
+    ),
+    density_stroke_hex=(
+        "#B55252",
+        "#8E1B1B",
+        "#5A0000",
+        "#2A0000",
+    ),
+    popup_max_width_px=320,
+    fit_bounds_padding_px=48,
+    fit_bounds_max_zoom=6,
+    legend_highlight_swatch_fill_index=0,
+)
+
+FAMILY_MAP_COLOUR_SCHEME_1 = FamilyMapColourScheme(**_FAMILY_MAP_SCHEME_VALUES)
+# Scheme 2 — duplicate of scheme 1 until you diverge it for experiments.
+FAMILY_MAP_COLOUR_SCHEME_2 = FamilyMapColourScheme(**_FAMILY_MAP_SCHEME_VALUES)
+
+# Set to ``1`` or ``2`` to select ``FAMILY_MAP_COLOUR_SCHEME_1`` / ``FAMILY_MAP_COLOUR_SCHEME_2``.
+FAMILY_MAP_ACTIVE_COLOUR_SCHEME: int = 2
+
+
+def active_family_map_colour_scheme() -> FamilyMapColourScheme:
+    """Return the active family-map style bundle (refs #138)."""
+    n = int(FAMILY_MAP_ACTIVE_COLOUR_SCHEME)
+    if n == 2:
+        return FAMILY_MAP_COLOUR_SCHEME_2
+    return FAMILY_MAP_COLOUR_SCHEME_1
+
 
 # ---------------------------------------------------------------------------
 # Layout / theme (Streamlit-only)

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -67,8 +67,8 @@ MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Selected species", "Lifer 
 # ---------------------------------------------------------------------------
 # Family map (Map view → **Family locations**; refs #138)
 #
-# Two preset **colour schemes** (same structure); flip ``FAMILY_MAP_ACTIVE_COLOUR_SCHEME``
-# between ``1`` and ``2``. Not exposed in the UI yet — edit here and reload the app.
+# Two preset **colour schemes** (same structure). Sidebar radio (session-only) selects the active
+# scheme; ``FAMILY_MAP_ACTIVE_COLOUR_SCHEME`` is the default when no UI index is passed (tests).
 # ---------------------------------------------------------------------------
 
 
@@ -76,6 +76,7 @@ MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Selected species", "Lifer 
 class FamilyMapColourScheme:
     """All Folium family-map tunables (colours, sizes, strokes, viewport, legend)."""
 
+    display_name: str
     circle_marker_radius_px: int
     circle_marker_fill_opacity: float
     base_stroke_weight: int
@@ -91,37 +92,10 @@ class FamilyMapColourScheme:
     legend_highlight_swatch_fill_index: int
 
 
-# Scheme 1 — blue → purple density ramp, orange highlight ring (restored from the pre-dataclass
-# family map constants in git: ``c48caca`` centralise-family-map-style; lost when both schemes were
-# initialised to the red ramp in ``fff4ce6``).
+# Scheme 1 — default: red density ramp + teal highlight.
 _FAMILY_MAP_SCHEME_1_VALUES = dict(
-    circle_marker_radius_px=6,
-    circle_marker_fill_opacity=0.88,
-    base_stroke_weight=2,
-    highlight_stroke_hex="#FF7F11",
-    highlight_stroke_weight=2,
-    density_fill_hex=(
-        "#3A86FF", 
-        "#5E60CE", 
-        "#9D4EDD", 
-        "#C9184A"
-    ),
-    density_stroke_hex=(
-        "#2F6FD1", 
-        "#4A4DA6", 
-        "#7E3EAF", 
-        "#A1143A"
-    ),
-    popup_max_width_px=320,
-    fit_bounds_padding_px=48,
-    fit_bounds_max_zoom=6,
-    fit_bounds_max_zoom_highlight=8,
-    legend_highlight_swatch_fill_index=0,
-)
-
-# Scheme 2 — red density ramp + teal highlight (current preferred look).
-_FAMILY_MAP_SCHEME_2_VALUES = dict(
-    circle_marker_radius_px=6,
+    display_name="Reds",
+    circle_marker_radius_px=5,
     circle_marker_fill_opacity=0.88,
     base_stroke_weight=2,
     highlight_stroke_hex="#2EC4B6",
@@ -145,16 +119,46 @@ _FAMILY_MAP_SCHEME_2_VALUES = dict(
     legend_highlight_swatch_fill_index=0,
 )
 
+# Scheme 2 — blue → purple density ramp, orange highlight (restored pre-dataclass palette; ``c48caca``).
+_FAMILY_MAP_SCHEME_2_VALUES = dict(
+    display_name="Blues & purples",
+    circle_marker_radius_px=4,
+    circle_marker_fill_opacity=0.88,
+    base_stroke_weight=3,
+    highlight_stroke_hex="#FF7F11",
+    highlight_stroke_weight=3,
+    density_fill_hex=(
+        "#3A86FF",
+        "#5E60CE",
+        "#9D4EDD",
+        "#C9184A",
+    ),
+    density_stroke_hex=(
+        "#2F6FD1",
+        "#4A4DA6",
+        "#7E3EAF",
+        "#A1143A",
+    ),
+    popup_max_width_px=320,
+    fit_bounds_padding_px=48,
+    fit_bounds_max_zoom=6,
+    fit_bounds_max_zoom_highlight=8,
+    legend_highlight_swatch_fill_index=0,
+)
+
 FAMILY_MAP_COLOUR_SCHEME_1 = FamilyMapColourScheme(**_FAMILY_MAP_SCHEME_1_VALUES)
 FAMILY_MAP_COLOUR_SCHEME_2 = FamilyMapColourScheme(**_FAMILY_MAP_SCHEME_2_VALUES)
 
-# Set to ``1`` or ``2`` to select ``FAMILY_MAP_COLOUR_SCHEME_1`` / ``FAMILY_MAP_COLOUR_SCHEME_2``.
+# Default scheme index when callers do not pass a UI selection (tests, non-Streamlit builders).
 FAMILY_MAP_ACTIVE_COLOUR_SCHEME: int = 1
 
 
-def active_family_map_colour_scheme() -> FamilyMapColourScheme:
-    """Return the active family-map style bundle (refs #138)."""
-    n = int(FAMILY_MAP_ACTIVE_COLOUR_SCHEME)
+def active_family_map_colour_scheme(scheme_index: int | None = None) -> FamilyMapColourScheme:
+    """Return the family-map style bundle for *scheme_index* ``1`` or ``2`` (refs #138).
+
+    When *scheme_index* is ``None``, uses :data:`FAMILY_MAP_ACTIVE_COLOUR_SCHEME` (Reds by default).
+    """
+    n = int(FAMILY_MAP_ACTIVE_COLOUR_SCHEME if scheme_index is None else scheme_index)
     if n == 2:
         return FAMILY_MAP_COLOUR_SCHEME_2
     return FAMILY_MAP_COLOUR_SCHEME_1

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -122,11 +122,11 @@ _FAMILY_MAP_SCHEME_1_VALUES = dict(
 # Scheme 2 — blue → purple density ramp, orange highlight (restored pre-dataclass palette; ``c48caca``).
 _FAMILY_MAP_SCHEME_2_VALUES = dict(
     display_name="Blues & purples",
-    circle_marker_radius_px=4,
+    circle_marker_radius_px=5,
     circle_marker_fill_opacity=0.88,
-    base_stroke_weight=3,
+    base_stroke_weight=2,
     highlight_stroke_hex="#FF7F11",
-    highlight_stroke_weight=3,
+    highlight_stroke_weight=2,
     density_fill_hex=(
         "#3A86FF",
         "#5E60CE",

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -60,7 +60,7 @@ MAP_HEIGHT_PX_STEP = 20
 
 MAP_DATE_FILTER_DEFAULT = False
 
-MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Selected species", "Lifer locations")
+MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Selected species", "Lifer locations", "Family map")
 
 # ---------------------------------------------------------------------------
 # Layout / theme (Streamlit-only)

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -91,10 +91,38 @@ class FamilyMapColourScheme:
     legend_highlight_swatch_fill_index: int
 
 
-# Scheme 1 — current default look (edit freely).
-_FAMILY_MAP_SCHEME_VALUES = dict(
+# Scheme 1 — blue → purple density ramp, orange highlight ring (restored from the pre-dataclass
+# family map constants in git: ``c48caca`` centralise-family-map-style; lost when both schemes were
+# initialised to the red ramp in ``fff4ce6``).
+_FAMILY_MAP_SCHEME_1_VALUES = dict(
     circle_marker_radius_px=6,
-    circle_marker_fill_opacity=0.9,
+    circle_marker_fill_opacity=0.88,
+    base_stroke_weight=2,
+    highlight_stroke_hex="#FF7F11",
+    highlight_stroke_weight=2,
+    density_fill_hex=(
+        "#3A86FF", 
+        "#5E60CE", 
+        "#9D4EDD", 
+        "#C9184A"
+    ),
+    density_stroke_hex=(
+        "#2F6FD1", 
+        "#4A4DA6", 
+        "#7E3EAF", 
+        "#A1143A"
+    ),
+    popup_max_width_px=320,
+    fit_bounds_padding_px=48,
+    fit_bounds_max_zoom=6,
+    fit_bounds_max_zoom_highlight=8,
+    legend_highlight_swatch_fill_index=0,
+)
+
+# Scheme 2 — red density ramp + teal highlight (current preferred look).
+_FAMILY_MAP_SCHEME_2_VALUES = dict(
+    circle_marker_radius_px=6,
+    circle_marker_fill_opacity=0.88,
     base_stroke_weight=2,
     highlight_stroke_hex="#2EC4B6",
     highlight_stroke_weight=2,
@@ -117,12 +145,11 @@ _FAMILY_MAP_SCHEME_VALUES = dict(
     legend_highlight_swatch_fill_index=0,
 )
 
-FAMILY_MAP_COLOUR_SCHEME_1 = FamilyMapColourScheme(**_FAMILY_MAP_SCHEME_VALUES)
-# Scheme 2 — duplicate of scheme 1 until you diverge it for experiments.
-FAMILY_MAP_COLOUR_SCHEME_2 = FamilyMapColourScheme(**_FAMILY_MAP_SCHEME_VALUES)
+FAMILY_MAP_COLOUR_SCHEME_1 = FamilyMapColourScheme(**_FAMILY_MAP_SCHEME_1_VALUES)
+FAMILY_MAP_COLOUR_SCHEME_2 = FamilyMapColourScheme(**_FAMILY_MAP_SCHEME_2_VALUES)
 
 # Set to ``1`` or ``2`` to select ``FAMILY_MAP_COLOUR_SCHEME_1`` / ``FAMILY_MAP_COLOUR_SCHEME_2``.
-FAMILY_MAP_ACTIVE_COLOUR_SCHEME: int = 2
+FAMILY_MAP_ACTIVE_COLOUR_SCHEME: int = 1
 
 
 def active_family_map_colour_scheme() -> FamilyMapColourScheme:

--- a/explorer/app/streamlit/family_map_streamlit_html.py
+++ b/explorer/app/streamlit/family_map_streamlit_html.py
@@ -1,0 +1,142 @@
+"""Family Map tab — Streamlit UI (refs #138).
+
+Runs in ``@st.fragment`` so family/highlight changes do not rerun the full script. Taxonomy + work
+frame are cached in :func:`~explorer.app.streamlit.app_caches.cached_family_map_bundle`.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pandas as pd
+import streamlit as st
+
+from explorer.app.streamlit.app_caches import cached_family_map_bundle
+from explorer.app.streamlit.app_constants import (
+    STREAMLIT_FAMILY_MAP_FAMILY_KEY,
+    STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY,
+)
+from explorer.app.streamlit.app_map_ui import inject_map_folium_iframe_min_height_css
+from explorer.core.family_map_compute import (
+    build_family_location_pins,
+    compute_family_map_banner_metrics,
+    filter_work_to_family,
+    highlight_species_choices_alphabetical,
+)
+from explorer.core.family_map_folium import (
+    build_family_composition_folium_map,
+    build_family_map_banner_overlay_html,
+    build_family_map_legend_overlay_html,
+)
+
+
+def _ebird_location_url(location_id: str) -> str | None:
+    lid = str(location_id).strip()
+    if not lid:
+        return None
+    return f"https://ebird.org/lifelist/{lid}"
+
+
+@st.fragment
+def run_family_map_streamlit_fragment(
+    *,
+    df_full: pd.DataFrame,
+    taxonomy_locale: str,
+    map_height: int,
+    map_style: str,
+    species_url_fn: Callable[[str], str | None],
+) -> None:
+    """Render the **Families** tab: family + highlight controls and Folium composition map."""
+    st.caption(
+        "Map species-group (family) richness by location. Select a family to load pins; "
+        "optionally highlight locations where a chosen species occurs (refs #138)."
+    )
+
+    if df_full is None or df_full.empty:
+        st.info("Load your eBird export to explore families on the map.")
+        return
+
+    bundle = cached_family_map_bundle(df_full, taxonomy_locale)
+    families = bundle["families"]
+    work = bundle["work"]
+    tax_merged = bundle["tax_merged"]
+    base_to_common = bundle["base_to_common"]
+
+    if not families:
+        st.warning(
+            "No taxonomy-backed families found in your data. "
+            "Check your network connection so eBird taxonomy and species groups can load, "
+            "then refresh the page."
+        )
+        m = build_family_composition_folium_map(())
+        _embed_family_map(m, map_height)
+        return
+
+    fam_options = [""] + list(families)
+    family = st.selectbox(
+        "Family",
+        options=fam_options,
+        format_func=lambda x: "— Select a family —" if x == "" else x,
+        key=STREAMLIT_FAMILY_MAP_FAMILY_KEY,
+    )
+
+    if not family:
+        st.selectbox(
+            "Highlight species (optional)",
+            options=["— None —"],
+            disabled=True,
+            key=f"{STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY}__none",
+        )
+        m = build_family_composition_folium_map(())
+        _embed_family_map(m, map_height)
+        st.info("Select a family above to show where you recorded those species.")
+        return
+
+    wf = filter_work_to_family(work, family)
+    choices = highlight_species_choices_alphabetical(wf, base_to_common)
+    label_to_base: dict[str, str | None] = {"— None —": None}
+    for lab, bs in choices:
+        label_to_base[lab] = bs
+    hl_labels = list(label_to_base.keys())
+    hl_key = f"{STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY}__{family}"
+    hl_label = st.selectbox(
+        "Highlight species (optional)",
+        options=hl_labels,
+        key=hl_key,
+    )
+    highlight_base = label_to_base.get(hl_label)
+    metrics = compute_family_map_banner_metrics(wf, family, tax_merged)
+    pins = build_family_location_pins(wf, highlight_base_species=highlight_base)
+    banner = build_family_map_banner_overlay_html(metrics) if metrics else ""
+    legend = build_family_map_legend_overlay_html(include_highlight=bool(highlight_base))
+
+    m = build_family_composition_folium_map(
+        pins,
+        banner_html=banner,
+        legend_html=legend,
+        map_style=map_style,
+        height_px=int(map_height),
+        location_page_url_fn=_ebird_location_url,
+        species_url_fn=species_url_fn,
+    )
+    _embed_family_map(m, map_height)
+
+
+def _embed_family_map(m: object, map_height: int) -> None:
+    inject_map_folium_iframe_min_height_css(map_height)
+    try:
+        from streamlit_folium import st_folium
+    except ImportError:
+        st.error(
+            "Missing **streamlit-folium** (needed to embed the Folium map). "
+            "Install with: `pip install -r requirements.txt`."
+        )
+        return
+    st_folium(
+        m,
+        use_container_width=True,
+        height=map_height,
+        key="explorer_family_map_folium_v1",
+        returned_objects=[],
+        return_on_hover=False,
+    )

--- a/explorer/app/streamlit/family_map_streamlit_html.py
+++ b/explorer/app/streamlit/family_map_streamlit_html.py
@@ -13,8 +13,15 @@ import streamlit as st
 
 from explorer.app.streamlit.app_caches import cached_family_map_bundle
 from explorer.app.streamlit.app_constants import (
+    STREAMLIT_FAMILY_MAP_COLOUR_SCHEME_KEY,
     STREAMLIT_FAMILY_MAP_FAMILY_KEY,
     STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY,
+)
+from explorer.app.streamlit.app_map_working_ui import invalidate_folium_map_embed_cache
+from explorer.app.streamlit.defaults import (
+    FAMILY_MAP_COLOUR_SCHEME_1,
+    FAMILY_MAP_COLOUR_SCHEME_2,
+    active_family_map_colour_scheme,
 )
 from explorer.app.streamlit.app_map_ui import inject_map_folium_iframe_min_height_css
 from explorer.core.family_map_compute import (
@@ -26,7 +33,7 @@ from explorer.core.family_map_compute import (
 from explorer.core.family_map_folium import (
     build_family_composition_folium_map,
     build_family_map_banner_overlay_html,
-    build_family_map_legend_overlay_html,
+    build_family_map_legend_overlay_html_for_pins,
 )
 
 
@@ -68,7 +75,7 @@ def run_family_map_streamlit_fragment(
             "Check your network connection so eBird taxonomy and species groups can load, "
             "then refresh the page."
         )
-        m = build_family_composition_folium_map(())
+        m = build_family_composition_folium_map((), colour_scheme_index=1)
         _embed_family_map(m, map_height)
         return
 
@@ -87,28 +94,58 @@ def run_family_map_streamlit_fragment(
             disabled=True,
             key=f"{STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY}__none",
         )
-        m = build_family_composition_folium_map(())
+    else:
+        wf = filter_work_to_family(work, family)
+        choices = highlight_species_choices_alphabetical(wf, base_to_common)
+        label_to_base = {"— None —": None}
+        for lab, bs in choices:
+            label_to_base[lab] = bs
+        hl_labels = list(label_to_base.keys())
+        hl_key = f"{STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY}__{family}"
+        hl_label = st.selectbox(
+            "Highlight species (optional)",
+            options=hl_labels,
+            key=hl_key,
+        )
+        highlight_base = label_to_base.get(hl_label)
+
+    colour_scheme = int(
+        st.radio(
+            "Colour scheme",
+            options=[1, 2],
+            format_func=lambda n: (
+                FAMILY_MAP_COLOUR_SCHEME_1.display_name
+                if n == 1
+                else FAMILY_MAP_COLOUR_SCHEME_2.display_name
+            ),
+            horizontal=True,
+            key=STREAMLIT_FAMILY_MAP_COLOUR_SCHEME_KEY,
+            index=0,
+            on_change=invalidate_folium_map_embed_cache,
+        )
+    )
+
+    if not family:
+        m = build_family_composition_folium_map((), colour_scheme_index=colour_scheme)
         _embed_family_map(m, map_height)
         st.info("Select a family above to show where you recorded those species.")
         return
 
-    wf = filter_work_to_family(work, family)
-    choices = highlight_species_choices_alphabetical(wf, base_to_common)
-    label_to_base: dict[str, str | None] = {"— None —": None}
-    for lab, bs in choices:
-        label_to_base[lab] = bs
-    hl_labels = list(label_to_base.keys())
-    hl_key = f"{STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY}__{family}"
-    hl_label = st.selectbox(
-        "Highlight species (optional)",
-        options=hl_labels,
-        key=hl_key,
-    )
-    highlight_base = label_to_base.get(hl_label)
     metrics = compute_family_map_banner_metrics(wf, family, tax_merged)
     pins = build_family_location_pins(wf, highlight_base_species=highlight_base)
     banner = build_family_map_banner_overlay_html(metrics) if metrics else ""
-    legend = build_family_map_legend_overlay_html(include_highlight=bool(highlight_base))
+    _sch = active_family_map_colour_scheme(colour_scheme)
+    hl_label_common = (base_to_common.get(highlight_base) or highlight_base) if highlight_base else ""
+    hl_species_url = None
+    if highlight_base and hl_label_common:
+        _u = species_url_fn(hl_label_common)
+        hl_species_url = _u if _u else None
+    legend = build_family_map_legend_overlay_html_for_pins(
+        pins,
+        highlight_label=hl_label_common or None,
+        highlight_species_url=hl_species_url,
+        style=_sch,
+    )
 
     m = build_family_composition_folium_map(
         pins,
@@ -118,6 +155,8 @@ def run_family_map_streamlit_fragment(
         height_px=int(map_height),
         location_page_url_fn=_ebird_location_url,
         species_url_fn=species_url_fn,
+        fit_bounds_highlight_only=bool(highlight_base),
+        colour_scheme_index=colour_scheme,
     )
     _embed_family_map(m, map_height)
 

--- a/explorer/core/family_map_compute.py
+++ b/explorer/core/family_map_compute.py
@@ -1,0 +1,300 @@
+"""Family Map (refs #138) — pure aggregation for taxonomy family × location composition.
+
+Density uses **distinct base species** per location (subspecies roll up). Popup lines use
+**distinct common names** as recorded (subspecies appear as separate lines). Highlight
+targets a **base species**; any subspecies row counts as a match.
+
+Callers supply :func:`~explorer.core.species_family.build_base_species_to_family_map` and
+taxonomy tables built the same way as Rankings **Families** (``group_name`` per species row).
+"""
+
+from __future__ import annotations
+
+import html as html_module
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+from explorer.core.species_logic import countable_species_vectorized
+
+UNMAPPED_FAMILY_LABEL = "Unmapped"
+
+# Legend bands: 1 | 2–3 | 4–5 | 6+ distinct base species in the family at the location.
+DENSITY_BAND_LABELS: tuple[str, ...] = ("1", "2–3", "4–5", "6+")
+
+
+def family_density_band_index(distinct_base_species_count: int) -> int:
+    """Map a richness count to a band index in ``0 .. len(DENSITY_BAND_LABELS)-1``."""
+    n = int(distinct_base_species_count)
+    if n <= 0:
+        return 0
+    if n == 1:
+        return 0
+    if n <= 3:
+        return 1
+    if n <= 5:
+        return 2
+    return 3
+
+
+def family_density_band_label(distinct_base_species_count: int) -> str:
+    """Human-readable band label for legend rows (matches :data:`DENSITY_BAND_LABELS`)."""
+    idx = family_density_band_index(distinct_base_species_count)
+    return DENSITY_BAND_LABELS[idx]
+
+
+@dataclass(frozen=True)
+class FamilyMapBannerMetrics:
+    """Summary numbers for the family-map banner (refs #138)."""
+
+    family_name: str
+    total_species_taxonomy: int
+    species_recorded_user: int
+    locations_with_records: int
+
+
+@dataclass(frozen=True)
+class FamilyLocationPin:
+    """One location row for family composition map rendering."""
+
+    location_id: str
+    location_name: str
+    latitude: float
+    longitude: float
+    distinct_base_species_count: int
+    density_band_index: int
+    common_name_lines: tuple[str, ...]
+    highlight_match: bool
+
+
+def prepare_family_map_work_frame(
+    df: pd.DataFrame,
+    base_to_family: dict[str, str],
+) -> pd.DataFrame:
+    """Attach ``_base`` and ``_family``; keep only countable rows with a mapped family.
+
+    *base_to_family* is typically from :func:`~explorer.core.species_family.build_base_species_to_family_map`.
+    Rows with missing family or :data:`UNMAPPED_FAMILY_LABEL` are dropped (family map is taxonomy-backed).
+    """
+    if df.empty:
+        return pd.DataFrame()
+    work = df.copy()
+    work["_base"] = countable_species_vectorized(work)
+    work = work[work["_base"].notna()].copy()
+    work["_base"] = work["_base"].astype(str).str.strip()
+    fam_series = work["_base"].map(lambda b: base_to_family.get(b))
+    work["_family"] = fam_series
+    work = work[work["_family"].notna()].copy()
+    work = work[work["_family"].astype(str).str.strip() != UNMAPPED_FAMILY_LABEL].copy()
+    return work
+
+
+def families_recorded_alphabetically(work: pd.DataFrame) -> tuple[str, ...]:
+    """Distinct families present in *work*, sorted A→Z (refs #138 family dropdown)."""
+    if work.empty or "_family" not in work.columns:
+        return ()
+    s = work["_family"].dropna().astype(str).str.strip()
+    s = s[s != ""]
+    return tuple(sorted(s.unique(), key=str.casefold))
+
+
+def filter_work_to_family(work: pd.DataFrame, family_name: str) -> pd.DataFrame:
+    """Rows for a single family (caller ensures *family_name* is non-empty)."""
+    if work.empty:
+        return work
+    fn = str(family_name).strip()
+    return work[work["_family"].astype(str).str.strip() == fn].copy()
+
+
+def taxonomy_species_count_for_family(taxonomy_merged: pd.DataFrame, family_name: str) -> int:
+    """Count distinct ``base_species`` in *taxonomy_merged* for ``group_name == family_name``.
+
+    *taxonomy_merged* matches the Rankings Families merge: at least ``base_species`` and ``group_name``.
+    """
+    if taxonomy_merged.empty or not family_name:
+        return 0
+    fn = str(family_name).strip()
+    sub = taxonomy_merged[taxonomy_merged["group_name"].astype(str).str.strip() == fn]
+    if sub.empty or "base_species" not in sub.columns:
+        return 0
+    return int(sub["base_species"].nunique())
+
+
+def compute_family_map_banner_metrics(
+    work: pd.DataFrame,
+    family_name: str,
+    taxonomy_merged: pd.DataFrame,
+) -> FamilyMapBannerMetrics | None:
+    """Banner metrics; returns ``None`` if *family_name* is empty or there is no user data for the family."""
+    fn = (family_name or "").strip()
+    if not fn:
+        return None
+    wf = filter_work_to_family(work, fn)
+    if wf.empty:
+        return None
+    total_tax = taxonomy_species_count_for_family(taxonomy_merged, fn)
+    user_species = int(wf["_base"].nunique())
+    locs = int(wf["Location ID"].nunique())
+    return FamilyMapBannerMetrics(
+        family_name=fn,
+        total_species_taxonomy=total_tax,
+        species_recorded_user=user_species,
+        locations_with_records=locs,
+    )
+
+
+def highlight_species_choices_alphabetical(
+    work_family: pd.DataFrame,
+    base_to_common: dict[str, str],
+) -> tuple[tuple[str, str], ...]:
+    """(display label, base species key) for the highlight dropdown, A→Z by display label.
+
+    *base_to_common* maps lowercased base scientific key → preferred common name (e.g. from taxonomy).
+    Multiple bases fall back to the base string itself. Only **base species** appear (refs #138: no
+    subspecies rows in the highlight list).
+    """
+    if work_family.empty or "_base" not in work_family.columns:
+        return ()
+    bases = sorted(work_family["_base"].dropna().astype(str).str.strip().unique(), key=str.casefold)
+
+    def label_for(b: str) -> str:
+        return (base_to_common.get(b) or b).strip() or b
+
+    pairs = [(label_for(b), b) for b in bases]
+    pairs.sort(key=lambda p: (p[0].casefold(), p[1].casefold()))
+    return tuple(pairs)
+
+
+def _location_coords_and_name(grp: pd.DataFrame) -> tuple[float, float, str]:
+    lat = grp["Latitude"].iloc[0]
+    lon = grp["Longitude"].iloc[0]
+    if hasattr(lat, "item"):
+        lat = float(lat.item())
+    else:
+        lat = float(lat)
+    if hasattr(lon, "item"):
+        lon = float(lon.item())
+    else:
+        lon = float(lon)
+    loc_col = "Location" if "Location" in grp.columns else None
+    name = ""
+    if loc_col:
+        name = str(grp[loc_col].iloc[0] if len(grp) else "").strip()
+    return lat, lon, name
+
+
+def build_family_location_pins(
+    work_family: pd.DataFrame,
+    *,
+    highlight_base_species: str | None = None,
+) -> tuple[FamilyLocationPin, ...]:
+    """One pin per location with richness, popup lines, and optional highlight match."""
+    if work_family.empty:
+        return ()
+    required = {"Location ID", "Latitude", "Longitude", "_base", "Common Name"}
+    missing = required - set(work_family.columns)
+    if missing:
+        raise ValueError(f"work_family missing columns: {sorted(missing)}")
+
+    hb = (highlight_base_species or "").strip().lower() or None
+
+    rows: list[FamilyLocationPin] = []
+    for lid, grp in work_family.groupby("Location ID", sort=False):
+        grp = grp.dropna(subset=["Latitude", "Longitude"])
+        if grp.empty:
+            continue
+        n_base = int(grp["_base"].nunique())
+        band_idx = family_density_band_index(n_base)
+        commons = grp["Common Name"].fillna("").astype(str).str.strip()
+        lines = tuple(sorted(c for c in commons.unique() if c))
+        lat, lon, loc_name = _location_coords_and_name(grp)
+        bases_lower = {str(b).strip().lower() for b in grp["_base"].dropna().astype(str)}
+        hl = bool(hb and hb in bases_lower)
+        rows.append(
+            FamilyLocationPin(
+                location_id=str(lid),
+                location_name=loc_name,
+                latitude=lat,
+                longitude=lon,
+                distinct_base_species_count=n_base,
+                density_band_index=band_idx,
+                common_name_lines=lines,
+                highlight_match=hl,
+            )
+        )
+    # Stable order: alphabetical by location name, then id
+    rows.sort(key=lambda p: (p.location_name.casefold(), p.location_id.casefold()))
+    return tuple(rows)
+
+
+def merge_taxonomy_detail_for_family_map(
+    taxonomy_species_rows: pd.DataFrame,
+    groups: Iterable[dict],
+) -> pd.DataFrame:
+    """Same merge as Rankings Families: species rows + ``group_name`` / ``group_order``.
+
+    *taxonomy_species_rows* is from :func:`~explorer.core.species_family.load_taxonomy_species_rows`.
+    *groups* is from :func:`~explorer.core.species_family.load_taxonomy_groups`.
+    """
+    from explorer.core.species_family import assign_group_for_taxon_order
+
+    tax = taxonomy_species_rows.copy()
+    if tax.empty:
+        return pd.DataFrame()
+    glist = list(groups)
+    if not glist:
+        return pd.DataFrame()
+
+    tax[["group_name", "group_order"]] = tax["taxon_order"].apply(
+        lambda x: pd.Series(assign_group_for_taxon_order(float(x), glist))
+    )
+    return tax
+
+
+def base_species_to_common_from_taxonomy(taxonomy_merged: pd.DataFrame) -> dict[str, str]:
+    """Map lowercased ``base_species`` → ``common_name`` (first occurrence wins)."""
+    if taxonomy_merged.empty:
+        return {}
+    need = {"base_species", "common_name"}
+    if not need.issubset(taxonomy_merged.columns):
+        return {}
+    out: dict[str, str] = {}
+    for _, row in taxonomy_merged.iterrows():
+        b = str(row["base_species"]).strip().lower()
+        c = str(row.get("common_name", "")).strip()
+        if b and b not in out and c:
+            out[b] = c
+    return out
+
+
+def format_family_location_popup_html(
+    pin: FamilyLocationPin,
+    *,
+    location_page_url: str | None = None,
+    species_url_by_common: dict[str, str] | None = None,
+) -> str:
+    """HTML body for a family-map pin: location title + alphabetical species lines (refs #138).
+
+    *species_url_by_common* maps exact common-name strings (as in *pin.common_name_lines*) to
+    eBird species URLs; missing keys render as plain text.
+    """
+    title = pin.location_name or pin.location_id
+    esc_title = html_module.escape(title)
+    if location_page_url and str(location_page_url).strip():
+        esc_href = html_module.escape(str(location_page_url).strip(), quote=True)
+        head = f'<div style="font-weight:600;margin-bottom:0.35em;"><a href="{esc_href}" target="_blank" rel="noopener noreferrer">{esc_title}</a></div>'
+    else:
+        head = f'<div style="font-weight:600;margin-bottom:0.35em;">{esc_title}</div>'
+    lines: list[str] = []
+    url_map = species_url_by_common or {}
+    for name in pin.common_name_lines:
+        esc_n = html_module.escape(name)
+        u = url_map.get(name) or url_map.get(name.strip())
+        if u and str(u).strip():
+            esc_u = html_module.escape(str(u).strip(), quote=True)
+            lines.append(f'<div style="font-size:0.92em;"><a href="{esc_u}" target="_blank" rel="noopener noreferrer">{esc_n}</a></div>')
+        else:
+            lines.append(f'<div style="font-size:0.92em;">{esc_n}</div>')
+    body = "".join(lines) if lines else '<div style="opacity:0.7;font-size:0.85em;">No species lines</div>'
+    return f'<div style="min-width:12rem;max-width:22rem;">{head}{body}</div>'

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -118,17 +118,27 @@ def build_family_composition_folium_map(
     height_px: int = MAP_HEIGHT_PX_DEFAULT,
     location_page_url_fn: Callable[[str], str | None] | None = None,
     species_url_fn: Callable[[str], str | None] | None = None,
+    fit_bounds_highlight_only: bool = False,
 ) -> folium.Map:
     """Render CircleMarkers for family composition; optional eBird links in popups.
 
     *location_page_url_fn* maps ``Location ID`` → hotspot URL; *species_url_fn* maps common name
     (as shown in the export) to species page URL.
+
+    When *fit_bounds_highlight_only* is true (highlight species selected), the initial ``fit_bounds``
+    uses only pins where ``highlight_match`` is true, with the same padding / ``max_zoom`` as the
+    full-family case. If none match, falls back to all pins.
     """
     pin_list = list(pins)
     if pin_list:
+        if fit_bounds_highlight_only:
+            hl_only = [p for p in pin_list if p.highlight_match]
+            _cent_src = hl_only if hl_only else pin_list
+        else:
+            _cent_src = pin_list
         center = (
-            sum(p.latitude for p in pin_list) / len(pin_list),
-            sum(p.longitude for p in pin_list) / len(pin_list),
+            sum(p.latitude for p in _cent_src) / len(_cent_src),
+            sum(p.longitude for p in _cent_src) / len(_cent_src),
         )
     else:
         center = _default_au_center()
@@ -174,10 +184,14 @@ def build_family_composition_folium_map(
         ).add_to(m)
 
     # Family-map-only initial viewport:
-    # - fit all pins with some edge padding
-    # - never start closer than zoom 6 (allow wider zoom-out when needed)
+    # - fit relevant pins with edge padding (all family pins, or highlight-only when requested)
+    # - never start closer than configured max zoom (allow wider zoom-out when needed)
     if pin_list:
-        bounds = [[p.latitude, p.longitude] for p in pin_list]
+        if fit_bounds_highlight_only:
+            _bounds_src = [p for p in pin_list if p.highlight_match] or pin_list
+        else:
+            _bounds_src = pin_list
+        bounds = [[p.latitude, p.longitude] for p in _bounds_src]
         pad = int(style.fit_bounds_padding_px)
         m.fit_bounds(
             bounds,

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -9,18 +9,9 @@ import folium
 from branca.element import Element
 
 from explorer.app.streamlit.defaults import (
-    FAMILY_MAP_BASE_STROKE_WEIGHT,
-    FAMILY_MAP_CIRCLE_MARKER_FILL_OPACITY,
-    FAMILY_MAP_CIRCLE_MARKER_RADIUS_PX,
-    FAMILY_MAP_DENSITY_FILL_HEX,
-    FAMILY_MAP_DENSITY_STROKE_HEX,
-    FAMILY_MAP_FIT_BOUNDS_MAX_ZOOM,
-    FAMILY_MAP_FIT_BOUNDS_PADDING_PX,
-    FAMILY_MAP_HIGHLIGHT_STROKE_HEX,
-    FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT,
-    FAMILY_MAP_LEGEND_HIGHLIGHT_SWATCH_FILL_INDEX,
-    FAMILY_MAP_POPUP_MAX_WIDTH_PX,
+    FamilyMapColourScheme,
     MAP_HEIGHT_PX_DEFAULT,
+    active_family_map_colour_scheme,
 )
 from explorer.core.family_map_compute import (
     DENSITY_BAND_LABELS,
@@ -33,16 +24,21 @@ from explorer.presentation.map_renderer import build_legend_html, create_map, ma
 # Match species-map banner placement (``map_renderer``).
 _FAMILY_MAP_BANNER_POSITION = "position:fixed;top:10px;right:10px;z-index:1000;"
 
-def family_map_marker_style(pin: FamilyLocationPin) -> tuple[str, str, int]:
+def family_map_marker_style(
+    pin: FamilyLocationPin,
+    *,
+    style: FamilyMapColourScheme | None = None,
+) -> tuple[str, str, int]:
     """Return ``(fill_hex, stroke_hex, stroke_weight)`` for a composition pin."""
-    fills = FAMILY_MAP_DENSITY_FILL_HEX
-    strokes = FAMILY_MAP_DENSITY_STROKE_HEX
+    s = style or active_family_map_colour_scheme()
+    fills = s.density_fill_hex
+    strokes = s.density_stroke_hex
     idx = max(0, min(pin.density_band_index, len(fills) - 1))
     fill = fills[idx]
     stroke = strokes[idx]
     if pin.highlight_match:
-        return fill, FAMILY_MAP_HIGHLIGHT_STROKE_HEX, FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT
-    return fill, stroke, FAMILY_MAP_BASE_STROKE_WEIGHT
+        return fill, s.highlight_stroke_hex, s.highlight_stroke_weight
+    return fill, stroke, s.base_stroke_weight
 
 
 def _default_au_center() -> tuple[float, float]:
@@ -77,8 +73,10 @@ def build_family_map_legend_overlay_html_for_pins(
     pins: tuple[FamilyLocationPin, ...] | list[FamilyLocationPin],
     *,
     highlight_label: str | None,
+    style: FamilyMapColourScheme | None = None,
 ) -> str:
     """Dynamic legend: only include density bands present on the map (refs #138)."""
+    s = style or active_family_map_colour_scheme()
     pin_list = list(pins)
     bands_present = sorted({int(p.density_band_index) for p in pin_list}) if pin_list else []
     items: list[tuple[str, str, str]] = []
@@ -87,8 +85,8 @@ def build_family_map_legend_overlay_html_for_pins(
             lab = DENSITY_BAND_LABELS[i]
             items.append(
                 (
-                    FAMILY_MAP_DENSITY_STROKE_HEX[i],
-                    FAMILY_MAP_DENSITY_FILL_HEX[i],
+                    s.density_stroke_hex[i],
+                    s.density_fill_hex[i],
                     f"{lab} species at location",
                 )
             )
@@ -97,14 +95,14 @@ def build_family_map_legend_overlay_html_for_pins(
         sw_i = max(
             0,
             min(
-                FAMILY_MAP_LEGEND_HIGHLIGHT_SWATCH_FILL_INDEX,
-                len(FAMILY_MAP_DENSITY_FILL_HEX) - 1,
+                s.legend_highlight_swatch_fill_index,
+                len(s.density_fill_hex) - 1,
             ),
         )
         items.append(
             (
-                FAMILY_MAP_HIGHLIGHT_STROKE_HEX,
-                FAMILY_MAP_DENSITY_FILL_HEX[sw_i],
+                s.highlight_stroke_hex,
+                s.density_fill_hex[sw_i],
                 f"Highlight: {hl}",
             )
         )
@@ -146,12 +144,13 @@ def build_family_composition_folium_map(
 
     loc_fn = location_page_url_fn or (lambda _lid: None)
     sp_fn = species_url_fn or (lambda _c: None)
+    style = active_family_map_colour_scheme()
 
     # Draw non-highlighted first, then highlighted so highlights sit on top.
     normal = [p for p in pin_list if not p.highlight_match]
     highlighted = [p for p in pin_list if p.highlight_match]
     for pin in normal + highlighted:
-        fill, stroke, sw = family_map_marker_style(pin)
+        fill, stroke, sw = family_map_marker_style(pin, style=style)
         url_map: dict[str, str] = {}
         for line in pin.common_name_lines:
             u = sp_fn(line)
@@ -165,13 +164,13 @@ def build_family_composition_folium_map(
         popup_body = f'<div class="pebird-map-popup">{inner}</div>'
         folium.CircleMarker(
             location=(pin.latitude, pin.longitude),
-            radius=FAMILY_MAP_CIRCLE_MARKER_RADIUS_PX,
+            radius=style.circle_marker_radius_px,
             color=stroke,
             weight=sw,
             fill=True,
             fill_color=fill,
-            fill_opacity=FAMILY_MAP_CIRCLE_MARKER_FILL_OPACITY,
-            popup=folium.Popup(popup_body, max_width=FAMILY_MAP_POPUP_MAX_WIDTH_PX),
+            fill_opacity=style.circle_marker_fill_opacity,
+            popup=folium.Popup(popup_body, max_width=style.popup_max_width_px),
         ).add_to(m)
 
     # Family-map-only initial viewport:
@@ -179,11 +178,11 @@ def build_family_composition_folium_map(
     # - never start closer than zoom 6 (allow wider zoom-out when needed)
     if pin_list:
         bounds = [[p.latitude, p.longitude] for p in pin_list]
-        pad = int(FAMILY_MAP_FIT_BOUNDS_PADDING_PX)
+        pad = int(style.fit_bounds_padding_px)
         m.fit_bounds(
             bounds,
             padding=(pad, pad),
-            max_zoom=int(FAMILY_MAP_FIT_BOUNDS_MAX_ZOOM),
+            max_zoom=int(style.fit_bounds_max_zoom),
         )
 
     return m

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -126,8 +126,9 @@ def build_family_composition_folium_map(
     (as shown in the export) to species page URL.
 
     When *fit_bounds_highlight_only* is true (highlight species selected), the initial ``fit_bounds``
-    uses only pins where ``highlight_match`` is true, with the same padding / ``max_zoom`` as the
-    full-family case. If none match, falls back to all pins.
+    uses only pins where ``highlight_match`` is true, with the same padding as the full-family case
+    and ``fit_bounds_max_zoom_highlight`` (closer zoom allowed than ``fit_bounds_max_zoom``).
+    If none match, falls back to all pins.
     """
     pin_list = list(pins)
     if pin_list:
@@ -185,18 +186,26 @@ def build_family_composition_folium_map(
 
     # Family-map-only initial viewport:
     # - fit relevant pins with edge padding (all family pins, or highlight-only when requested)
-    # - never start closer than configured max zoom (allow wider zoom-out when needed)
+    # - cap how far fitBounds may zoom in (family-wide vs species-highlight use different caps)
     if pin_list:
         if fit_bounds_highlight_only:
-            _bounds_src = [p for p in pin_list if p.highlight_match] or pin_list
+            hl_pins = [p for p in pin_list if p.highlight_match]
+            _bounds_src = hl_pins or pin_list
+            _species_framed = bool(hl_pins)
         else:
             _bounds_src = pin_list
+            _species_framed = False
         bounds = [[p.latitude, p.longitude] for p in _bounds_src]
         pad = int(style.fit_bounds_padding_px)
+        _mz = int(
+            style.fit_bounds_max_zoom_highlight
+            if _species_framed
+            else style.fit_bounds_max_zoom
+        )
         m.fit_bounds(
             bounds,
             padding=(pad, pad),
-            max_zoom=int(style.fit_bounds_max_zoom),
+            max_zoom=_mz,
         )
 
     return m

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -45,12 +45,21 @@ def _default_au_center() -> tuple[float, float]:
     return -25.0, 134.0
 
 
+def _family_map_banner_recorded_clause(metrics: FamilyMapBannerMetrics) -> str:
+    u = int(metrics.species_recorded_user)
+    t = int(metrics.total_species_taxonomy)
+    if t > 0:
+        pct = round(100.0 * u / t)
+        return f"{u} recorded ({pct}%)"
+    return f"{u} recorded"
+
+
 def build_family_map_banner_overlay_html(metrics: FamilyMapBannerMetrics) -> str:
     """Full fixed banner div (``pebird-map-banner``) for family composition (refs #138)."""
     title = html_module.escape(metrics.family_name, quote=False)
     stats = html_module.escape(
         f"{metrics.total_species_taxonomy} in taxonomy · "
-        f"{metrics.species_recorded_user} recorded · "
+        f"{_family_map_banner_recorded_clause(metrics)} · "
         f"{metrics.locations_with_records} locations",
         quote=False,
     )
@@ -73,9 +82,14 @@ def build_family_map_legend_overlay_html_for_pins(
     pins: tuple[FamilyLocationPin, ...] | list[FamilyLocationPin],
     *,
     highlight_label: str | None,
+    highlight_species_url: str | None = None,
     style: FamilyMapColourScheme | None = None,
 ) -> str:
-    """Dynamic legend: only include density bands present on the map (refs #138)."""
+    """Dynamic legend: only include density bands present on the map (refs #138).
+
+    When *highlight_species_url* is set with a non-empty *highlight_label*, the label is shown as a
+    link to the eBird species page.
+    """
     s = style or active_family_map_colour_scheme()
     pin_list = list(pins)
     bands_present = sorted({int(p.density_band_index) for p in pin_list}) if pin_list else []
@@ -99,11 +113,20 @@ def build_family_map_legend_overlay_html_for_pins(
                 len(s.density_fill_hex) - 1,
             ),
         )
+        url = (highlight_species_url or "").strip()
+        if url:
+            href = html_module.escape(url, quote=True)
+            esc_name = html_module.escape(hl, quote=False)
+            hl_legend = (
+                f'Highlight: <a href="{href}" target="_blank" rel="noopener noreferrer">{esc_name}</a>'
+            )
+        else:
+            hl_legend = f"Highlight: {html_module.escape(hl, quote=False)}"
         items.append(
             (
                 s.highlight_stroke_hex,
                 s.density_fill_hex[sw_i],
-                f"Highlight: {hl}",
+                hl_legend,
             )
         )
     return build_legend_html(items) if items else ""
@@ -119,6 +142,7 @@ def build_family_composition_folium_map(
     location_page_url_fn: Callable[[str], str | None] | None = None,
     species_url_fn: Callable[[str], str | None] | None = None,
     fit_bounds_highlight_only: bool = False,
+    colour_scheme_index: int | None = None,
 ) -> folium.Map:
     """Render CircleMarkers for family composition; optional eBird links in popups.
 
@@ -129,6 +153,9 @@ def build_family_composition_folium_map(
     uses only pins where ``highlight_match`` is true, with the same padding as the full-family case
     and ``fit_bounds_max_zoom_highlight`` (closer zoom allowed than ``fit_bounds_max_zoom``).
     If none match, falls back to all pins.
+
+    *colour_scheme_index* ``1`` or ``2`` selects the sidebar palette; ``None`` uses
+    :func:`~explorer.app.streamlit.defaults.active_family_map_colour_scheme` defaults.
     """
     pin_list = list(pins)
     if pin_list:
@@ -155,7 +182,7 @@ def build_family_composition_folium_map(
 
     loc_fn = location_page_url_fn or (lambda _lid: None)
     sp_fn = species_url_fn or (lambda _c: None)
-    style = active_family_map_colour_scheme()
+    style = active_family_map_colour_scheme(colour_scheme_index)
 
     # Draw non-highlighted first, then highlighted so highlights sit on top.
     normal = [p for p in pin_list if not p.highlight_match]

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -8,7 +8,20 @@ from typing import Callable
 import folium
 from branca.element import Element
 
-from explorer.app.streamlit.defaults import MAP_HEIGHT_PX_DEFAULT
+from explorer.app.streamlit.defaults import (
+    FAMILY_MAP_BASE_STROKE_WEIGHT,
+    FAMILY_MAP_CIRCLE_MARKER_FILL_OPACITY,
+    FAMILY_MAP_CIRCLE_MARKER_RADIUS_PX,
+    FAMILY_MAP_DENSITY_FILL_HEX,
+    FAMILY_MAP_DENSITY_STROKE_HEX,
+    FAMILY_MAP_FIT_BOUNDS_MAX_ZOOM,
+    FAMILY_MAP_FIT_BOUNDS_PADDING_PX,
+    FAMILY_MAP_HIGHLIGHT_STROKE_HEX,
+    FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT,
+    FAMILY_MAP_LEGEND_HIGHLIGHT_SWATCH_FILL_INDEX,
+    FAMILY_MAP_POPUP_MAX_WIDTH_PX,
+    MAP_HEIGHT_PX_DEFAULT,
+)
 from explorer.core.family_map_compute import (
     DENSITY_BAND_LABELS,
     FamilyLocationPin,
@@ -20,21 +33,15 @@ from explorer.presentation.map_renderer import build_legend_html, create_map, ma
 # Match species-map banner placement (``map_renderer``).
 _FAMILY_MAP_BANNER_POSITION = "position:fixed;top:10px;right:10px;z-index:1000;"
 
-# High-contrast sequential palette (user-tested for map visibility).
-FAMILY_MAP_DENSITY_FILL: tuple[str, ...] = ("#3A86FF", "#5E60CE", "#9D4EDD", "#C9184A")
-FAMILY_MAP_DENSITY_STROKE: tuple[str, ...] = ("#2F6FD1", "#4A4DA6", "#7E3EAF", "#A1143A")
-FAMILY_MAP_HIGHLIGHT_STROKE = "#FF7F11"
-FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT = 3
-FAMILY_MAP_BASE_STROKE_WEIGHT = 2
-
-
 def family_map_marker_style(pin: FamilyLocationPin) -> tuple[str, str, int]:
     """Return ``(fill_hex, stroke_hex, stroke_weight)`` for a composition pin."""
-    idx = max(0, min(pin.density_band_index, len(FAMILY_MAP_DENSITY_FILL) - 1))
-    fill = FAMILY_MAP_DENSITY_FILL[idx]
-    stroke = FAMILY_MAP_DENSITY_STROKE[idx]
+    fills = FAMILY_MAP_DENSITY_FILL_HEX
+    strokes = FAMILY_MAP_DENSITY_STROKE_HEX
+    idx = max(0, min(pin.density_band_index, len(fills) - 1))
+    fill = fills[idx]
+    stroke = strokes[idx]
     if pin.highlight_match:
-        return fill, FAMILY_MAP_HIGHLIGHT_STROKE, FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT
+        return fill, FAMILY_MAP_HIGHLIGHT_STROKE_HEX, FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT
     return fill, stroke, FAMILY_MAP_BASE_STROKE_WEIGHT
 
 
@@ -79,14 +86,25 @@ def build_family_map_legend_overlay_html_for_pins(
         if 0 <= i < len(DENSITY_BAND_LABELS):
             lab = DENSITY_BAND_LABELS[i]
             items.append(
-                (FAMILY_MAP_DENSITY_STROKE[i], FAMILY_MAP_DENSITY_FILL[i], f"{lab} species at location")
+                (
+                    FAMILY_MAP_DENSITY_STROKE_HEX[i],
+                    FAMILY_MAP_DENSITY_FILL_HEX[i],
+                    f"{lab} species at location",
+                )
             )
     hl = (highlight_label or "").strip()
     if hl:
+        sw_i = max(
+            0,
+            min(
+                FAMILY_MAP_LEGEND_HIGHLIGHT_SWATCH_FILL_INDEX,
+                len(FAMILY_MAP_DENSITY_FILL_HEX) - 1,
+            ),
+        )
         items.append(
             (
-                FAMILY_MAP_HIGHLIGHT_STROKE,
-                FAMILY_MAP_DENSITY_FILL[0],
+                FAMILY_MAP_HIGHLIGHT_STROKE_HEX,
+                FAMILY_MAP_DENSITY_FILL_HEX[sw_i],
                 f"Highlight: {hl}",
             )
         )
@@ -145,17 +163,15 @@ def build_family_composition_folium_map(
             species_url_by_common=url_map or None,
         )
         popup_body = f'<div class="pebird-map-popup">{inner}</div>'
-        # Keep marker size consistent across density bands; colour/edge encodes information.
-        radius_px = 7
         folium.CircleMarker(
             location=(pin.latitude, pin.longitude),
-            radius=radius_px,
+            radius=FAMILY_MAP_CIRCLE_MARKER_RADIUS_PX,
             color=stroke,
             weight=sw,
             fill=True,
             fill_color=fill,
-            fill_opacity=0.88,
-            popup=folium.Popup(popup_body, max_width=320),
+            fill_opacity=FAMILY_MAP_CIRCLE_MARKER_FILL_OPACITY,
+            popup=folium.Popup(popup_body, max_width=FAMILY_MAP_POPUP_MAX_WIDTH_PX),
         ).add_to(m)
 
     # Family-map-only initial viewport:
@@ -163,7 +179,12 @@ def build_family_composition_folium_map(
     # - never start closer than zoom 6 (allow wider zoom-out when needed)
     if pin_list:
         bounds = [[p.latitude, p.longitude] for p in pin_list]
-        m.fit_bounds(bounds, padding=(48, 48), max_zoom=6)
+        pad = int(FAMILY_MAP_FIT_BOUNDS_PADDING_PX)
+        m.fit_bounds(
+            bounds,
+            padding=(pad, pad),
+            max_zoom=int(FAMILY_MAP_FIT_BOUNDS_MAX_ZOOM),
+        )
 
     return m
 

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -1,0 +1,182 @@
+"""Folium rendering for Family Map (refs #138) — distinct from species overlay styling."""
+
+from __future__ import annotations
+
+import html as html_module
+from typing import Callable
+
+import folium
+from branca.element import Element
+
+from explorer.app.streamlit.defaults import MAP_HEIGHT_PX_DEFAULT
+from explorer.core.family_map_compute import (
+    DENSITY_BAND_LABELS,
+    FamilyLocationPin,
+    FamilyMapBannerMetrics,
+    format_family_location_popup_html,
+)
+from explorer.presentation.map_renderer import build_legend_html, create_map, map_overlay_theme_stylesheet
+
+# Match species-map banner placement (``map_renderer``).
+_FAMILY_MAP_BANNER_POSITION = "position:fixed;top:10px;right:10px;z-index:1000;"
+
+# High-contrast sequential palette (user-tested for map visibility).
+FAMILY_MAP_DENSITY_FILL: tuple[str, ...] = ("#3A86FF", "#5E60CE", "#9D4EDD", "#C9184A")
+FAMILY_MAP_DENSITY_STROKE: tuple[str, ...] = ("#2F6FD1", "#4A4DA6", "#7E3EAF", "#A1143A")
+FAMILY_MAP_HIGHLIGHT_STROKE = "#FF7F11"
+FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT = 3
+FAMILY_MAP_BASE_STROKE_WEIGHT = 2
+
+
+def family_map_marker_style(pin: FamilyLocationPin) -> tuple[str, str, int]:
+    """Return ``(fill_hex, stroke_hex, stroke_weight)`` for a composition pin."""
+    idx = max(0, min(pin.density_band_index, len(FAMILY_MAP_DENSITY_FILL) - 1))
+    fill = FAMILY_MAP_DENSITY_FILL[idx]
+    stroke = FAMILY_MAP_DENSITY_STROKE[idx]
+    if pin.highlight_match:
+        return fill, FAMILY_MAP_HIGHLIGHT_STROKE, FAMILY_MAP_HIGHLIGHT_STROKE_WEIGHT
+    return fill, stroke, FAMILY_MAP_BASE_STROKE_WEIGHT
+
+
+def _default_au_center() -> tuple[float, float]:
+    return -25.0, 134.0
+
+
+def build_family_map_banner_overlay_html(metrics: FamilyMapBannerMetrics) -> str:
+    """Full fixed banner div (``pebird-map-banner``) for family composition (refs #138)."""
+    title = html_module.escape(metrics.family_name, quote=False)
+    stats = html_module.escape(
+        f"{metrics.total_species_taxonomy} in taxonomy · "
+        f"{metrics.species_recorded_user} recorded · "
+        f"{metrics.locations_with_records} locations",
+        quote=False,
+    )
+    return (
+        f'<div class="pebird-map-banner" style="{_FAMILY_MAP_BANNER_POSITION}">'
+        f'<span class="pebird-map-banner__title">{title}</span>'
+        f'<div class="pebird-map-banner__stats">{stats}</div>'
+        f"</div>"
+    )
+
+
+def build_family_map_legend_overlay_html(*, include_highlight: bool) -> str:
+    """Backward-compatible wrapper (prefer the pins-based helper)."""
+    if include_highlight:
+        return build_family_map_legend_overlay_html_for_pins((), highlight_label="selected species")
+    return build_family_map_legend_overlay_html_for_pins((), highlight_label=None)
+
+
+def build_family_map_legend_overlay_html_for_pins(
+    pins: tuple[FamilyLocationPin, ...] | list[FamilyLocationPin],
+    *,
+    highlight_label: str | None,
+) -> str:
+    """Dynamic legend: only include density bands present on the map (refs #138)."""
+    pin_list = list(pins)
+    bands_present = sorted({int(p.density_band_index) for p in pin_list}) if pin_list else []
+    items: list[tuple[str, str, str]] = []
+    for i in bands_present:
+        if 0 <= i < len(DENSITY_BAND_LABELS):
+            lab = DENSITY_BAND_LABELS[i]
+            items.append(
+                (FAMILY_MAP_DENSITY_STROKE[i], FAMILY_MAP_DENSITY_FILL[i], f"{lab} species at location")
+            )
+    hl = (highlight_label or "").strip()
+    if hl:
+        items.append(
+            (
+                FAMILY_MAP_HIGHLIGHT_STROKE,
+                FAMILY_MAP_DENSITY_FILL[0],
+                f"Highlight: {hl}",
+            )
+        )
+    return build_legend_html(items) if items else ""
+
+
+def build_family_composition_folium_map(
+    pins: tuple[FamilyLocationPin, ...] | list[FamilyLocationPin],
+    *,
+    banner_html: str = "",
+    legend_html: str = "",
+    map_style: str = "default",
+    height_px: int = MAP_HEIGHT_PX_DEFAULT,
+    location_page_url_fn: Callable[[str], str | None] | None = None,
+    species_url_fn: Callable[[str], str | None] | None = None,
+) -> folium.Map:
+    """Render CircleMarkers for family composition; optional eBird links in popups.
+
+    *location_page_url_fn* maps ``Location ID`` → hotspot URL; *species_url_fn* maps common name
+    (as shown in the export) to species page URL.
+    """
+    pin_list = list(pins)
+    if pin_list:
+        center = (
+            sum(p.latitude for p in pin_list) / len(pin_list),
+            sum(p.longitude for p in pin_list) / len(pin_list),
+        )
+    else:
+        center = _default_au_center()
+
+    m = create_map(center, map_style, height_px=height_px)
+    m.get_root().html.add_child(Element(map_overlay_theme_stylesheet()))
+
+    if banner_html and str(banner_html).strip():
+        m.get_root().html.add_child(Element(str(banner_html).strip()))
+
+    if legend_html and str(legend_html).strip():
+        m.get_root().html.add_child(Element(str(legend_html).strip()))
+
+    loc_fn = location_page_url_fn or (lambda _lid: None)
+    sp_fn = species_url_fn or (lambda _c: None)
+
+    # Draw non-highlighted first, then highlighted so highlights sit on top.
+    normal = [p for p in pin_list if not p.highlight_match]
+    highlighted = [p for p in pin_list if p.highlight_match]
+    for pin in normal + highlighted:
+        fill, stroke, sw = family_map_marker_style(pin)
+        url_map: dict[str, str] = {}
+        for line in pin.common_name_lines:
+            u = sp_fn(line)
+            if u:
+                url_map[line] = u
+        inner = format_family_location_popup_html(
+            pin,
+            location_page_url=loc_fn(pin.location_id),
+            species_url_by_common=url_map or None,
+        )
+        popup_body = f'<div class="pebird-map-popup">{inner}</div>'
+        # Keep marker size consistent across density bands; colour/edge encodes information.
+        radius_px = 7
+        folium.CircleMarker(
+            location=(pin.latitude, pin.longitude),
+            radius=radius_px,
+            color=stroke,
+            weight=sw,
+            fill=True,
+            fill_color=fill,
+            fill_opacity=0.88,
+            popup=folium.Popup(popup_body, max_width=320),
+        ).add_to(m)
+
+    # Family-map-only initial viewport:
+    # - fit all pins with some edge padding
+    # - never start closer than zoom 6 (allow wider zoom-out when needed)
+    if pin_list:
+        bounds = [[p.latitude, p.longitude] for p in pin_list]
+        m.fit_bounds(bounds, padding=(48, 48), max_zoom=6)
+
+    return m
+
+
+def build_family_map_banner_element_html(
+    metrics_line: str,
+    *,
+    extra_safe_html: str = "",
+) -> str:
+    """Wrap a single metrics line for insertion above the map (callers escape *metrics_line*)."""
+    esc = html_module.escape(metrics_line, quote=False)
+    extra = extra_safe_html if extra_safe_html else ""
+    return (
+        f'<div style="padding:0.35rem 0.75rem;font-size:0.95rem;line-height:1.35;">'
+        f"{esc}{extra}</div>"
+    )

--- a/tests/explorer/test_family_map_compute.py
+++ b/tests/explorer/test_family_map_compute.py
@@ -1,0 +1,226 @@
+"""Unit tests for family map aggregation (refs #138)."""
+
+import pandas as pd
+import pytest
+
+from explorer.core.family_map_compute import (
+    DENSITY_BAND_LABELS,
+    FamilyMapBannerMetrics,
+    FamilyLocationPin,
+    base_species_to_common_from_taxonomy,
+    build_family_location_pins,
+    compute_family_map_banner_metrics,
+    families_recorded_alphabetically,
+    family_density_band_index,
+    family_density_band_label,
+    filter_work_to_family,
+    format_family_location_popup_html,
+    highlight_species_choices_alphabetical,
+    merge_taxonomy_detail_for_family_map,
+    prepare_family_map_work_frame,
+    taxonomy_species_count_for_family,
+)
+
+
+def _tiny_export_rows():
+    """Two whistler species + subspecies at two locations; one duck elsewhere."""
+    return pd.DataFrame(
+        {
+            "Submission ID": ["A", "A", "B", "C", "C"],
+            "Location ID": ["L1", "L1", "L1", "L2", "L2"],
+            "Location": ["Alpha", "Alpha", "Alpha", "Beta", "Beta"],
+            "Latitude": [-35.0, -35.0, -35.0, -34.0, -34.0],
+            "Longitude": [149.0, 149.0, 149.0, 150.0, 150.0],
+            "Scientific Name": [
+                "Pachycephala olivacea",
+                "Pachycephala pectoralis glaucura",
+                "Anas gracilis",
+                "Pachycephala rufiventris",
+                "Pachycephala rufiventris",
+            ],
+            "Common Name": [
+                "Olive Whistler",
+                "Golden Whistler (Eastern)",
+                "Grey Teal",
+                "Rufous Whistler",
+                "Rufous Whistler",
+            ],
+            "Count": [1, 1, 2, 1, 1],
+        }
+    )
+
+
+def _base_to_family_stub():
+    return {
+        "pachycephala olivacea": "Whistlers and Allies",
+        "pachycephala pectoralis": "Whistlers and Allies",
+        "anas gracilis": "Ducks, Geese, and Swans",
+        "pachycephala rufiventris": "Whistlers and Allies",
+    }
+
+
+def test_density_bands_and_labels():
+    assert family_density_band_index(0) == 0
+    assert family_density_band_index(1) == 0
+    assert family_density_band_index(2) == 1
+    assert family_density_band_index(3) == 1
+    assert family_density_band_index(4) == 2
+    assert family_density_band_index(5) == 2
+    assert family_density_band_index(6) == 3
+    assert family_density_band_index(99) == 3
+    assert family_density_band_label(1) == DENSITY_BAND_LABELS[0]
+    assert family_density_band_label(4) == DENSITY_BAND_LABELS[2]
+
+
+def test_prepare_work_frame_and_families_alphabetical():
+    df = _tiny_export_rows()
+    m = _base_to_family_stub()
+    work = prepare_family_map_work_frame(df, m)
+    assert not work.empty
+    assert set(work["_family"].unique()) == {"Whistlers and Allies", "Ducks, Geese, and Swans"}
+    fams = families_recorded_alphabetically(work)
+    assert fams == ("Ducks, Geese, and Swans", "Whistlers and Allies")
+
+
+def test_filter_work_to_family():
+    df = _tiny_export_rows()
+    work = prepare_family_map_work_frame(df, _base_to_family_stub())
+    w = filter_work_to_family(work, "Whistlers and Allies")
+    assert w["Location ID"].nunique() == 2
+    assert w["_base"].nunique() == 3
+
+
+def test_taxonomy_species_count_for_family():
+    tax = pd.DataFrame(
+        {
+            "base_species": ["a a", "b b", "c c", "d d"],
+            "group_name": ["G1", "G1", "G1", "G2"],
+        }
+    )
+    assert taxonomy_species_count_for_family(tax, "G1") == 3
+    assert taxonomy_species_count_for_family(tax, "G2") == 1
+    assert taxonomy_species_count_for_family(tax, "None") == 0
+
+
+def test_banner_metrics():
+    df = _tiny_export_rows()
+    work = prepare_family_map_work_frame(df, _base_to_family_stub())
+    tax = pd.DataFrame(
+        {
+            "base_species": ["pachycephala olivacea", "pachycephala pectoralis", "pachycephala rufiventris", "x x"],
+            "group_name": ["Whistlers and Allies"] * 4,
+        }
+    )
+    m = compute_family_map_banner_metrics(work, "Whistlers and Allies", tax)
+    assert isinstance(m, FamilyMapBannerMetrics)
+    assert m.total_species_taxonomy == 4
+    assert m.species_recorded_user == 3
+    assert m.locations_with_records == 2
+
+
+def test_highlight_choices_sorted_by_common_name():
+    df = _tiny_export_rows()
+    work = prepare_family_map_work_frame(df, _base_to_family_stub())
+    wf = filter_work_to_family(work, "Whistlers and Allies")
+    common = {
+        "pachycephala olivacea": "Olive Whistler",
+        "pachycephala pectoralis": "Golden Whistler",
+        "pachycephala rufiventris": "Rufous Whistler",
+    }
+    pairs = highlight_species_choices_alphabetical(wf, common)
+    labels = [p[0] for p in pairs]
+    assert labels == ["Golden Whistler", "Olive Whistler", "Rufous Whistler"]
+
+
+def test_build_family_location_pins_richness_and_popup_lines():
+    df = _tiny_export_rows()
+    work = prepare_family_map_work_frame(df, _base_to_family_stub())
+    wf = filter_work_to_family(work, "Whistlers and Allies")
+    pins = build_family_location_pins(wf, highlight_base_species=None)
+    assert len(pins) == 2
+    by_id = {p.location_id: p for p in pins}
+    p1 = by_id["L1"]
+    # Olive + Golden (Eastern) subspecies row → two base species
+    assert p1.distinct_base_species_count == 2
+    assert p1.density_band_index == 1
+    assert "Golden Whistler (Eastern)" in p1.common_name_lines
+    assert "Olive Whistler" in p1.common_name_lines
+    p2 = by_id["L2"]
+    assert p2.distinct_base_species_count == 1
+    assert p2.density_band_index == 0
+
+
+def test_build_family_location_pins_highlight():
+    df = _tiny_export_rows()
+    work = prepare_family_map_work_frame(df, _base_to_family_stub())
+    wf = filter_work_to_family(work, "Whistlers and Allies")
+    pins = build_family_location_pins(
+        wf,
+        highlight_base_species="pachycephala rufiventris",
+    )
+    by_id = {p.location_id: p for p in pins}
+    assert by_id["L1"].highlight_match is False
+    assert by_id["L2"].highlight_match is True
+
+
+def test_build_family_location_pins_missing_columns():
+    wf = pd.DataFrame({"Location ID": ["x"]})
+    with pytest.raises(ValueError, match="missing columns"):
+        build_family_location_pins(wf)
+
+
+def test_merge_taxonomy_detail_for_family_map_smoke():
+    tax = pd.DataFrame(
+        {
+            "scientific_name": ["Aa bb", "Cc dd"],
+            "common_name": ["A b", "C d"],
+            "species_code": ["aabb", "ccdd"],
+            "taxon_order": [100.0, 200.0],
+            "base_species": ["aa bb", "cc dd"],
+        }
+    )
+    groups = [
+        {
+            "group_name": "G",
+            "group_order": 1,
+            "bounds": [(50.0, 250.0)],
+        }
+    ]
+    merged = merge_taxonomy_detail_for_family_map(tax, groups)
+    assert "group_name" in merged.columns
+    assert merged["group_name"].iloc[0] == "G"
+
+
+def test_base_species_to_common_from_taxonomy():
+    tax = pd.DataFrame(
+        {
+            "base_species": ["aa bb", "cc dd"],
+            "common_name": ["A", "C"],
+        }
+    )
+    d = base_species_to_common_from_taxonomy(tax)
+    assert d["aa bb"] == "A"
+    assert d["cc dd"] == "C"
+
+
+def test_format_family_location_popup_html_links():
+    pin = FamilyLocationPin(
+        location_id="L1",
+        location_name="Test & Park",
+        latitude=-35.0,
+        longitude=149.0,
+        distinct_base_species_count=2,
+        density_band_index=1,
+        common_name_lines=("Bird A", "Bird B"),
+        highlight_match=False,
+    )
+    html = format_family_location_popup_html(
+        pin,
+        location_page_url="https://ebird.org/hotspot/L1",
+        species_url_by_common={"Bird A": "https://ebird.org/species/foo"},
+    )
+    assert "Test &amp; Park" in html
+    assert "hotspot" in html
+    assert "Bird A" in html
+    assert "species/foo" in html
+    assert "Bird B" in html

--- a/tests/explorer/test_family_map_folium.py
+++ b/tests/explorer/test_family_map_folium.py
@@ -79,6 +79,18 @@ def test_build_family_map_empty_pins_still_returns_map():
     assert "folium" in html.lower() or "map" in html.lower()
 
 
+def test_fit_bounds_highlight_only_uses_highlight_pins():
+    pins = _sample_pins()
+    m_all = build_family_composition_folium_map(pins, fit_bounds_highlight_only=False)
+    m_hl = build_family_composition_folium_map(pins, fit_bounds_highlight_only=True)
+    h_all = m_all._repr_html_()
+    h_hl = m_hl._repr_html_()
+    assert "fitBounds" in h_all and "fitBounds" in h_hl
+    assert "[[-35.0, 149.0], [-34.0, 150.0]]" in h_all
+    assert "[[-34.0, 150.0]]" in h_hl
+    assert "maxZoom" in h_hl and "6" in h_hl
+
+
 def test_build_family_map_banner_element_html_escapes():
     h = build_family_map_banner_element_html('Birds & more <script>')
     assert "&amp;" in h or "Birds" in h

--- a/tests/explorer/test_family_map_folium.py
+++ b/tests/explorer/test_family_map_folium.py
@@ -1,5 +1,6 @@
 """Tests for Family Map Folium builder (refs #138)."""
 
+from explorer.app.streamlit.defaults import FAMILY_MAP_COLOUR_SCHEME_1
 from explorer.core.family_map_compute import FamilyLocationPin, FamilyMapBannerMetrics
 from explorer.core.family_map_folium import (
     build_family_composition_folium_map,
@@ -37,10 +38,10 @@ def _sample_pins():
 
 def test_family_map_marker_style_highlight_uses_amber_stroke():
     p = _sample_pins()[1]
-    fill, stroke, w = family_map_marker_style(p)
+    fill, stroke, w = family_map_marker_style(p, style=FAMILY_MAP_COLOUR_SCHEME_1)
     assert p.highlight_match
-    assert stroke == "#FF7F11"
-    assert w == 3
+    assert stroke == FAMILY_MAP_COLOUR_SCHEME_1.highlight_stroke_hex
+    assert w == FAMILY_MAP_COLOUR_SCHEME_1.highlight_stroke_weight
 
 
 def test_build_family_composition_folium_map_html_contains_markers():

--- a/tests/explorer/test_family_map_folium.py
+++ b/tests/explorer/test_family_map_folium.py
@@ -54,7 +54,11 @@ def test_build_family_composition_folium_map_html_contains_markers():
             locations_with_records=2,
         )
     )
-    legend = build_family_map_legend_overlay_html_for_pins(pins, highlight_label="Rufous Whistler")
+    legend = build_family_map_legend_overlay_html_for_pins(
+        pins,
+        highlight_label="Rufous Whistler",
+        highlight_species_url="https://ebird.org/species/goldenwhi1",
+    )
     m = build_family_composition_folium_map(
         pins,
         banner_html=banner,
@@ -68,7 +72,9 @@ def test_build_family_composition_folium_map_html_contains_markers():
     assert "CircleMarker" in html or "circle" in html.lower()
     assert "Whistlers" in html
     assert "12 in taxonomy" in html
-    assert "Highlight: Rufous Whistler" in html
+    assert "5 recorded (42%)" in html
+    # Legend is embedded in the Folium iframe; link href is HTML-entity encoded in ``_repr_html_``.
+    assert "goldenwhi1" in html and "Rufous Whistler" in html
     assert "fitBounds" in html
     assert "maxZoom" in html and "6" in html
 

--- a/tests/explorer/test_family_map_folium.py
+++ b/tests/explorer/test_family_map_folium.py
@@ -1,0 +1,84 @@
+"""Tests for Family Map Folium builder (refs #138)."""
+
+from explorer.core.family_map_compute import FamilyLocationPin, FamilyMapBannerMetrics
+from explorer.core.family_map_folium import (
+    build_family_composition_folium_map,
+    build_family_map_banner_element_html,
+    build_family_map_banner_overlay_html,
+    build_family_map_legend_overlay_html_for_pins,
+    family_map_marker_style,
+)
+
+
+def _sample_pins():
+    return (
+        FamilyLocationPin(
+            location_id="L1",
+            location_name="Site One",
+            latitude=-35.0,
+            longitude=149.0,
+            distinct_base_species_count=2,
+            density_band_index=1,
+            common_name_lines=("A", "B"),
+            highlight_match=False,
+        ),
+        FamilyLocationPin(
+            location_id="L2",
+            location_name="Site Two",
+            latitude=-34.0,
+            longitude=150.0,
+            distinct_base_species_count=1,
+            density_band_index=0,
+            common_name_lines=("C",),
+            highlight_match=True,
+        ),
+    )
+
+
+def test_family_map_marker_style_highlight_uses_amber_stroke():
+    p = _sample_pins()[1]
+    fill, stroke, w = family_map_marker_style(p)
+    assert p.highlight_match
+    assert stroke == "#FF7F11"
+    assert w == 3
+
+
+def test_build_family_composition_folium_map_html_contains_markers():
+    pins = _sample_pins()
+    banner = build_family_map_banner_overlay_html(
+        FamilyMapBannerMetrics(
+            family_name="Whistlers",
+            total_species_taxonomy=12,
+            species_recorded_user=5,
+            locations_with_records=2,
+        )
+    )
+    legend = build_family_map_legend_overlay_html_for_pins(pins, highlight_label="Rufous Whistler")
+    m = build_family_composition_folium_map(
+        pins,
+        banner_html=banner,
+        legend_html=legend,
+        location_page_url_fn=lambda lid: f"https://ebird.org/hotspot/{lid}" if lid else None,
+        species_url_fn=lambda c: f"https://ebird.org/species/x/{c}" if c == "A" else None,
+    )
+    html = m._repr_html_()
+    assert "Site One" in html
+    assert "Site Two" in html
+    assert "CircleMarker" in html or "circle" in html.lower()
+    assert "Whistlers" in html
+    assert "12 in taxonomy" in html
+    assert "Highlight: Rufous Whistler" in html
+    assert "fitBounds" in html
+    assert "maxZoom" in html and "6" in html
+
+
+def test_build_family_map_empty_pins_still_returns_map():
+    m = build_family_composition_folium_map(())
+    html = m._repr_html_()
+    assert "folium" in html.lower() or "map" in html.lower()
+
+
+def test_build_family_map_banner_element_html_escapes():
+    h = build_family_map_banner_element_html('Birds & more <script>')
+    assert "&amp;" in h or "Birds" in h
+    assert "<script>" not in h or "&lt;" in h

--- a/tests/explorer/test_family_map_folium.py
+++ b/tests/explorer/test_family_map_folium.py
@@ -88,7 +88,25 @@ def test_fit_bounds_highlight_only_uses_highlight_pins():
     assert "fitBounds" in h_all and "fitBounds" in h_hl
     assert "[[-35.0, 149.0], [-34.0, 150.0]]" in h_all
     assert "[[-34.0, 150.0]]" in h_hl
-    assert "maxZoom" in h_hl and "6" in h_hl
+    assert '&quot;maxZoom&quot;: 8' in h_hl
+    assert '&quot;maxZoom&quot;: 6' in h_all
+
+
+def test_fit_bounds_highlight_no_matches_uses_family_max_zoom():
+    """Species-highlight mode but no matching pins: frame all pins, cap zoom like family view."""
+    p = FamilyLocationPin(
+        location_id="L1",
+        location_name="Only",
+        latitude=-35.0,
+        longitude=149.0,
+        distinct_base_species_count=1,
+        density_band_index=0,
+        common_name_lines=("X",),
+        highlight_match=False,
+    )
+    m = build_family_composition_folium_map((p,), fit_bounds_highlight_only=True)
+    h = m._repr_html_()
+    assert '&quot;maxZoom&quot;: 6' in h
 
 
 def test_build_family_map_banner_element_html_escapes():


### PR DESCRIPTION
Added family map to the mapping options in the explorer app.

refs #138 
refs #73 
refs #105 
Implemented #126

NOTE:  The family map has different zoom/centring logic than the other maps.  May be worth remembering when revisiting #105 