### PR TITLE
Enhancement - add family group metadata to species search weightings [#73]

### DIFF
--- a/explorer/app/streamlit/app.py
+++ b/explorer/app/streamlit/app.py
@@ -89,6 +89,7 @@ from explorer.app.streamlit.app_caches import (  # noqa: E402
 )
 from explorer.app.streamlit.app_constants import (  # noqa: E402
     DEFAULT_TAXONOMY_LOCALE,
+    EXPLORER_MAIN_SCRIPT_RUN_ID_KEY,
     FILTERED_BY_LOC_CACHE_KEY,
     POPUP_HTML_CACHE_KEY,
     REPO_ROOT,
@@ -181,6 +182,10 @@ def main() -> None:
     if loaded is None:
         return
     df_full, provenance, source_label, data_abs_path, data_basename = loaded
+
+    st.session_state[EXPLORER_MAIN_SCRIPT_RUN_ID_KEY] = int(
+        st.session_state.get(EXPLORER_MAIN_SCRIPT_RUN_ID_KEY, 0)
+    ) + 1
 
     st.session_state[SETTINGS_CONFIG_SOURCE_KEY] = source_label or ""
     settings_yaml_path = settings_yaml_path_for_source(REPO_ROOT, source_label or "")

--- a/explorer/app/streamlit/app.py
+++ b/explorer/app/streamlit/app.py
@@ -217,8 +217,7 @@ def main() -> None:
 
     title_with_logo()
 
-    # Main tabs: plain ``st.tabs`` (no ``key`` / ``on_change``). Keyed lazy tabs existed only for Family Lists
-    # “main tab” session bookkeeping; the Families flow now relies on dataframe selection only (refs #73).
+    # Main tabs: plain ``st.tabs`` (no ``key`` / ``on_change``).
     (
         tab_map,
         tab_checklist,

--- a/explorer/app/streamlit/app_caches.py
+++ b/explorer/app/streamlit/app_caches.py
@@ -130,8 +130,8 @@ def static_map_cache_key(
 ) -> tuple:
     """Stable key for Folium map reuse (session holds one cached map; same key → skip rebuild).
 
-    *species_* / *hide_non_matching* matter for **Selected species** view; pass empty / False for
-    All / Lifers or Species with no selection (aligned with ``map_controller`` coercion).
+    *species_* / *hide_non_matching* matter for **Species locations** view (including the empty-map
+    case when no species is selected and only matching pins are shown).
     """
     n = len(work_df)
     sid0 = ""

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -202,6 +202,7 @@ SESSION_SPECIES_PICK_KEY = "_streamlit_species_pick_common"
 # Selected species group (eBird label) → second dropdown lists species in data (refs #73).
 SESSION_SPECIES_GROUP_PENDING_KEY = "_streamlit_species_group_pending"
 SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY = "streamlit_species_group_species_select"
+SESSION_SPECIES_GROUP_BACK_TO_ALL_KEY = "streamlit_species_group_back_to_all"
 # Last (pending group label, species common) we ran a full app rerun for; avoids callback st.rerun (#73).
 SESSION_SPECIES_GROUP_SEL_COMMIT_KEY = "_species_in_group_dropdown_commit"
 FOLIUM_STATIC_MAP_CACHE_KEY = "_folium_static_all_lifer_cache"

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -193,6 +193,8 @@ PERSIST_SPECIES_COMMON_KEY = "_preserve_streamlit_species_common"
 PERSIST_SPECIES_SCI_KEY = "_preserve_streamlit_species_sci"
 SESSION_PREV_MAP_VIEW_KEY = "_streamlit_prev_map_view_mode"
 SESSION_SPECIES_SEARCH_KEY = "streamlit_species_searchbox"
+# Bumped on search reset so ``st_searchbox`` remounts with an empty field (refs #73).
+SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY = "_streamlit_species_search_remount_nonce"
 SESSION_SPECIES_WS_KEY = "_ws_for_species_search_fragment"
 SESSION_SPECIES_IX_KEY = "_streamlit_species_whoosh_ix"
 SESSION_SPECIES_IX_SIG_KEY = "_streamlit_species_whoosh_ix_sig"

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -199,6 +199,12 @@ SESSION_SPECIES_WS_KEY = "_ws_for_species_search_fragment"
 SESSION_SPECIES_IX_KEY = "_streamlit_species_whoosh_ix"
 SESSION_SPECIES_IX_SIG_KEY = "_streamlit_species_whoosh_ix_sig"
 SESSION_SPECIES_PICK_KEY = "_streamlit_species_pick_common"
+# Incremented once per ``main()`` run (fragment-only reruns do not execute ``main``).
+EXPLORER_MAIN_SCRIPT_RUN_ID_KEY = "_explorer_main_script_run_id"
+# Species search: user has changed the text away from the persisted pick (typing, clear-to-search).
+SESSION_SPECIES_SEARCH_USER_EDITING_KEY = "_streamlit_species_search_user_editing"
+# Last main-run id the species search fragment saw; used to refill the bar after tab navigation.
+SESSION_SPECIES_SEARCH_LAST_MAIN_RUN_KEY = "_streamlit_species_search_last_main_run_id"
 FOLIUM_STATIC_MAP_CACHE_KEY = "_folium_static_all_lifer_cache"
 # Bumped when toggling Map view All locations <-> Species locations so streamlit-folium remounts cleanly.
 FOLIUM_MAP_MOUNT_NONCE_KEY = "_folium_map_mount_nonce"

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -33,7 +33,7 @@ DEFAULT_EBIRD_FILENAME = os.environ.get("STREAMLIT_EBIRD_DATA_FILE", DEFAULT_EBI
 
 MAP_VIEW_LABEL_TO_MODE = {
     "All locations": "all",
-    "Selected species": "species",
+    "Species locations": "species",
     "Lifer locations": "lifers",
     "Family locations": "families",
 }
@@ -197,8 +197,13 @@ SESSION_SPECIES_WS_KEY = "_ws_for_species_search_fragment"
 SESSION_SPECIES_IX_KEY = "_streamlit_species_whoosh_ix"
 SESSION_SPECIES_IX_SIG_KEY = "_streamlit_species_whoosh_ix_sig"
 SESSION_SPECIES_PICK_KEY = "_streamlit_species_pick_common"
+# Selected species group (eBird label) → second dropdown lists species in data (refs #73).
+SESSION_SPECIES_GROUP_PENDING_KEY = "_streamlit_species_group_pending"
+SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY = "streamlit_species_group_species_select"
+# Last (pending group label, species common) we ran a full app rerun for; avoids callback st.rerun (#73).
+SESSION_SPECIES_GROUP_SEL_COMMIT_KEY = "_species_in_group_dropdown_commit"
 FOLIUM_STATIC_MAP_CACHE_KEY = "_folium_static_all_lifer_cache"
-# Bumped when toggling Map view All locations <-> Selected species so streamlit-folium remounts cleanly.
+# Bumped when toggling Map view All locations <-> Species locations so streamlit-folium remounts cleanly.
 FOLIUM_MAP_MOUNT_NONCE_KEY = "_folium_map_mount_nonce"
 SETTINGS_CONFIG_PATH_KEY = "_streamlit_settings_yaml_path"
 SETTINGS_CONFIG_SOURCE_KEY = "_streamlit_settings_source_label"

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -199,12 +199,6 @@ SESSION_SPECIES_WS_KEY = "_ws_for_species_search_fragment"
 SESSION_SPECIES_IX_KEY = "_streamlit_species_whoosh_ix"
 SESSION_SPECIES_IX_SIG_KEY = "_streamlit_species_whoosh_ix_sig"
 SESSION_SPECIES_PICK_KEY = "_streamlit_species_pick_common"
-# Selected species group (eBird label) → second dropdown lists species in data (refs #73).
-SESSION_SPECIES_GROUP_PENDING_KEY = "_streamlit_species_group_pending"
-SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY = "streamlit_species_group_species_select"
-SESSION_SPECIES_GROUP_BACK_TO_ALL_KEY = "streamlit_species_group_back_to_all"
-# Last (pending group label, species common) we ran a full app rerun for; avoids callback st.rerun (#73).
-SESSION_SPECIES_GROUP_SEL_COMMIT_KEY = "_species_in_group_dropdown_commit"
 FOLIUM_STATIC_MAP_CACHE_KEY = "_folium_static_all_lifer_cache"
 # Bumped when toggling Map view All locations <-> Species locations so streamlit-folium remounts cleanly.
 FOLIUM_MAP_MOUNT_NONCE_KEY = "_folium_map_mount_nonce"

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -335,37 +335,3 @@ div[data-testid="stSpinner"] div[class*="Spinner"] {{
 }}
 </style>
 """
-
-# Sidebar **control** labels only (selectbox, slider, toggles) — not the loading spinner. Injected separately
-# and early so typography matches on first paint; bump SPINNER_THEME_CSS_CACHE_KEY_SUFFIX when this changes.
-SIDEBAR_CONTROL_LABEL_CSS = f"""
-<style>
-[data-testid="stSidebar"] [data-testid="stWidgetLabel"],
-[data-testid="stSidebar"] [data-testid="stWidgetLabel"] span,
-[data-testid="stSidebar"] [data-testid="stWidgetLabel"] p {{
-  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important;
-  font-size: 0.875rem !important;
-  font-weight: 500 !important;
-  line-height: 1.45 !important;
-  letter-spacing: normal !important;
-  color: {THEME_TEXT_HEX};
-  color: color-mix(in srgb, {THEME_PRIMARY_HEX} 22%, {THEME_TEXT_HEX}) !important;
-}}
-[data-testid="stSidebar"] label[data-baseweb="checkbox"] > div:first-of-type {{
-  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif !important;
-  font-size: 0.875rem !important;
-  font-weight: 500 !important;
-  line-height: 1.45 !important;
-  letter-spacing: normal !important;
-  color: {THEME_TEXT_HEX};
-  color: color-mix(in srgb, {THEME_PRIMARY_HEX} 22%, {THEME_TEXT_HEX}) !important;
-}}
-[data-testid="stSidebar"] label[data-baseweb="checkbox"] > div:first-of-type span {{
-  font-family: inherit !important;
-  font-size: inherit !important;
-  font-weight: inherit !important;
-  line-height: inherit !important;
-  color: inherit !important;
-}}
-</style>
-"""

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -33,7 +33,6 @@ from explorer.app.streamlit.app_constants import (
     SESSION_SPECIES_SEARCH_KEY,
     SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY,
     SESSION_SPECIES_WS_KEY,
-    SIDEBAR_CONTROL_LABEL_CSS,
     SPINNER_THEME_CSS,
 )
 from explorer.app.streamlit.defaults import (
@@ -93,22 +92,9 @@ def inject_spinner_theme_css() -> None:
     ``st.html`` is applied via Streamlit’s event container (see Streamlit ``HtmlMixin.html``).
 
     **Must run on every rerun:** if injection is skipped after the first run, the ``<style>`` node is
-    omitted from Streamlit output and spinners revert to default styling (same issue as sidebar
-    control labels — see :func:`inject_sidebar_control_label_css`).
+    omitted from Streamlit output and spinners revert to default styling.
     """
     st.html(SPINNER_THEME_CSS.strip())
-
-
-def inject_sidebar_control_label_css() -> None:
-    """Unify Map sidebar **control** label typography (selectbox, slider, ``st.toggle``), not spinners (refs #124).
-
-    Separate from :func:`inject_spinner_theme_css` so loading-spinner styling stays clearly scoped.
-    Call before ``with st.sidebar``.
-
-    **Must run on every rerun:** if we skip ``st.html`` after the first run, Streamlit omits that node from the
-    new output and the global ``<style>`` block disappears — controls then revert to default Streamlit fonts.
-    """
-    st.html(SIDEBAR_CONTROL_LABEL_CSS.strip())
 
 
 def inject_spinner_emoji_animation() -> None:

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -25,6 +25,7 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_TAXONOMY_LOCALE_KEY,
     PERSIST_SPECIES_COMMON_KEY,
     PERSIST_SPECIES_SCI_KEY,
+    SESSION_SPECIES_GROUP_BACK_TO_ALL_KEY,
     SESSION_SPECIES_GROUP_PENDING_KEY,
     SESSION_SPECIES_GROUP_SEL_COMMIT_KEY,
     SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
@@ -41,6 +42,7 @@ from explorer.app.streamlit.defaults import (
     MAP_HEIGHT_PX_MAX,
     MAP_HEIGHT_PX_MIN,
     MAP_HEIGHT_PX_DEFAULT,
+    SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2,
     THEME_PRIMARY_HEX,
 )
 from explorer.app.streamlit.streamlit_ui_constants import (
@@ -58,6 +60,7 @@ from explorer.app.streamlit.streamlit_ui_constants import (
     SPECIES_SEARCH_MAX_OPTIONS,
     SPECIES_SEARCH_MIN_QUERY_LEN,
     SPECIES_SEARCH_PLACEHOLDER,
+    SPECIES_SEARCH_PLACEHOLDER_GROUP_FILTERED,
     SPECIES_SEARCH_RERUN_SCOPE,
 )
 
@@ -66,6 +69,33 @@ def _species_searchbox_widget_key() -> str:
     """Stable Streamlit widget id; nonce bumps on reset so the field remounts empty (refs #73)."""
     n = int(st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0))
     return f"{SESSION_SPECIES_SEARCH_KEY}__v{n}"
+
+
+def _refresh_species_searchbox_options_for_group(group_label: str) -> None:
+    """Replace cached streamlit-searchbox suggestions after picking a ``… (group)`` row.
+
+    The component only calls the search callback when the text changes; **submit** does not refresh
+    options, so the menu would keep showing the previous global list (refs #73).
+    """
+    label = str(group_label or "").strip()
+    if not label:
+        return
+    ix = st.session_state.get(SESSION_SPECIES_IX_KEY)
+    sk = _species_searchbox_widget_key()
+    box = st.session_state.get(sk)
+    if ix is None or not isinstance(box, dict):
+        return
+    fresh = whoosh_species_suggestions(
+        ix,
+        "",
+        max_options=SPECIES_SEARCH_MAX_OPTIONS,
+        min_query_len=SPECIES_SEARCH_MIN_QUERY_LEN,
+        restrict_taxonomy_group=label,
+    )
+    box["options_js"] = [{"label": str(x), "value": i} for i, x in enumerate(fresh)]
+    box["options_py"] = list(fresh)
+    # Next dropdown open / keystroke must not skip ``_process_search`` because term == last search.
+    box["search"] = ""
 
 
 def inject_map_folium_iframe_min_height_css(height_px: int) -> None:
@@ -286,10 +316,11 @@ def sidebar_footer_links(*, leading_divider: bool = True) -> None:
 
 @st.fragment
 def species_searchbox_fragment() -> None:
-    """Whoosh-backed search + optional “species in group” dropdown.
+    """Whoosh-backed species search; taxonomy groups via ``… (group)`` rows (refs #70, #73).
 
-    Taxonomy group picks use ``st.rerun(scope="fragment")`` so the main prep spinner and map
-    pipeline do not run until a species is chosen (refs #70, #73).
+    **Prototype 2** (``SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2``): one searchbox switches to
+    group-filtered species options — no second ``st.selectbox``. **Prototype 1**: group row plus
+    secondary dropdown (rollback via defaults flag).
     """
     try:
         from streamlit_searchbox import st_searchbox
@@ -304,13 +335,32 @@ def species_searchbox_fragment() -> None:
         return
     persisted = st.session_state.get(PERSIST_SPECIES_COMMON_KEY)
     group_pending = bool(str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip())
+    pg_label = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
     # While a taxonomy group is selected, keep the previous species on the map until the user
-    # picks from the secondary dropdown (avoids a flash to the all-locations default). Don't
-    # pre-fill the search typing field with the persisted species name during group flow (#73).
+    # picks a species (avoids a flash to the all-locations default). Don't pre-fill the search
+    # typing field with the persisted species name during group flow (#73).
     search_default = None if group_pending else persisted
     search_term = "" if group_pending else (persisted or "")
+    species_search_label = (
+        f"Species ({pg_label})" if (SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2 and pg_label) else "Species"
+    )
+    species_search_placeholder = (
+        SPECIES_SEARCH_PLACEHOLDER_GROUP_FILTERED
+        if (SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2 and pg_label)
+        else SPECIES_SEARCH_PLACEHOLDER
+    )
 
     def _search(term: str) -> list:
+        if SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2:
+            pg_local = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
+            if pg_local:
+                return whoosh_species_suggestions(
+                    ix,
+                    term,
+                    max_options=SPECIES_SEARCH_MAX_OPTIONS,
+                    min_query_len=SPECIES_SEARCH_MIN_QUERY_LEN,
+                    restrict_taxonomy_group=pg_local,
+                )
         return whoosh_species_suggestions(
             ix,
             term,
@@ -320,8 +370,11 @@ def species_searchbox_fragment() -> None:
 
     def _on_species_submit(selected: Any) -> None:
         if isinstance(selected, str) and selected.endswith(GROUP_ROW_SUFFIX):
-            st.session_state[SESSION_SPECIES_GROUP_PENDING_KEY] = selected[: -len(GROUP_ROW_SUFFIX)].strip()
+            g = selected[: -len(GROUP_ROW_SUFFIX)].strip()
+            st.session_state[SESSION_SPECIES_GROUP_PENDING_KEY] = g
             st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+            if SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2:
+                _refresh_species_searchbox_options_for_group(g)
             # Keep SESSION_SPECIES_PICK_KEY so the map stays on the previous species until the
             # secondary dropdown chooses a species in this group.
             try:
@@ -349,8 +402,8 @@ def species_searchbox_fragment() -> None:
     pick = st_searchbox(
         _search,
         key=_species_searchbox_widget_key(),
-        placeholder=SPECIES_SEARCH_PLACEHOLDER,
-        label="Species",
+        placeholder=species_search_placeholder,
+        label=species_search_label,
         default=search_default,
         default_searchterm=search_term,
         debounce=SPECIES_SEARCH_DEBOUNCE_MS,
@@ -371,6 +424,8 @@ def species_searchbox_fragment() -> None:
         # forever (refs #73).
         if gname != prev_g:
             st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+            if SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2:
+                _refresh_species_searchbox_options_for_group(gname)
     elif pick is not None:
         raw = pick if isinstance(pick, str) else str(pick)
         p = raw.strip()
@@ -396,7 +451,27 @@ def species_searchbox_fragment() -> None:
             tax_loc,
             pending_group,
         )
-        if group_choices:
+        if SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2:
+            if not group_choices:
+                st.caption(f'No species from "{pending_group}" in the current filtered set.')
+                st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+                st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+            else:
+                if st.button(
+                    "Back to all species",
+                    key=SESSION_SPECIES_GROUP_BACK_TO_ALL_KEY,
+                    use_container_width=True,
+                ):
+                    st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+                    st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+                    st.session_state[SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY] = int(
+                        st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0)
+                    ) + 1
+                    try:
+                        st.rerun(scope="fragment")
+                    except StreamlitAPIException:
+                        st.rerun()
+        elif group_choices:
             opts = [""] + group_choices
             prev = str(st.session_state.get(SESSION_SPECIES_PICK_KEY) or "")
             idx = opts.index(prev) if prev in opts else 0

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -9,17 +9,28 @@ from typing import Any
 
 import streamlit as st
 import streamlit.components.v1 as components
+from streamlit.errors import StreamlitAPIException
 
-from explorer.core.species_search import whoosh_species_suggestions
+from explorer.core.species_search import (
+    GROUP_ROW_SUFFIX,
+    species_common_names_in_group,
+    whoosh_species_suggestions,
+)
 from explorer.app.streamlit.app_constants import (
+    DEFAULT_TAXONOMY_LOCALE,
     STREAMLIT_MAP_BASEMAP_KEY,
     STREAMLIT_MAP_BASEMAP_SAVED_KEY,
     STREAMLIT_MAP_HEIGHT_PX_KEY,
     STREAMLIT_MAP_HEIGHT_PX_SAVED_KEY,
+    STREAMLIT_TAXONOMY_LOCALE_KEY,
     PERSIST_SPECIES_COMMON_KEY,
+    SESSION_SPECIES_GROUP_PENDING_KEY,
+    SESSION_SPECIES_GROUP_SEL_COMMIT_KEY,
+    SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
     SESSION_SPECIES_IX_KEY,
     SESSION_SPECIES_PICK_KEY,
     SESSION_SPECIES_SEARCH_KEY,
+    SESSION_SPECIES_WS_KEY,
     SIDEBAR_CONTROL_LABEL_CSS,
     SPINNER_THEME_CSS,
 )
@@ -281,7 +292,11 @@ def sidebar_footer_links(*, leading_divider: bool = True) -> None:
 
 @st.fragment
 def species_searchbox_fragment() -> None:
-    """Whoosh-backed search; fragment-scoped reruns avoid greying the whole app (refs #70)."""
+    """Whoosh-backed search + optional “species in group” dropdown.
+
+    Taxonomy group picks use ``st.rerun(scope="fragment")`` so the main prep spinner and map
+    pipeline do not run until a species is chosen (refs #70, #73).
+    """
     try:
         from streamlit_searchbox import st_searchbox
     except ImportError:
@@ -294,6 +309,12 @@ def species_searchbox_fragment() -> None:
     if ix is None:
         return
     persisted = st.session_state.get(PERSIST_SPECIES_COMMON_KEY)
+    group_pending = bool(str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip())
+    # While a taxonomy group is selected, keep the previous species on the map until the user
+    # picks from the secondary dropdown (avoids a flash to the all-locations default). Don't
+    # pre-fill the search typing field with the persisted species name during group flow (#73).
+    search_default = None if group_pending else persisted
+    search_term = "" if group_pending else (persisted or "")
 
     def _search(term: str) -> list:
         return whoosh_species_suggestions(
@@ -304,11 +325,25 @@ def species_searchbox_fragment() -> None:
         )
 
     def _on_species_submit(selected: Any) -> None:
-        st.session_state[SESSION_SPECIES_PICK_KEY] = selected
-        st.rerun()
+        if isinstance(selected, str) and selected.endswith(GROUP_ROW_SUFFIX):
+            st.session_state[SESSION_SPECIES_GROUP_PENDING_KEY] = selected[: -len(GROUP_ROW_SUFFIX)].strip()
+            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+            # Keep SESSION_SPECIES_PICK_KEY so the map stays on the previous species until the
+            # secondary dropdown chooses a species in this group.
+            try:
+                st.rerun(scope="fragment")
+            except StreamlitAPIException:
+                st.rerun()
+        else:
+            st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+            st.session_state[SESSION_SPECIES_PICK_KEY] = selected
+            st.rerun()
 
     def _on_species_reset() -> None:
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
+        st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+        st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
         st.rerun()
 
     pick = st_searchbox(
@@ -316,12 +351,63 @@ def species_searchbox_fragment() -> None:
         key=SESSION_SPECIES_SEARCH_KEY,
         placeholder=SPECIES_SEARCH_PLACEHOLDER,
         label="Species",
-        default=persisted,
-        default_searchterm=persisted or "",
+        default=search_default,
+        default_searchterm=search_term,
         debounce=SPECIES_SEARCH_DEBOUNCE_MS,
         edit_after_submit=SPECIES_SEARCH_EDIT_AFTER_SUBMIT,
         rerun_scope=SPECIES_SEARCH_RERUN_SCOPE,
         submit_function=_on_species_submit,
         reset_function=_on_species_reset,
     )
-    st.session_state[SESSION_SPECIES_PICK_KEY] = pick
+    if isinstance(pick, str) and pick.endswith(GROUP_ROW_SUFFIX):
+        gname = pick[: -len(GROUP_ROW_SUFFIX)].strip()
+        prev_g = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
+        st.session_state[SESSION_SPECIES_GROUP_PENDING_KEY] = gname
+        # Only reset dropdown commit when the **group** changes. If we clear commit on every run while
+        # the searchbox still holds the group row, the species dropdown retriggers ``st.rerun()``
+        # forever (refs #73).
+        if gname != prev_g:
+            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+    elif pick is not None:
+        st.session_state[SESSION_SPECIES_PICK_KEY] = pick
+        st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+        st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+
+    pending_group = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
+    if pending_group:
+        ws = st.session_state.get(SESSION_SPECIES_WS_KEY)
+        if ws is not None:
+            tax_loc = (
+                str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
+                or DEFAULT_TAXONOMY_LOCALE
+            )
+            group_choices = species_common_names_in_group(
+                ws.species_list,
+                ws.name_map,
+                tax_loc,
+                pending_group,
+            )
+            if group_choices:
+                opts = [""] + group_choices
+                prev = str(st.session_state.get(SESSION_SPECIES_PICK_KEY) or "")
+                idx = opts.index(prev) if prev in opts else 0
+                st.selectbox(
+                    f'Species in "{pending_group}" (your data)',
+                    options=opts,
+                    index=idx,
+                    format_func=lambda x: "— Select a species —" if x == "" else x,
+                    key=SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
+                )
+                # ``st.rerun()`` inside ``on_change`` is a no-op in Streamlit; commit + rerun here (#73).
+                raw_sel = st.session_state.get(SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY)
+                sel = raw_sel.strip() if isinstance(raw_sel, str) else ""
+                if sel:
+                    st.session_state[SESSION_SPECIES_PICK_KEY] = sel
+                    sig = (pending_group, sel)
+                    if st.session_state.get(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY) != sig:
+                        st.session_state[SESSION_SPECIES_GROUP_SEL_COMMIT_KEY] = sig
+                        st.rerun()
+            else:
+                st.caption(f'No species from "{pending_group}" in the current filtered set.')
+                st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+                st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -9,26 +9,15 @@ from typing import Any
 
 import streamlit as st
 import streamlit.components.v1 as components
-from streamlit.errors import StreamlitAPIException
 
-from explorer.core.species_search import (
-    GROUP_ROW_SUFFIX,
-    species_common_names_in_group,
-    whoosh_species_suggestions,
-)
+from explorer.core.species_search import whoosh_species_suggestions
 from explorer.app.streamlit.app_constants import (
-    DEFAULT_TAXONOMY_LOCALE,
     STREAMLIT_MAP_BASEMAP_KEY,
     STREAMLIT_MAP_BASEMAP_SAVED_KEY,
     STREAMLIT_MAP_HEIGHT_PX_KEY,
     STREAMLIT_MAP_HEIGHT_PX_SAVED_KEY,
-    STREAMLIT_TAXONOMY_LOCALE_KEY,
     PERSIST_SPECIES_COMMON_KEY,
     PERSIST_SPECIES_SCI_KEY,
-    SESSION_SPECIES_GROUP_BACK_TO_ALL_KEY,
-    SESSION_SPECIES_GROUP_PENDING_KEY,
-    SESSION_SPECIES_GROUP_SEL_COMMIT_KEY,
-    SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
     SESSION_SPECIES_IX_KEY,
     SESSION_SPECIES_PICK_KEY,
     SESSION_SPECIES_SEARCH_KEY,
@@ -42,7 +31,6 @@ from explorer.app.streamlit.defaults import (
     MAP_HEIGHT_PX_MAX,
     MAP_HEIGHT_PX_MIN,
     MAP_HEIGHT_PX_DEFAULT,
-    SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2,
     THEME_PRIMARY_HEX,
 )
 from explorer.app.streamlit.streamlit_ui_constants import (
@@ -60,7 +48,6 @@ from explorer.app.streamlit.streamlit_ui_constants import (
     SPECIES_SEARCH_MAX_OPTIONS,
     SPECIES_SEARCH_MIN_QUERY_LEN,
     SPECIES_SEARCH_PLACEHOLDER,
-    SPECIES_SEARCH_PLACEHOLDER_GROUP_FILTERED,
     SPECIES_SEARCH_RERUN_SCOPE,
 )
 
@@ -69,33 +56,6 @@ def _species_searchbox_widget_key() -> str:
     """Stable Streamlit widget id; nonce bumps on reset so the field remounts empty (refs #73)."""
     n = int(st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0))
     return f"{SESSION_SPECIES_SEARCH_KEY}__v{n}"
-
-
-def _refresh_species_searchbox_options_for_group(group_label: str) -> None:
-    """Replace cached streamlit-searchbox suggestions after picking a ``… (group)`` row.
-
-    The component only calls the search callback when the text changes; **submit** does not refresh
-    options, so the menu would keep showing the previous global list (refs #73).
-    """
-    label = str(group_label or "").strip()
-    if not label:
-        return
-    ix = st.session_state.get(SESSION_SPECIES_IX_KEY)
-    sk = _species_searchbox_widget_key()
-    box = st.session_state.get(sk)
-    if ix is None or not isinstance(box, dict):
-        return
-    fresh = whoosh_species_suggestions(
-        ix,
-        "",
-        max_options=SPECIES_SEARCH_MAX_OPTIONS,
-        min_query_len=SPECIES_SEARCH_MIN_QUERY_LEN,
-        restrict_taxonomy_group=label,
-    )
-    box["options_js"] = [{"label": str(x), "value": i} for i, x in enumerate(fresh)]
-    box["options_py"] = list(fresh)
-    # Next dropdown open / keystroke must not skip ``_process_search`` because term == last search.
-    box["search"] = ""
 
 
 def inject_map_folium_iframe_min_height_css(height_px: int) -> None:
@@ -316,12 +276,7 @@ def sidebar_footer_links(*, leading_divider: bool = True) -> None:
 
 @st.fragment
 def species_searchbox_fragment() -> None:
-    """Whoosh-backed species search; taxonomy groups via ``… (group)`` rows (refs #70, #73).
-
-    **Prototype 2** (``SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2``): one searchbox switches to
-    group-filtered species options — no second ``st.selectbox``. **Prototype 1**: group row plus
-    secondary dropdown (rollback via defaults flag).
-    """
+    """Whoosh-backed species search with weighted common/scientific/group matching (refs #73)."""
     try:
         from streamlit_searchbox import st_searchbox
     except ImportError:
@@ -334,33 +289,10 @@ def species_searchbox_fragment() -> None:
     if ix is None:
         return
     persisted = st.session_state.get(PERSIST_SPECIES_COMMON_KEY)
-    group_pending = bool(str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip())
-    pg_label = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
-    # While a taxonomy group is selected, keep the previous species on the map until the user
-    # picks a species (avoids a flash to the all-locations default). Don't pre-fill the search
-    # typing field with the persisted species name during group flow (#73).
-    search_default = None if group_pending else persisted
-    search_term = "" if group_pending else (persisted or "")
-    species_search_label = (
-        f"Species ({pg_label})" if (SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2 and pg_label) else "Species"
-    )
-    species_search_placeholder = (
-        SPECIES_SEARCH_PLACEHOLDER_GROUP_FILTERED
-        if (SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2 and pg_label)
-        else SPECIES_SEARCH_PLACEHOLDER
-    )
+    search_default = persisted
+    search_term = persisted or ""
 
     def _search(term: str) -> list:
-        if SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2:
-            pg_local = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
-            if pg_local:
-                return whoosh_species_suggestions(
-                    ix,
-                    term,
-                    max_options=SPECIES_SEARCH_MAX_OPTIONS,
-                    min_query_len=SPECIES_SEARCH_MIN_QUERY_LEN,
-                    restrict_taxonomy_group=pg_local,
-                )
         return whoosh_species_suggestions(
             ix,
             term,
@@ -369,31 +301,13 @@ def species_searchbox_fragment() -> None:
         )
 
     def _on_species_submit(selected: Any) -> None:
-        if isinstance(selected, str) and selected.endswith(GROUP_ROW_SUFFIX):
-            g = selected[: -len(GROUP_ROW_SUFFIX)].strip()
-            st.session_state[SESSION_SPECIES_GROUP_PENDING_KEY] = g
-            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
-            if SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2:
-                _refresh_species_searchbox_options_for_group(g)
-            # Keep SESSION_SPECIES_PICK_KEY so the map stays on the previous species until the
-            # secondary dropdown chooses a species in this group.
-            try:
-                st.rerun(scope="fragment")
-            except StreamlitAPIException:
-                st.rerun()
-        else:
-            st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
-            st.session_state[SESSION_SPECIES_PICK_KEY] = selected
-            st.rerun()
+        st.session_state[SESSION_SPECIES_PICK_KEY] = selected
+        st.rerun()
 
     def _on_species_reset() -> None:
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
-        st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-        st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
         st.session_state.pop(PERSIST_SPECIES_COMMON_KEY, None)
         st.session_state.pop(PERSIST_SPECIES_SCI_KEY, None)
-        st.session_state.pop(SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY, None)
         st.session_state[SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY] = int(
             st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0)
         ) + 1
@@ -402,8 +316,8 @@ def species_searchbox_fragment() -> None:
     pick = st_searchbox(
         _search,
         key=_species_searchbox_widget_key(),
-        placeholder=species_search_placeholder,
-        label=species_search_label,
+        placeholder=SPECIES_SEARCH_PLACEHOLDER,
+        label="Species",
         default=search_default,
         default_searchterm=search_term,
         debounce=SPECIES_SEARCH_DEBOUNCE_MS,
@@ -415,83 +329,11 @@ def species_searchbox_fragment() -> None:
     ws = st.session_state.get(SESSION_SPECIES_WS_KEY)
     valid_common = frozenset(ws.species_list) if ws is not None else frozenset()
 
-    if isinstance(pick, str) and pick.endswith(GROUP_ROW_SUFFIX):
-        gname = pick[: -len(GROUP_ROW_SUFFIX)].strip()
-        prev_g = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
-        st.session_state[SESSION_SPECIES_GROUP_PENDING_KEY] = gname
-        # Only reset dropdown commit when the **group** changes. If we clear commit on every run while
-        # the searchbox still holds the group row, the species dropdown retriggers ``st.rerun()``
-        # forever (refs #73).
-        if gname != prev_g:
-            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
-            if SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2:
-                _refresh_species_searchbox_options_for_group(gname)
-    elif pick is not None:
+    if pick is not None:
         raw = pick if isinstance(pick, str) else str(pick)
         p = raw.strip()
         if not p:
             st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
-            st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
         elif p in valid_common:
             st.session_state[SESSION_SPECIES_PICK_KEY] = p
-            st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
         # Partial / invalid typing: do not assign PICK (avoids empty filter → blank map) (refs #73).
-
-    pending_group = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
-    if pending_group and ws is not None:
-        tax_loc = (
-            str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
-            or DEFAULT_TAXONOMY_LOCALE
-        )
-        group_choices = species_common_names_in_group(
-            ws.species_list,
-            ws.name_map,
-            tax_loc,
-            pending_group,
-        )
-        if SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2:
-            if not group_choices:
-                st.caption(f'No species from "{pending_group}" in the current filtered set.')
-                st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-                st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
-            else:
-                if st.button(
-                    "Back to all species",
-                    key=SESSION_SPECIES_GROUP_BACK_TO_ALL_KEY,
-                    use_container_width=True,
-                ):
-                    st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-                    st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
-                    st.session_state[SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY] = int(
-                        st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0)
-                    ) + 1
-                    try:
-                        st.rerun(scope="fragment")
-                    except StreamlitAPIException:
-                        st.rerun()
-        elif group_choices:
-            opts = [""] + group_choices
-            prev = str(st.session_state.get(SESSION_SPECIES_PICK_KEY) or "")
-            idx = opts.index(prev) if prev in opts else 0
-            st.selectbox(
-                f'Species in "{pending_group}" (your data)',
-                options=opts,
-                index=idx,
-                format_func=lambda x: "— Select a species —" if x == "" else x,
-                key=SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
-            )
-            # ``st.rerun()`` inside ``on_change`` is a no-op in Streamlit; commit + rerun here (#73).
-            raw_sel = st.session_state.get(SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY)
-            sel = raw_sel.strip() if isinstance(raw_sel, str) else ""
-            if sel:
-                st.session_state[SESSION_SPECIES_PICK_KEY] = sel
-                sig = (pending_group, sel)
-                if st.session_state.get(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY) != sig:
-                    st.session_state[SESSION_SPECIES_GROUP_SEL_COMMIT_KEY] = sig
-                    st.rerun()
-        else:
-            st.caption(f'No species from "{pending_group}" in the current filtered set.')
-            st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -12,6 +12,9 @@ import streamlit.components.v1 as components
 
 from explorer.core.species_search import whoosh_species_suggestions
 from explorer.app.streamlit.app_constants import (
+    EXPLORER_MAP_HTML_BYTES_KEY,
+    FOLIUM_MAP_MOUNT_NONCE_KEY,
+    FOLIUM_STATIC_MAP_CACHE_KEY,
     STREAMLIT_MAP_BASEMAP_KEY,
     STREAMLIT_MAP_BASEMAP_SAVED_KEY,
     STREAMLIT_MAP_HEIGHT_PX_KEY,
@@ -290,7 +293,10 @@ def species_searchbox_fragment() -> None:
         return
     persisted = st.session_state.get(PERSIST_SPECIES_COMMON_KEY)
     search_default = persisted
-    search_term = persisted or ""
+    # Always use an empty initial search term for the widget props. Passing the persisted species
+    # here on every fragment rerun re-injected that string into the control and fought backspace /
+    # edits (focus jumped; map state flickered). Selection stays in session via ``default`` and
+    # ``SESSION_SPECIES_PICK_KEY``; only the reset (×) clears those (refs #73).
 
     def _search(term: str) -> list:
         return whoosh_species_suggestions(
@@ -301,8 +307,17 @@ def species_searchbox_fragment() -> None:
         )
 
     def _on_species_submit(selected: Any) -> None:
-        st.session_state[SESSION_SPECIES_PICK_KEY] = selected
-        st.rerun()
+        # Submit can fire while editing; only commit a real species and rerun when it changes (refs #73).
+        ws = st.session_state.get(SESSION_SPECIES_WS_KEY)
+        valid_common = frozenset(ws.species_list) if ws is not None else frozenset()
+        raw = selected if isinstance(selected, str) else str(selected)
+        s = raw.strip()
+        if s not in valid_common:
+            return
+        prev = st.session_state.get(SESSION_SPECIES_PICK_KEY)
+        st.session_state[SESSION_SPECIES_PICK_KEY] = s
+        if prev != s:
+            st.rerun()
 
     def _on_species_reset() -> None:
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
@@ -311,6 +326,12 @@ def species_searchbox_fragment() -> None:
         st.session_state[SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY] = int(
             st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0)
         ) + 1
+        # Remount Folium + drop cached HTML so the map returns to the all-locations view cleanly.
+        st.session_state[FOLIUM_MAP_MOUNT_NONCE_KEY] = int(
+            st.session_state.get(FOLIUM_MAP_MOUNT_NONCE_KEY, 0)
+        ) + 1
+        st.session_state.pop(FOLIUM_STATIC_MAP_CACHE_KEY, None)
+        st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
         st.rerun()
 
     pick = st_searchbox(
@@ -319,7 +340,7 @@ def species_searchbox_fragment() -> None:
         placeholder=SPECIES_SEARCH_PLACEHOLDER,
         label="Species",
         default=search_default,
-        default_searchterm=search_term,
+        default_searchterm="",
         debounce=SPECIES_SEARCH_DEBOUNCE_MS,
         edit_after_submit=SPECIES_SEARCH_EDIT_AFTER_SUBMIT,
         rerun_scope=SPECIES_SEARCH_RERUN_SCOPE,
@@ -332,8 +353,8 @@ def species_searchbox_fragment() -> None:
     if pick is not None:
         raw = pick if isinstance(pick, str) else str(pick)
         p = raw.strip()
-        if not p:
-            st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
-        elif p in valid_common:
+        # Empty field while typing / backspacing must not clear the map species — only choosing a
+        # valid species updates PICK; reset (×) clears via ``_on_species_reset`` (refs #73).
+        if p in valid_common:
             st.session_state[SESSION_SPECIES_PICK_KEY] = p
         # Partial / invalid typing: do not assign PICK (avoids empty filter → blank map) (refs #73).

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -12,6 +12,7 @@ import streamlit.components.v1 as components
 
 from explorer.core.species_search import whoosh_species_suggestions
 from explorer.app.streamlit.app_constants import (
+    EXPLORER_MAIN_SCRIPT_RUN_ID_KEY,
     EXPLORER_MAP_HTML_BYTES_KEY,
     FOLIUM_MAP_MOUNT_NONCE_KEY,
     FOLIUM_STATIC_MAP_CACHE_KEY,
@@ -24,7 +25,9 @@ from explorer.app.streamlit.app_constants import (
     SESSION_SPECIES_IX_KEY,
     SESSION_SPECIES_PICK_KEY,
     SESSION_SPECIES_SEARCH_KEY,
+    SESSION_SPECIES_SEARCH_LAST_MAIN_RUN_KEY,
     SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY,
+    SESSION_SPECIES_SEARCH_USER_EDITING_KEY,
     SESSION_SPECIES_WS_KEY,
     SPINNER_THEME_CSS,
 )
@@ -293,12 +296,36 @@ def species_searchbox_fragment() -> None:
         return
     persisted = st.session_state.get(PERSIST_SPECIES_COMMON_KEY)
     search_default = persisted
-    # Always use an empty initial search term for the widget props. Passing the persisted species
-    # here on every fragment rerun re-injected that string into the control and fought backspace /
-    # edits (focus jumped; map state flickered). Selection stays in session via ``default`` and
-    # ``SESSION_SPECIES_PICK_KEY``; only the reset (×) clears those (refs #73).
+    # ``default_searchterm``: show the persisted species name after full-app reruns (e.g. returning to
+    # the Map tab). Fragment-only reruns (typing) skip ``main()`` so we pass "" and avoid fighting
+    # backspace. ``SESSION_SPECIES_SEARCH_USER_EDITING_KEY`` prevents a full run from overwriting
+    # text the user is still editing (e.g. after switching tabs mid-query).
+    _main_id = int(st.session_state.get(EXPLORER_MAIN_SCRIPT_RUN_ID_KEY, 0))
+    _last_main = int(st.session_state.get(SESSION_SPECIES_SEARCH_LAST_MAIN_RUN_KEY, -1))
+    _just_ran_full_script = _main_id != _last_main
+    st.session_state[SESSION_SPECIES_SEARCH_LAST_MAIN_RUN_KEY] = _main_id
+    _editing = bool(st.session_state.get(SESSION_SPECIES_SEARCH_USER_EDITING_KEY, False))
+    _pick_s = (st.session_state.get(SESSION_SPECIES_PICK_KEY) or "").strip()
+    _persist_s = (persisted or "").strip()
+    # Full script run: refill bar after tab / map-view changes. Same run may execute this fragment
+    # twice; then ``_just_ran_full_script`` is false on the second pass—still show if pick matches
+    # persist (rehydrated in ``app_map_working_ui`` when re-entering species view).
+    _show_persisted_in_bar = (
+        not _editing
+        and bool(_persist_s)
+        and (_just_ran_full_script or _pick_s == _persist_s)
+    )
+    default_searchterm = _persist_s if _show_persisted_in_bar else ""
 
     def _search(term: str) -> list:
+        p = (persisted or "").strip()
+        t = (term or "").strip()
+        if t == p:
+            st.session_state[SESSION_SPECIES_SEARCH_USER_EDITING_KEY] = False
+        elif not t and not p:
+            st.session_state[SESSION_SPECIES_SEARCH_USER_EDITING_KEY] = False
+        else:
+            st.session_state[SESSION_SPECIES_SEARCH_USER_EDITING_KEY] = True
         return whoosh_species_suggestions(
             ix,
             term,
@@ -316,10 +343,12 @@ def species_searchbox_fragment() -> None:
             return
         prev = st.session_state.get(SESSION_SPECIES_PICK_KEY)
         st.session_state[SESSION_SPECIES_PICK_KEY] = s
+        st.session_state[SESSION_SPECIES_SEARCH_USER_EDITING_KEY] = False
         if prev != s:
             st.rerun()
 
     def _on_species_reset() -> None:
+        st.session_state[SESSION_SPECIES_SEARCH_USER_EDITING_KEY] = False
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
         st.session_state.pop(PERSIST_SPECIES_COMMON_KEY, None)
         st.session_state.pop(PERSIST_SPECIES_SCI_KEY, None)
@@ -340,7 +369,7 @@ def species_searchbox_fragment() -> None:
         placeholder=SPECIES_SEARCH_PLACEHOLDER,
         label="Species",
         default=search_default,
-        default_searchterm="",
+        default_searchterm=default_searchterm,
         debounce=SPECIES_SEARCH_DEBOUNCE_MS,
         edit_after_submit=SPECIES_SEARCH_EDIT_AFTER_SUBMIT,
         rerun_scope=SPECIES_SEARCH_RERUN_SCOPE,

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -24,12 +24,14 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_MAP_HEIGHT_PX_SAVED_KEY,
     STREAMLIT_TAXONOMY_LOCALE_KEY,
     PERSIST_SPECIES_COMMON_KEY,
+    PERSIST_SPECIES_SCI_KEY,
     SESSION_SPECIES_GROUP_PENDING_KEY,
     SESSION_SPECIES_GROUP_SEL_COMMIT_KEY,
     SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
     SESSION_SPECIES_IX_KEY,
     SESSION_SPECIES_PICK_KEY,
     SESSION_SPECIES_SEARCH_KEY,
+    SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY,
     SESSION_SPECIES_WS_KEY,
     SIDEBAR_CONTROL_LABEL_CSS,
     SPINNER_THEME_CSS,
@@ -59,6 +61,12 @@ from explorer.app.streamlit.streamlit_ui_constants import (
     SPECIES_SEARCH_PLACEHOLDER,
     SPECIES_SEARCH_RERUN_SCOPE,
 )
+
+
+def _species_searchbox_widget_key() -> str:
+    """Stable Streamlit widget id; nonce bumps on reset so the field remounts empty (refs #73)."""
+    n = int(st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0))
+    return f"{SESSION_SPECIES_SEARCH_KEY}__v{n}"
 
 
 def inject_map_folium_iframe_min_height_css(height_px: int) -> None:
@@ -344,11 +352,17 @@ def species_searchbox_fragment() -> None:
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
         st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
         st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+        st.session_state.pop(PERSIST_SPECIES_COMMON_KEY, None)
+        st.session_state.pop(PERSIST_SPECIES_SCI_KEY, None)
+        st.session_state.pop(SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY, None)
+        st.session_state[SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY] = int(
+            st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0)
+        ) + 1
         st.rerun()
 
     pick = st_searchbox(
         _search,
-        key=SESSION_SPECIES_SEARCH_KEY,
+        key=_species_searchbox_widget_key(),
         placeholder=SPECIES_SEARCH_PLACEHOLDER,
         label="Species",
         default=search_default,
@@ -359,6 +373,9 @@ def species_searchbox_fragment() -> None:
         submit_function=_on_species_submit,
         reset_function=_on_species_reset,
     )
+    ws = st.session_state.get(SESSION_SPECIES_WS_KEY)
+    valid_common = frozenset(ws.species_list) if ws is not None else frozenset()
+
     if isinstance(pick, str) and pick.endswith(GROUP_ROW_SUFFIX):
         gname = pick[: -len(GROUP_ROW_SUFFIX)].strip()
         prev_g = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
@@ -369,45 +386,51 @@ def species_searchbox_fragment() -> None:
         if gname != prev_g:
             st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
     elif pick is not None:
-        st.session_state[SESSION_SPECIES_PICK_KEY] = pick
-        st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-        st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+        raw = pick if isinstance(pick, str) else str(pick)
+        p = raw.strip()
+        if not p:
+            st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
+            st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+        elif p in valid_common:
+            st.session_state[SESSION_SPECIES_PICK_KEY] = p
+            st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+        # Partial / invalid typing: do not assign PICK (avoids empty filter → blank map) (refs #73).
 
     pending_group = str(st.session_state.get(SESSION_SPECIES_GROUP_PENDING_KEY) or "").strip()
-    if pending_group:
-        ws = st.session_state.get(SESSION_SPECIES_WS_KEY)
-        if ws is not None:
-            tax_loc = (
-                str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
-                or DEFAULT_TAXONOMY_LOCALE
+    if pending_group and ws is not None:
+        tax_loc = (
+            str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
+            or DEFAULT_TAXONOMY_LOCALE
+        )
+        group_choices = species_common_names_in_group(
+            ws.species_list,
+            ws.name_map,
+            tax_loc,
+            pending_group,
+        )
+        if group_choices:
+            opts = [""] + group_choices
+            prev = str(st.session_state.get(SESSION_SPECIES_PICK_KEY) or "")
+            idx = opts.index(prev) if prev in opts else 0
+            st.selectbox(
+                f'Species in "{pending_group}" (your data)',
+                options=opts,
+                index=idx,
+                format_func=lambda x: "— Select a species —" if x == "" else x,
+                key=SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
             )
-            group_choices = species_common_names_in_group(
-                ws.species_list,
-                ws.name_map,
-                tax_loc,
-                pending_group,
-            )
-            if group_choices:
-                opts = [""] + group_choices
-                prev = str(st.session_state.get(SESSION_SPECIES_PICK_KEY) or "")
-                idx = opts.index(prev) if prev in opts else 0
-                st.selectbox(
-                    f'Species in "{pending_group}" (your data)',
-                    options=opts,
-                    index=idx,
-                    format_func=lambda x: "— Select a species —" if x == "" else x,
-                    key=SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
-                )
-                # ``st.rerun()`` inside ``on_change`` is a no-op in Streamlit; commit + rerun here (#73).
-                raw_sel = st.session_state.get(SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY)
-                sel = raw_sel.strip() if isinstance(raw_sel, str) else ""
-                if sel:
-                    st.session_state[SESSION_SPECIES_PICK_KEY] = sel
-                    sig = (pending_group, sel)
-                    if st.session_state.get(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY) != sig:
-                        st.session_state[SESSION_SPECIES_GROUP_SEL_COMMIT_KEY] = sig
-                        st.rerun()
-            else:
-                st.caption(f'No species from "{pending_group}" in the current filtered set.')
-                st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-                st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+            # ``st.rerun()`` inside ``on_change`` is a no-op in Streamlit; commit + rerun here (#73).
+            raw_sel = st.session_state.get(SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY)
+            sel = raw_sel.strip() if isinstance(raw_sel, str) else ""
+            if sel:
+                st.session_state[SESSION_SPECIES_PICK_KEY] = sel
+                sig = (pending_group, sel)
+                if st.session_state.get(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY) != sig:
+                    st.session_state[SESSION_SPECIES_GROUP_SEL_COMMIT_KEY] = sig
+                    st.rerun()
+        else:
+            st.caption(f'No species from "{pending_group}" in the current filtered set.')
+            st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+            st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -28,6 +28,7 @@ from explorer.app.streamlit.app_constants import (
     SESSION_SPECIES_GROUP_SEL_COMMIT_KEY,
     SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
     SESSION_SPECIES_SEARCH_KEY,
+    SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY,
     SESSION_SPECIES_WS_KEY,
     STREAMLIT_MAP_BASEMAP_KEY,
     STREAMLIT_MAP_BASEMAP_SAVED_KEY,
@@ -245,6 +246,9 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
     _prev_mv = st.session_state.get(SESSION_PREV_MAP_VIEW_KEY)
     if map_view_mode == "species" and _prev_mv is not None and _prev_mv != "species":
         st.session_state.pop(SESSION_SPECIES_SEARCH_KEY, None)
+        _n = int(st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0))
+        st.session_state.pop(f"{SESSION_SPECIES_SEARCH_KEY}__v{_n}", None)
+        st.session_state.pop(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, None)
 
     if map_view_mode == "species":
         tax_loc = (

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -60,6 +60,7 @@ from explorer.app.streamlit.defaults import (
     MAP_HEIGHT_PX_MAX,
     MAP_HEIGHT_PX_MIN,
     MAP_HEIGHT_PX_STEP,
+    MAP_SPECIES_HIDE_ONLY_DEFAULT,
     MAP_VIEW_LABELS,
 )
 from explorer.app.streamlit.map_working import (
@@ -276,13 +277,11 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                     if _para:
                         st.caption(_para)
             species_searchbox_fragment()
+            if STREAMLIT_SPECIES_HIDE_ONLY_KEY not in st.session_state:
+                st.session_state[STREAMLIT_SPECIES_HIDE_ONLY_KEY] = MAP_SPECIES_HIDE_ONLY_DEFAULT
             hide_non_matching_locations = st.toggle(
                 "Show only selected species",
                 key=STREAMLIT_SPECIES_HIDE_ONLY_KEY,
-                help=(
-                    "When off, all locations are shown with your species highlighted. "
-                    "When on, only locations where you recorded the species."
-                ),
             )
 
         species_pick_common = st.session_state.get(SESSION_SPECIES_PICK_KEY)

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -74,6 +74,7 @@ from explorer.app.streamlit.streamlit_ui_constants import (
     SPECIES_SEARCH_HELP_EXPANDER_LABEL,
 )
 from explorer.core.species_search import (
+    SPECIES_WHOOSH_INDEX_VERSION,
     build_ram_species_whoosh_index,
     taxonomy_group_names_in_working_set,
 )
@@ -257,12 +258,18 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             or DEFAULT_TAXONOMY_LOCALE
         )
         group_names = taxonomy_group_names_in_working_set(ws.species_list, ws.name_map, tax_loc)
-        _ix_sig = (len(ws.species_list), st.session_state.get(EBIRD_DATA_SIG_KEY), tax_loc)
+        _ix_sig = (
+            SPECIES_WHOOSH_INDEX_VERSION,
+            len(ws.species_list),
+            st.session_state.get(EBIRD_DATA_SIG_KEY),
+            tax_loc,
+        )
         if st.session_state.get(SESSION_SPECIES_IX_SIG_KEY) != _ix_sig:
             st.session_state[SESSION_SPECIES_IX_KEY] = build_ram_species_whoosh_index(
                 ws.species_list,
                 ws.name_map,
                 taxonomy_group_names=group_names,
+                taxonomy_locale=tax_loc,
             )
             st.session_state[SESSION_SPECIES_IX_SIG_KEY] = _ix_sig
         st.session_state[SESSION_SPECIES_WS_KEY] = ws

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -250,6 +250,13 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         st.session_state.pop(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, None)
 
     if map_view_mode == "species":
+        # PICK is cleared when leaving species for All / Family / Lifers; PERSIST keeps the last
+        # species name for the map. Restore PICK so the map, search box, and persist stay aligned.
+        if not st.session_state.get(SESSION_SPECIES_PICK_KEY):
+            _pc = st.session_state.get(PERSIST_SPECIES_COMMON_KEY)
+            if _pc:
+                st.session_state[SESSION_SPECIES_PICK_KEY] = str(_pc).strip()
+
         tax_loc = (
             str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
             or DEFAULT_TAXONOMY_LOCALE

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -24,6 +24,9 @@ from explorer.app.streamlit.app_constants import (
     SESSION_SPECIES_IX_KEY,
     SESSION_SPECIES_IX_SIG_KEY,
     SESSION_SPECIES_PICK_KEY,
+    SESSION_SPECIES_GROUP_PENDING_KEY,
+    SESSION_SPECIES_GROUP_SEL_COMMIT_KEY,
+    SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
     SESSION_SPECIES_SEARCH_KEY,
     SESSION_SPECIES_WS_KEY,
     STREAMLIT_MAP_BASEMAP_KEY,
@@ -67,7 +70,10 @@ from explorer.app.streamlit.map_working import (
     streamlit_working_set_and_status,
 )
 from explorer.app.streamlit.streamlit_ui_constants import SPECIES_SEARCH_CAPTION
-from explorer.core.species_search import build_ram_species_whoosh_index
+from explorer.core.species_search import (
+    build_ram_species_whoosh_index,
+    taxonomy_group_names_in_working_set,
+)
 
 
 def invalidate_folium_map_embed_cache() -> None:
@@ -120,6 +126,10 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             saved_basemap = MAP_BASEMAP_OPTIONS[0]
         override = st.session_state.get(STREAMLIT_MAP_BASEMAP_KEY, "__default__")
         map_style = override if override in MAP_BASEMAP_OPTIONS else saved_basemap
+
+        # Renamed label (was "Selected species"); keep existing sessions valid.
+        if st.session_state.get(STREAMLIT_MAP_VIEW_LABEL_KEY) == "Selected species":
+            st.session_state[STREAMLIT_MAP_VIEW_LABEL_KEY] = "Species locations"
 
         map_view_label = st.selectbox(
             "Map view",
@@ -237,10 +247,17 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         st.session_state.pop(SESSION_SPECIES_SEARCH_KEY, None)
 
     if map_view_mode == "species":
-        _ix_sig = (len(ws.species_list), st.session_state.get(EBIRD_DATA_SIG_KEY))
+        tax_loc = (
+            str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
+            or DEFAULT_TAXONOMY_LOCALE
+        )
+        group_names = taxonomy_group_names_in_working_set(ws.species_list, ws.name_map, tax_loc)
+        _ix_sig = (len(ws.species_list), st.session_state.get(EBIRD_DATA_SIG_KEY), tax_loc)
         if st.session_state.get(SESSION_SPECIES_IX_SIG_KEY) != _ix_sig:
             st.session_state[SESSION_SPECIES_IX_KEY] = build_ram_species_whoosh_index(
-                ws.species_list, ws.name_map
+                ws.species_list,
+                ws.name_map,
+                taxonomy_group_names=group_names,
             )
             st.session_state[SESSION_SPECIES_IX_SIG_KEY] = _ix_sig
         st.session_state[SESSION_SPECIES_WS_KEY] = ws
@@ -268,6 +285,9 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             st.session_state.pop(PERSIST_SPECIES_SCI_KEY, None)
     else:
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
+        st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
+        st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
+        st.session_state.pop(SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY, None)
 
     if map_view_mode == "families":
         from explorer.app.streamlit.app_caches import cached_family_map_bundle

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -24,9 +24,6 @@ from explorer.app.streamlit.app_constants import (
     SESSION_SPECIES_IX_KEY,
     SESSION_SPECIES_IX_SIG_KEY,
     SESSION_SPECIES_PICK_KEY,
-    SESSION_SPECIES_GROUP_PENDING_KEY,
-    SESSION_SPECIES_GROUP_SEL_COMMIT_KEY,
-    SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY,
     SESSION_SPECIES_SEARCH_KEY,
     SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY,
     SESSION_SPECIES_WS_KEY,
@@ -76,7 +73,6 @@ from explorer.app.streamlit.streamlit_ui_constants import (
 from explorer.core.species_search import (
     SPECIES_WHOOSH_INDEX_VERSION,
     build_ram_species_whoosh_index,
-    taxonomy_group_names_in_working_set,
 )
 
 
@@ -257,7 +253,6 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
             or DEFAULT_TAXONOMY_LOCALE
         )
-        group_names = taxonomy_group_names_in_working_set(ws.species_list, ws.name_map, tax_loc)
         _ix_sig = (
             SPECIES_WHOOSH_INDEX_VERSION,
             len(ws.species_list),
@@ -268,7 +263,6 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             st.session_state[SESSION_SPECIES_IX_KEY] = build_ram_species_whoosh_index(
                 ws.species_list,
                 ws.name_map,
-                taxonomy_group_names=group_names,
                 taxonomy_locale=tax_loc,
             )
             st.session_state[SESSION_SPECIES_IX_SIG_KEY] = _ix_sig
@@ -301,9 +295,6 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             st.session_state.pop(PERSIST_SPECIES_SCI_KEY, None)
     else:
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
-        st.session_state.pop(SESSION_SPECIES_GROUP_PENDING_KEY, None)
-        st.session_state.pop(SESSION_SPECIES_GROUP_SEL_COMMIT_KEY, None)
-        st.session_state.pop(SESSION_SPECIES_GROUP_SPECIES_SELECT_KEY, None)
 
     if map_view_mode == "families":
         from explorer.app.streamlit.app_caches import cached_family_map_bundle

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -48,7 +48,6 @@ from explorer.app.streamlit.app_constants import (
 )
 from explorer.app.streamlit.app_map_ui import (
     ensure_streamlit_map_basemap_height_keys,
-    inject_sidebar_control_label_css,
     inject_spinner_theme_css,
     species_searchbox_fragment,
 )
@@ -70,7 +69,10 @@ from explorer.app.streamlit.map_working import (
     date_inception_to_today_default,
     streamlit_working_set_and_status,
 )
-from explorer.app.streamlit.streamlit_ui_constants import SPECIES_SEARCH_CAPTION
+from explorer.app.streamlit.streamlit_ui_constants import (
+    SPECIES_SEARCH_CAPTION,
+    SPECIES_SEARCH_HELP_EXPANDER_LABEL,
+)
 from explorer.core.species_search import (
     build_ram_species_whoosh_index,
     taxonomy_group_names_in_working_set,
@@ -118,7 +120,6 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
     apply_pending_map_height_override(st.session_state)
 
     inject_spinner_theme_css()
-    inject_sidebar_control_label_css()
 
     with st.sidebar:
         st.header("Map")
@@ -268,7 +269,11 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
 
         with st.sidebar:
             st.markdown("**Species**")
-            st.caption(SPECIES_SEARCH_CAPTION)
+            with st.expander(SPECIES_SEARCH_HELP_EXPANDER_LABEL, expanded=False):
+                # Match Yearly Summary helper line (``st.caption`` for “Showing results…”).
+                for _para in (p.strip() for p in SPECIES_SEARCH_CAPTION.split("\n\n")):
+                    if _para:
+                        st.caption(_para)
             species_searchbox_fragment()
             hide_non_matching_locations = st.toggle(
                 "Show only selected species",

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -250,9 +250,7 @@ def render_prep_spinner_and_map_tab(
                     )
                     overlay_sci = (species_pick_sci or "").strip() if map_view_mode == "species" else ""
                     hide_nm = (
-                        map_view_mode == "species"
-                        and bool(overlay_sci)
-                        and hide_non_matching_locations
+                        map_view_mode == "species" and bool(hide_non_matching_locations)
                     )
                     _map_kw = {
                         **ctx,
@@ -315,7 +313,8 @@ def render_prep_spinner_and_map_tab(
                     _species_selected = bool(overlay_sci)
                     _cache_map_view_mode = map_view_mode
                     if map_view_mode == "species" and not _species_selected:
-                        _cache_map_view_mode = "all"
+                        if not hide_non_matching_locations:
+                            _cache_map_view_mode = "all"
                     _ck = static_map_cache_key(
                         work_df,
                         _cache_map_view_mode,

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -64,6 +64,10 @@ MAP_DATE_FILTER_DEFAULT = False
 
 MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Species locations", "Lifer locations", "Family locations")
 
+# refs #73 Prototype 2: one searchbox for group → species (no second selectbox). Set False to use
+# Prototype 1 (group row + separate ``st.selectbox``) without reverting git.
+SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2: bool = True
+
 # ---------------------------------------------------------------------------
 # Family map (Map view → **Family locations**; refs #138)
 #

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -62,6 +62,9 @@ MAP_HEIGHT_PX_STEP = 20
 
 MAP_DATE_FILTER_DEFAULT = False
 
+# Species locations: when True, the map shows only pins for the selected species (session-only sidebar toggle).
+MAP_SPECIES_HIDE_ONLY_DEFAULT = True
+
 MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Species locations", "Lifer locations", "Family locations")
 
 # ---------------------------------------------------------------------------

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -64,10 +64,6 @@ MAP_DATE_FILTER_DEFAULT = False
 
 MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Species locations", "Lifer locations", "Family locations")
 
-# refs #73 Prototype 2: one searchbox for group → species (no second selectbox). Set False to use
-# Prototype 1 (group row + separate ``st.selectbox``) without reverting git.
-SPECIES_MAP_GROUP_SEARCH_PROTOTYPE2: bool = True
-
 # ---------------------------------------------------------------------------
 # Family map (Map view → **Family locations**; refs #138)
 #

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -62,7 +62,7 @@ MAP_HEIGHT_PX_STEP = 20
 
 MAP_DATE_FILTER_DEFAULT = False
 
-MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Selected species", "Lifer locations", "Family locations")
+MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Species locations", "Lifer locations", "Family locations")
 
 # ---------------------------------------------------------------------------
 # Family map (Map view → **Family locations**; refs #138)

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -32,7 +32,7 @@ SPECIES_SEARCH_CAPTION = """Start typing to search for a species.
 
 You can use common names, scientific names, or bird groups (e.g. Australasian Robins).
 
-Tip: Turning on "Show only selected species" can improve map performance."""
+Tip: "Show only selected species" defaults to on for performance; turn it off to see all locations with the selected species highlighted."""
 # Sidebar expander title (Map → Species locations); body is SPECIES_SEARCH_CAPTION.
 SPECIES_SEARCH_HELP_EXPANDER_LABEL = "Search tips"
 SPECIES_SEARCH_EDIT_AFTER_SUBMIT = "option"

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -28,7 +28,8 @@ SPECIES_SEARCH_MIN_QUERY_LEN = 3
 SPECIES_SEARCH_DEBOUNCE_MS = 400
 SPECIES_SEARCH_PLACEHOLDER = "Type species name…"
 SPECIES_SEARCH_CAPTION = (
-    "Type at least three letters. Searches common and scientific names."
+    "Type at least three letters. Searches common and scientific names, and eBird species groups "
+    "(e.g. Australasian Robins). Pick a group to choose one species from your data."
 )
 SPECIES_SEARCH_EDIT_AFTER_SUBMIT = "option"
 SPECIES_SEARCH_RERUN_SCOPE = "fragment"

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -25,7 +25,7 @@ CHECKLIST_STATS_TOP_N_TABLE_LIMIT = 200
 
 SPECIES_SEARCH_MAX_OPTIONS = 12
 SPECIES_SEARCH_MIN_QUERY_LEN = 3
-SPECIES_SEARCH_DEBOUNCE_MS = 400
+SPECIES_SEARCH_DEBOUNCE_MS = 500
 SPECIES_SEARCH_PLACEHOLDER = "Type species name…"
 SPECIES_SEARCH_CAPTION = (
     "Type at least three letters. Searches common and scientific names, and eBird species groups "

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -27,6 +27,7 @@ SPECIES_SEARCH_MAX_OPTIONS = 12
 SPECIES_SEARCH_MIN_QUERY_LEN = 3
 SPECIES_SEARCH_DEBOUNCE_MS = 500
 SPECIES_SEARCH_PLACEHOLDER = "Type species name…"
+SPECIES_SEARCH_PLACEHOLDER_GROUP_FILTERED = "Type to filter species in this group…"
 # Map sidebar “Search tips” expander: paragraphs separated by blank lines; rendered with ``st.caption``.
 SPECIES_SEARCH_CAPTION = """Start typing to search for a species.
 

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -27,10 +27,16 @@ SPECIES_SEARCH_MAX_OPTIONS = 12
 SPECIES_SEARCH_MIN_QUERY_LEN = 3
 SPECIES_SEARCH_DEBOUNCE_MS = 500
 SPECIES_SEARCH_PLACEHOLDER = "Type species name…"
-SPECIES_SEARCH_CAPTION = (
-    "Type at least three letters. Searches common and scientific names, and eBird species groups "
-    "(e.g. Australasian Robins). Pick a group to choose one species from your data."
-)
+# Map sidebar “Search tips” expander: paragraphs separated by blank lines; rendered with ``st.caption``.
+SPECIES_SEARCH_CAPTION = """Start typing to search for a species.
+
+You can use common names, scientific names, or bird groups (e.g. Australasian Robins).
+
+If you select a group, you'll then be able to choose a species from your data.
+
+Tip: Turning on "Show only selected species" can improve map performance."""
+# Sidebar expander title (Map → Species locations); body is SPECIES_SEARCH_CAPTION.
+SPECIES_SEARCH_HELP_EXPANDER_LABEL = "Search tips"
 SPECIES_SEARCH_EDIT_AFTER_SUBMIT = "option"
 SPECIES_SEARCH_RERUN_SCOPE = "fragment"
 

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -27,13 +27,10 @@ SPECIES_SEARCH_MAX_OPTIONS = 12
 SPECIES_SEARCH_MIN_QUERY_LEN = 3
 SPECIES_SEARCH_DEBOUNCE_MS = 500
 SPECIES_SEARCH_PLACEHOLDER = "Type species name…"
-SPECIES_SEARCH_PLACEHOLDER_GROUP_FILTERED = "Type to filter species in this group…"
 # Map sidebar “Search tips” expander: paragraphs separated by blank lines; rendered with ``st.caption``.
 SPECIES_SEARCH_CAPTION = """Start typing to search for a species.
 
 You can use common names, scientific names, or bird groups (e.g. Australasian Robins).
-
-If you select a group, you'll then be able to choose a species from your data.
 
 Tip: Turning on "Show only selected species" can improve map performance."""
 # Sidebar expander title (Map → Species locations); body is SPECIES_SEARCH_CAPTION.

--- a/explorer/core/__init__.py
+++ b/explorer/core/__init__.py
@@ -41,7 +41,6 @@ from typing import TYPE_CHECKING, Any
 # checkers and many IDEs without changing runtime imports.
 if TYPE_CHECKING:  # pragma: no cover
     from explorer.core.map_controller import MapOverlayResult, build_species_overlay_map
-    from explorer.core.species_search import whoosh_common_name_suggestions
     from explorer.presentation.checklist_stats_display import (
         format_checklist_stats_bundle,
         format_rankings_tab_html,
@@ -120,10 +119,6 @@ from explorer.presentation.maintenance_display import (
 # Whoosh / Folium are heavy optional stacks for search + map UIs. Lazy-load so
 # lightweight imports do not require whoosh or folium installed.
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
-    "whoosh_common_name_suggestions": (
-        "explorer.core.species_search",
-        "whoosh_common_name_suggestions",
-    ),
     "MapOverlayResult": ("explorer.core.map_controller", "MapOverlayResult"),
     "build_species_overlay_map": (
         "explorer.core.map_controller",
@@ -225,5 +220,4 @@ __all__ = [
     "format_map_maintenance_html",
     "format_sex_notation_maintenance_html",
     "format_incomplete_checklists_maintenance_html",
-    "whoosh_common_name_suggestions",
 ]

--- a/explorer/core/map_controller.py
+++ b/explorer/core/map_controller.py
@@ -96,6 +96,10 @@ def build_species_overlay_map(
     *cluster_all_locations*: when there is no species filter (All locations view),
     group nearby pins with Leaflet.markercluster. Ignored for species and lifer maps.
 
+    *hide_non_matching_locations*: in **Species locations** view with no species selected, when
+    ``False`` the map behaves like **All locations**; when ``True`` an empty map is shown until a
+    species is chosen (performance-friendly default in the Streamlit UI).
+
     *map_height_px*: pixel height for the Folium map pane (match Streamlit **Map height** slider).
     """
     tax_loc_key = (taxonomy_locale or "").strip()
@@ -103,7 +107,8 @@ def build_species_overlay_map(
     if mode not in VALID_MAP_VIEWS:
         mode = "all"
     if mode == "species" and not (selected_species or "").strip():
-        mode = "all"
+        if not hide_non_matching_locations:
+            mode = "all"
 
     if mode == "lifers":
         return build_lifer_overlay_map(

--- a/explorer/core/map_overlay_visit_map.py
+++ b/explorer/core/map_overlay_visit_map.py
@@ -28,6 +28,7 @@ from explorer.presentation.map_renderer import (
     build_legend_html,
     build_location_popup_html,
     build_species_banner_html,
+    build_species_locations_awaiting_selection_banner_html,
     build_visit_info_html,
     classify_locations,
     create_map,
@@ -103,11 +104,33 @@ def build_visit_overlay_map(
             effective_location_data["Longitude"].mean(),
         ]
 
+    popup_ascending = popup_sort_order == "ascending"
+    date_filter_status_line = date_filter_status or None
+
+    if not selected_species and hide_non_matching_locations:
+        if effective_location_data.empty:
+            lat, lon = -25.0, 134.0
+        else:
+            lat = float(effective_location_data["Latitude"].mean())
+            lon = float(effective_location_data["Longitude"].mean())
+            if pd.isna(lat) or pd.isna(lon):
+                lat, lon = -25.0, 134.0
+        map_center_empty = [lat, lon]
+        species_map = create_map(map_center_empty, map_style, height_px=map_height_px)
+        inject_map_overlay_theme(species_map)
+        add_zoom_level_debug_overlay(species_map, enabled=MAP_DEBUG_SHOW_ZOOM_LEVEL)
+        species_map.get_root().html.add_child(
+            Element(build_species_locations_awaiting_selection_banner_html(date_filter_status_line))
+        )
+        scroll_popup_script = popup_scroll_script(
+            popup_scroll_hint, popup_sort_order == "ascending"
+        )
+        species_map.get_root().html.add_child(Element(scroll_popup_script))
+        return MapOverlayResult(species_map, None)
+
     species_map = create_map(map_center, map_style, height_px=map_height_px)
     inject_map_overlay_theme(species_map)
     add_zoom_level_debug_overlay(species_map, enabled=MAP_DEBUG_SHOW_ZOOM_LEVEL)
-    popup_ascending = popup_sort_order == "ascending"
-    date_filter_status_line = date_filter_status or None
 
     if not selected_species:
         tc, ts, ti = effective_totals

--- a/explorer/core/species_search.py
+++ b/explorer/core/species_search.py
@@ -1,101 +1,89 @@
-"""
-Whoosh-backed species name suggestions for the map species picker (autocomplete-style).
+"""Whoosh-backed species suggestions for the map species picker (autocomplete-style).
 
 Pure helper with no UI imports: the app feeds suggestions into Streamlit widgets. Indexes store
-**common_name**, **scientific_name**, and per-species **taxonomy_group** tokens so global search can
-surface groups the same way as names. **taxonomy_group_key** (ID) scopes constrained search after the
-user picks a ``… (group)`` row so suggestions use the same Whoosh token logic as unrestricted search
-(refs #73).
+**common_name**, **scientific_name**, and derived per-species **taxonomy_group** text so global
+search can behave as a weighted helper (refs #73).
 """
 
 from __future__ import annotations
 
+import re
 import tempfile
 from typing import Any, Dict, List, Sequence
 
 from whoosh.analysis import StemmingAnalyzer
-from whoosh.fields import ID, Schema, TEXT
+from whoosh.fields import Schema, TEXT
 from whoosh.index import create_in
 from whoosh.qparser import MultifieldParser, OrGroup, QueryParser
-from whoosh.query import And, Every, Term
-from whoosh.sorting import FieldFacet
 
 from explorer.core.species_family import build_base_species_to_family_map
 from explorer.core.species_logic import base_species_name
 
-GROUP_ROW_SUFFIX = " (group)"
-
 # Bump when the RAM index schema or document shape changes (Streamlit map sidebar).
-SPECIES_WHOOSH_INDEX_VERSION = 2
+SPECIES_WHOOSH_INDEX_VERSION = 3
+
+# --- Map species suggestion ranking (``whoosh_species_suggestions``) ---
+# Whoosh returns a BM25-ish *base* score per document. We then add hand-tuned bonuses so behavior
+# matches “helper” expectations: prefer multi-token coverage, then visible common-name matches, then
+# scientific / taxonomy-group hints. Rough magnitudes (same unit, summed):
+#   base score        — from Whoosh (field weights + term frequency; not a fixed scale).
+#   coverage          — reward rows that match more query tokens anywhere (+/- below).
+#   common name       — small extra when a token hits **common_name** (user-visible) vs only sci/group.
+#   field hints       — starts-with / substring boosts for common, sci, taxonomy_group.
+#   length            — tiny tie-break (shorter common name).
+#   spuh-style name   — penalty when common name looks like ``… sp.`` / ``… spp.`` (still shown).
+#   trailing (…)      — subtle penalty for ``Name (Qualifier)`` (subspecies / regional eBird forms)
+#                       so nominate ``Name`` ranks slightly ahead when both match the same query.
+# Tune constants below to shift behavior without changing query logic; add tests when fixing a
+# specific ranking regression.
+RANK_COVERAGE_PER_MATCHED_TOKEN = 20.0
+RANK_COVERAGE_PER_MISSING_TOKEN = 18.0
+RANK_COMMON_STARTSWITH_FIRST_TOKEN = 30.0
+RANK_SCI_PREFIX_OR_SUBTOKEN = 22.0
+# Slightly lower than common-name substring bonus so “Australian …” in the visible name wins over
+# “Australasian …” in taxonomy_group alone for prefixes like ``austr``.
+RANK_GROUP_STARTSWITH_FIRST_TOKEN = 10.0
+RANK_GROUP_ANY_TOKEN_SUBSTRING = 8.0
+# Prefer matches users see in the picker label (mitigates e.g. *australis* ranking without “Australian” in common).
+RANK_COMMON_PER_TOKEN_SUBSTRING = 18.0
+RANK_LENGTH_TIEBREAK_PER_CHAR = 0.001
+# Deprioritize eBird-style species spuhs in the picker; does not remove them from results.
+RANK_SPUH_STYLE_COMMON_NAME_PENALTY = 52.0
+# Subtle vs spuh: nominate vs ``Eastern Yellow Robin (Southeastern)`` when both hit the same tokens.
+RANK_TRAILING_PAREN_QUALIFIER_PENALTY = 10.0
 
 
 def species_whoosh_schema() -> Schema:
-    """Schema for species autocomplete (common + scientific + group tokens) and group picker rows."""
+    """Schema for weighted species autocomplete (common + scientific + taxonomy-group)."""
     ana = StemmingAnalyzer()
     return Schema(
         common_name=TEXT(stored=True, analyzer=ana),
         scientific_name=TEXT(stored=True, analyzer=ana),
-        # Indexed group label on **species** rows for global multifield search; same on group rows.
         taxonomy_group=TEXT(stored=True, analyzer=ana),
-        # Exact eBird species-group label for post-pick filtering (ID = single token, no stemming).
-        taxonomy_group_key=ID(stored=True),
-        kind=ID(stored=True),
     )
 
 
-def taxonomy_group_names_in_working_set(
-    species_list: Sequence[str],
-    name_map: Dict[str, str],
-    taxonomy_locale: str,
-) -> List[str]:
-    """Distinct eBird species-group names that have at least one species in *species_list*.
+def _common_name_is_species_spuh_style(common: str) -> bool:
+    """True for typical eBird species-level spuh labels (``… sp.``, ``… spp.``)."""
+    c = (common or "").strip().lower()
+    return c.endswith(" sp.") or c.endswith(" spp.")
 
-    Uses the same base-species → group mapping as Rankings **Families**. Returns sorted
-    display names (excludes *Unmapped*). Empty when taxonomy cannot be loaded.
-    """
-    base_to_f = build_base_species_to_family_map(taxonomy_locale)
-    if not base_to_f:
+
+def _common_name_has_trailing_parenthetical_qualifier(common: str) -> bool:
+    """True for common names ending with a parenthetical qualifier (subspecies, regional, etc.)."""
+    c = (common or "").strip()
+    if not c or "(" not in c:
+        return False
+    return bool(re.search(r".+\([^)]+\)\s*$", c))
+
+
+def _query_tokens(raw_query: str) -> List[str]:
+    """Normalize user query into prefix-search tokens (hyphen-safe)."""
+    q = (raw_query or "").strip().lower()
+    if not q:
         return []
-    seen: set[str] = set()
-    out: list[str] = []
-    for common in species_list:
-        sci = str(name_map.get(common, "") or "")
-        base = base_species_name(sci)
-        if not base:
-            continue
-        g = base_to_f.get(base)
-        if not g or str(g).strip() == "Unmapped":
-            continue
-        gn = str(g).strip()
-        if gn not in seen:
-            seen.add(gn)
-            out.append(gn)
-    out.sort(key=str.casefold)
-    return out
-
-
-def species_common_names_in_group(
-    species_list: Sequence[str],
-    name_map: Dict[str, str],
-    taxonomy_locale: str,
-    group_name: str,
-) -> List[str]:
-    """Common names in *species_list* whose taxonomy group equals *group_name*."""
-    base_to_f = build_base_species_to_family_map(taxonomy_locale)
-    if not base_to_f:
-        return []
-    want = str(group_name).strip()
-    out: list[str] = []
-    for common in species_list:
-        sci = str(name_map.get(common, "") or "")
-        base = base_species_name(sci)
-        if not base:
-            continue
-        g = base_to_f.get(base)
-        if g and str(g).strip() == want:
-            out.append(common)
-    out.sort(key=str.casefold)
-    return out
+    # Treat punctuation (e.g. scrub-bird) as separators, not query operators.
+    return [t for t in re.findall(r"[a-z0-9]+", q) if t]
 
 
 def _common_to_taxonomy_group_key(
@@ -127,18 +115,13 @@ def build_ram_species_whoosh_index(
     species_list: Sequence[str],
     name_map: Dict[str, str],
     *,
-    taxonomy_group_names: Sequence[str] | None = None,
     taxonomy_locale: str | None = None,
 ) -> Any:
     """
     Build a small Whoosh index from unique common names and common→scientific map.
 
     When *taxonomy_locale* is set, each species row stores its eBird species-group label on
-    **taxonomy_group** / **taxonomy_group_key** so global search can match group words and
-    constrained search can filter with Whoosh (refs #73).
-
-    When *taxonomy_group_names* is non-empty, each label is indexed as a synthetic row
-    ``"{label} (group)"`` so it appears in the same type-ahead as species.
+    **taxonomy_group** so global search can give helper-style weight to family/group words.
 
     Uses a temporary directory (cleaned up by the OS); fine for Streamlit session use
     per working-set rebuild. Notebook uses a persistent temp dir with the same schema.
@@ -157,20 +140,6 @@ def build_ram_species_whoosh_index(
             common_name=common,
             scientific_name=sci,
             taxonomy_group=gkey,
-            taxonomy_group_key=gkey,
-            kind="species",
-        )
-    for g in taxonomy_group_names or ():
-        label = str(g).strip()
-        if not label:
-            continue
-        display = f"{label}{GROUP_ROW_SUFFIX}"
-        w.add_document(
-            common_name=display,
-            scientific_name=label,
-            taxonomy_group=label,
-            taxonomy_group_key=label,
-            kind="group",
         )
     w.commit()
     return ix
@@ -194,7 +163,7 @@ def whoosh_common_name_suggestions(
     q = (raw_query or "").strip().lower()
     if len(q) < min_query_len:
         return []
-    tokens = q.split()
+    tokens = _query_tokens(q)
     if not tokens:
         return []
     with whoosh_index.searcher() as searcher:
@@ -216,156 +185,32 @@ def whoosh_common_name_suggestions(
         return [r[field_name] for r in ranked[:max_options]]
 
 
-def normalize_query_for_group_filtered_mode(
-    raw_query: str,
-    selected_group_label: str,
-    *,
-    group_row_suffix: str = GROUP_ROW_SUFFIX,
-) -> str:
-    """Map searchbox text to the query used for in-group species suggestions (refs #73 Prototype 2).
-
-    After the user picks a taxonomy group, the widget often keeps the submitted row
-    ``"{label} (group)"`` in the field. That string must not be used as a filter substring or
-    no species names match — treat it (and a bare *selected_group_label* match) as **no** filter
-    so the dropdown can show the alphabetical species list.
-    """
-    want = (selected_group_label or "").strip()
-    if not want:
-        return (raw_query or "").strip()
-    t = (raw_query or "").strip()
-    if not t:
-        return ""
-    if t.casefold() == want.casefold():
-        return ""
-    if t.endswith(group_row_suffix):
-        base = t[: -len(group_row_suffix)].strip()
-        if base.casefold() == want.casefold():
-            return ""
-    return t
-
-
-def species_in_group_search_suggestions(
-    species_common_names: Sequence[str],
-    raw_query: str,
-    *,
-    max_options: int = 12,
-) -> List[str]:
-    """Filter *species_common_names* for Prototype 2 group-filtered search (refs #73).
-
-    Sorted alphabetically. Empty query returns the first *max_options* names so the dropdown is
-    usable without typing. Non-empty query keeps names whose common name contains the query
-    (case-insensitive).
-    """
-    names = sorted({str(x).strip() for x in species_common_names if str(x).strip()}, key=str.casefold)
-    q = (raw_query or "").strip().lower()
-    if not q:
-        return names[:max_options]
-    matched = [n for n in names if q in n.lower()]
-    return matched[:max_options]
-
-
 def whoosh_species_suggestions(
     whoosh_index: Any,
     raw_query: str,
     *,
     max_options: int = 12,
     min_query_len: int = 3,
-    restrict_taxonomy_group: str | None = None,
 ) -> List[str]:
     """
     Return common names matching *raw_query* across **common** and **scientific** name fields.
 
-    Global mode also searches **taxonomy_group** so tokens from the eBird species-group label
-    match species rows (and the synthetic ``… (group)`` row) in one pass.
-
-    When *restrict_taxonomy_group* is set (after the user picks a group row), only **species**
-    documents in that group are considered; the same token/prefix rules apply to common and
-    scientific names. Short queries inside a group use ``min_query_len`` of 1 so typing can
-    narrow without the global 3-character gate.
+    Also searches **taxonomy_group** so family/group terms act as a weighted helper for species
+    suggestions in a single control.
 
     Token query uses prefix matching per token (``token*``), combined with OR across fields
-    via :class:`~whoosh.qparser.MultifieldParser`. Results are ranked to prefer:
+    via :class:`~whoosh.qparser.MultifieldParser`. Ranking is documented in module constants
+    ``RANK_*`` (see :mod:`explorer.core.species_search`): Whoosh base score plus coverage,
+    a small **common-name** preference, then scientific/taxonomy-group hints and a length tie-break.
 
-    - stronger Whoosh score
-    - common name starting with the first token
-    - shorter common names (slight tie-break)
+    **Reasoning about behavior:** compare relative constant sizes — e.g. raising
+    ``RANK_COMMON_PER_TOKEN_SUBSTRING`` pulls results whose **display name** contains query
+    fragments ahead of rows that only match *Eopsaltria australis*-style scientific names.
     """
-    rg = str(restrict_taxonomy_group or "").strip()
-    if rg:
-        raw_query = normalize_query_for_group_filtered_mode(raw_query, rg)
-        eff_min = 1
-    else:
-        eff_min = min_query_len
-
     q = (raw_query or "").strip().lower()
-    if rg:
-        species_filter = And([Term("kind", "species"), Term("taxonomy_group_key", rg)])
-        with whoosh_index.searcher() as searcher:
-            if not q:
-                try:
-                    q_all = And([Every(), species_filter])
-                    results = searcher.search(
-                        q_all,
-                        limit=max_options,
-                        sortedby=FieldFacet("common_name"),
-                    )
-                except Exception:
-                    return []
-                return [r["common_name"] for r in results if r.get("common_name")]
-
-            if len(q) < eff_min:
-                return []
-            tokens = q.split()
-            if not tokens:
-                return []
-            mp = MultifieldParser(
-                ["common_name", "scientific_name"],
-                whoosh_index.schema,
-                group=OrGroup,
-            )
-            try:
-                parsed = mp.parse(" ".join(f"{t}*" for t in tokens))
-            except Exception:
-                return []
-            try:
-                combined = And([parsed, species_filter])
-                results = searcher.search(combined, limit=None)
-            except Exception:
-                return []
-
-            def rank_key(r):
-                common = (r["common_name"] or "").lower()
-                sci = (r.get("scientific_name") or "").lower()
-                base = getattr(r, "score", None)
-                if base is None:
-                    base = 100.0 - float(r.rank)
-                else:
-                    base = float(base)
-                if common.startswith(tokens[0]):
-                    base += 50.0
-                elif sci.startswith(tokens[0]) or any(
-                    sci.startswith(t) or f" {t}" in sci for t in tokens
-                ):
-                    base += 35.0
-                base -= len(common) * 0.001
-                return base
-
-            ranked = sorted(results, key=rank_key, reverse=True)
-            out: List[str] = []
-            seen: set[str] = set()
-            for r in ranked:
-                cn = r["common_name"]
-                if cn and cn not in seen:
-                    seen.add(cn)
-                    out.append(cn)
-                if len(out) >= max_options:
-                    break
-            return out
-
-    # --- global (unrestricted) ---
-    if len(q) < eff_min:
+    if len(q) < min_query_len:
         return []
-    tokens = q.split()
+    tokens = _query_tokens(q)
     if not tokens:
         return []
     fields = ["common_name", "scientific_name", "taxonomy_group"]
@@ -380,24 +225,37 @@ def whoosh_species_suggestions(
         def rank_key(r):
             common = (r["common_name"] or "").lower()
             sci = (r.get("scientific_name") or "").lower()
-            kind = (r.get("kind") or "species").strip()
+            grp = (r.get("taxonomy_group") or "").lower()
+            combined = f"{common} {sci} {grp}"
             # Base: Whoosh relevance (higher is better for BM25F default scoring)
             base = getattr(r, "score", None)
             if base is None:
                 base = 100.0 - float(r.rank)
             else:
                 base = float(base)
+            matched_tokens = sum(1 for t in tokens if t in combined)
+            # Prefer suggestions that satisfy more typed tokens, not just the first token.
+            base += matched_tokens * RANK_COVERAGE_PER_MATCHED_TOKEN
+            base -= (len(tokens) - matched_tokens) * RANK_COVERAGE_PER_MISSING_TOKEN
+            common_token_hits = sum(1 for t in tokens if t in common)
+            base += common_token_hits * RANK_COMMON_PER_TOKEN_SUBSTRING
             if common.startswith(tokens[0]):
-                base += 50.0
+                base += RANK_COMMON_STARTSWITH_FIRST_TOKEN
             elif sci.startswith(tokens[0]) or any(
                 sci.startswith(t) or f" {t}" in sci for t in tokens
             ):
-                base += 35.0
-            # Slight preference for species rows over taxonomy-group rows when scores are close
-            if kind == "group":
-                base -= 1.5
+                base += RANK_SCI_PREFIX_OR_SUBTOKEN
+            # Family/group is helper intent: boost if query tokens clearly match taxonomy group text.
+            if grp.startswith(tokens[0]):
+                base += RANK_GROUP_STARTSWITH_FIRST_TOKEN
+            if any(t in grp for t in tokens):
+                base += RANK_GROUP_ANY_TOKEN_SUBSTRING
+            if _common_name_is_species_spuh_style(r["common_name"]):
+                base -= RANK_SPUH_STYLE_COMMON_NAME_PENALTY
+            if _common_name_has_trailing_parenthetical_qualifier(r["common_name"]):
+                base -= RANK_TRAILING_PAREN_QUALIFIER_PENALTY
             # Prefer shorter display names when scores tie
-            base -= len(common) * 0.001
+            base -= len(common) * RANK_LENGTH_TIEBREAK_PER_CHAR
             return base
 
         ranked = sorted(results, key=rank_key, reverse=True)

--- a/explorer/core/species_search.py
+++ b/explorer/core/species_search.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Sequence
 from whoosh.analysis import StemmingAnalyzer
 from whoosh.fields import Schema, TEXT
 from whoosh.index import create_in
-from whoosh.qparser import MultifieldParser, OrGroup, QueryParser
+from whoosh.qparser import MultifieldParser, OrGroup
 
 from explorer.core.species_family import build_base_species_to_family_map
 from explorer.core.species_logic import base_species_name
@@ -143,46 +143,6 @@ def build_ram_species_whoosh_index(
         )
     w.commit()
     return ix
-
-
-def whoosh_common_name_suggestions(
-    whoosh_index: Any,
-    raw_query: str,
-    *,
-    field_name: str = "common_name",
-    max_options: int = 6,
-    min_query_len: int = 3,
-) -> List[str]:
-    """Return up to *max_options* common-name strings matching *raw_query* (prefix-style per token).
-
-    Uses a single field (default ``common_name``). For indexes with both fields, prefer
-    :func:`whoosh_species_suggestions`.
-
-    Empty list when query is too short, parse fails, or there are no hits.
-    """
-    q = (raw_query or "").strip().lower()
-    if len(q) < min_query_len:
-        return []
-    tokens = _query_tokens(q)
-    if not tokens:
-        return []
-    with whoosh_index.searcher() as searcher:
-        qp = QueryParser(field_name, whoosh_index.schema, group=OrGroup)
-        try:
-            parsed = qp.parse(" ".join(f"{t}*" for t in tokens))
-        except Exception:
-            return []
-        results = searcher.search(parsed, limit=None)
-
-        def score(r):
-            name = r[field_name].lower()
-            base = 100 - r.rank
-            if name.startswith(tokens[0]):
-                base += 50
-            return base
-
-        ranked = sorted(results, key=score, reverse=True)
-        return [r[field_name] for r in ranked[:max_options]]
 
 
 def whoosh_species_suggestions(

--- a/explorer/core/species_search.py
+++ b/explorer/core/species_search.py
@@ -2,9 +2,10 @@
 Whoosh-backed species name suggestions for the map species picker (autocomplete-style).
 
 Pure helper with no UI imports: the app feeds suggestions into Streamlit widgets. Indexes store
-**common_name** and **scientific_name** so queries can match either field (eBird-like multi-token
-search). Optional **group** rows (eBird species-group labels such as “Australasian Robins”) support
-taxonomy-group type-ahead; rows have ``kind="group"`` and display as ``"{name} (group)"`` (refs #73).
+**common_name**, **scientific_name**, and per-species **taxonomy_group** tokens so global search can
+surface groups the same way as names. **taxonomy_group_key** (ID) scopes constrained search after the
+user picks a ``… (group)`` row so suggestions use the same Whoosh token logic as unrestricted search
+(refs #73).
 """
 
 from __future__ import annotations
@@ -13,23 +14,32 @@ import tempfile
 from typing import Any, Dict, List, Sequence
 
 from whoosh.analysis import StemmingAnalyzer
-from whoosh.fields import Schema, TEXT
+from whoosh.fields import ID, Schema, TEXT
 from whoosh.index import create_in
 from whoosh.qparser import MultifieldParser, OrGroup, QueryParser
+from whoosh.query import And, Every, Term
+from whoosh.sorting import FieldFacet
 
 from explorer.core.species_family import build_base_species_to_family_map
 from explorer.core.species_logic import base_species_name
 
 GROUP_ROW_SUFFIX = " (group)"
 
+# Bump when the RAM index schema or document shape changes (Streamlit map sidebar).
+SPECIES_WHOOSH_INDEX_VERSION = 2
+
 
 def species_whoosh_schema() -> Schema:
-    """Schema for species autocomplete (common + scientific names) and optional group labels."""
+    """Schema for species autocomplete (common + scientific + group tokens) and group picker rows."""
     ana = StemmingAnalyzer()
     return Schema(
         common_name=TEXT(stored=True, analyzer=ana),
         scientific_name=TEXT(stored=True, analyzer=ana),
-        kind=TEXT(stored=True),
+        # Indexed group label on **species** rows for global multifield search; same on group rows.
+        taxonomy_group=TEXT(stored=True, analyzer=ana),
+        # Exact eBird species-group label for post-pick filtering (ID = single token, no stemming).
+        taxonomy_group_key=ID(stored=True),
+        kind=ID(stored=True),
     )
 
 
@@ -88,17 +98,47 @@ def species_common_names_in_group(
     return out
 
 
+def _common_to_taxonomy_group_key(
+    species_list: Sequence[str],
+    name_map: Dict[str, str],
+    taxonomy_locale: str,
+) -> Dict[str, str]:
+    """Map common name → eBird species-group label (empty string if unmapped)."""
+    base_to_f = build_base_species_to_family_map(taxonomy_locale)
+    out: Dict[str, str] = {}
+    if not base_to_f:
+        return {str(c).strip(): "" for c in species_list}
+    for common in species_list:
+        cn = str(common).strip()
+        sci = str(name_map.get(cn, "") or "")
+        base = base_species_name(sci)
+        if not base:
+            out[cn] = ""
+            continue
+        g = base_to_f.get(base)
+        if not g or str(g).strip() == "Unmapped":
+            out[cn] = ""
+        else:
+            out[cn] = str(g).strip()
+    return out
+
+
 def build_ram_species_whoosh_index(
     species_list: Sequence[str],
     name_map: Dict[str, str],
     *,
     taxonomy_group_names: Sequence[str] | None = None,
+    taxonomy_locale: str | None = None,
 ) -> Any:
     """
     Build a small Whoosh index from unique common names and common→scientific map.
 
+    When *taxonomy_locale* is set, each species row stores its eBird species-group label on
+    **taxonomy_group** / **taxonomy_group_key** so global search can match group words and
+    constrained search can filter with Whoosh (refs #73).
+
     When *taxonomy_group_names* is non-empty, each label is indexed as a synthetic row
-    ``"{label} (group)"`` so it appears in the same type-ahead as species (refs #73).
+    ``"{label} (group)"`` so it appears in the same type-ahead as species.
 
     Uses a temporary directory (cleaned up by the OS); fine for Streamlit session use
     per working-set rebuild. Notebook uses a persistent temp dir with the same schema.
@@ -106,15 +146,32 @@ def build_ram_species_whoosh_index(
     index_dir = tempfile.mkdtemp()
     ix = create_in(index_dir, species_whoosh_schema())
     w = ix.writer()
+    loc = (taxonomy_locale or "").strip()
+    common_to_grp: Dict[str, str] = (
+        _common_to_taxonomy_group_key(species_list, name_map, loc) if loc else {}
+    )
     for common in species_list:
         sci = str(name_map.get(common, "") or "")
-        w.add_document(common_name=common, scientific_name=sci, kind="species")
+        gkey = common_to_grp.get(str(common).strip(), "") if loc else ""
+        w.add_document(
+            common_name=common,
+            scientific_name=sci,
+            taxonomy_group=gkey,
+            taxonomy_group_key=gkey,
+            kind="species",
+        )
     for g in taxonomy_group_names or ():
         label = str(g).strip()
         if not label:
             continue
         display = f"{label}{GROUP_ROW_SUFFIX}"
-        w.add_document(common_name=display, scientific_name=label, kind="group")
+        w.add_document(
+            common_name=display,
+            scientific_name=label,
+            taxonomy_group=label,
+            taxonomy_group_key=label,
+            kind="group",
+        )
     w.commit()
     return ix
 
@@ -159,15 +216,72 @@ def whoosh_common_name_suggestions(
         return [r[field_name] for r in ranked[:max_options]]
 
 
+def normalize_query_for_group_filtered_mode(
+    raw_query: str,
+    selected_group_label: str,
+    *,
+    group_row_suffix: str = GROUP_ROW_SUFFIX,
+) -> str:
+    """Map searchbox text to the query used for in-group species suggestions (refs #73 Prototype 2).
+
+    After the user picks a taxonomy group, the widget often keeps the submitted row
+    ``"{label} (group)"`` in the field. That string must not be used as a filter substring or
+    no species names match — treat it (and a bare *selected_group_label* match) as **no** filter
+    so the dropdown can show the alphabetical species list.
+    """
+    want = (selected_group_label or "").strip()
+    if not want:
+        return (raw_query or "").strip()
+    t = (raw_query or "").strip()
+    if not t:
+        return ""
+    if t.casefold() == want.casefold():
+        return ""
+    if t.endswith(group_row_suffix):
+        base = t[: -len(group_row_suffix)].strip()
+        if base.casefold() == want.casefold():
+            return ""
+    return t
+
+
+def species_in_group_search_suggestions(
+    species_common_names: Sequence[str],
+    raw_query: str,
+    *,
+    max_options: int = 12,
+) -> List[str]:
+    """Filter *species_common_names* for Prototype 2 group-filtered search (refs #73).
+
+    Sorted alphabetically. Empty query returns the first *max_options* names so the dropdown is
+    usable without typing. Non-empty query keeps names whose common name contains the query
+    (case-insensitive).
+    """
+    names = sorted({str(x).strip() for x in species_common_names if str(x).strip()}, key=str.casefold)
+    q = (raw_query or "").strip().lower()
+    if not q:
+        return names[:max_options]
+    matched = [n for n in names if q in n.lower()]
+    return matched[:max_options]
+
+
 def whoosh_species_suggestions(
     whoosh_index: Any,
     raw_query: str,
     *,
     max_options: int = 12,
     min_query_len: int = 3,
+    restrict_taxonomy_group: str | None = None,
 ) -> List[str]:
     """
     Return common names matching *raw_query* across **common** and **scientific** name fields.
+
+    Global mode also searches **taxonomy_group** so tokens from the eBird species-group label
+    match species rows (and the synthetic ``… (group)`` row) in one pass.
+
+    When *restrict_taxonomy_group* is set (after the user picks a group row), only **species**
+    documents in that group are considered; the same token/prefix rules apply to common and
+    scientific names. Short queries inside a group use ``min_query_len`` of 1 so typing can
+    narrow without the global 3-character gate.
 
     Token query uses prefix matching per token (``token*``), combined with OR across fields
     via :class:`~whoosh.qparser.MultifieldParser`. Results are ranked to prefer:
@@ -176,13 +290,85 @@ def whoosh_species_suggestions(
     - common name starting with the first token
     - shorter common names (slight tie-break)
     """
+    rg = str(restrict_taxonomy_group or "").strip()
+    if rg:
+        raw_query = normalize_query_for_group_filtered_mode(raw_query, rg)
+        eff_min = 1
+    else:
+        eff_min = min_query_len
+
     q = (raw_query or "").strip().lower()
-    if len(q) < min_query_len:
+    if rg:
+        species_filter = And([Term("kind", "species"), Term("taxonomy_group_key", rg)])
+        with whoosh_index.searcher() as searcher:
+            if not q:
+                try:
+                    q_all = And([Every(), species_filter])
+                    results = searcher.search(
+                        q_all,
+                        limit=max_options,
+                        sortedby=FieldFacet("common_name"),
+                    )
+                except Exception:
+                    return []
+                return [r["common_name"] for r in results if r.get("common_name")]
+
+            if len(q) < eff_min:
+                return []
+            tokens = q.split()
+            if not tokens:
+                return []
+            mp = MultifieldParser(
+                ["common_name", "scientific_name"],
+                whoosh_index.schema,
+                group=OrGroup,
+            )
+            try:
+                parsed = mp.parse(" ".join(f"{t}*" for t in tokens))
+            except Exception:
+                return []
+            try:
+                combined = And([parsed, species_filter])
+                results = searcher.search(combined, limit=None)
+            except Exception:
+                return []
+
+            def rank_key(r):
+                common = (r["common_name"] or "").lower()
+                sci = (r.get("scientific_name") or "").lower()
+                base = getattr(r, "score", None)
+                if base is None:
+                    base = 100.0 - float(r.rank)
+                else:
+                    base = float(base)
+                if common.startswith(tokens[0]):
+                    base += 50.0
+                elif sci.startswith(tokens[0]) or any(
+                    sci.startswith(t) or f" {t}" in sci for t in tokens
+                ):
+                    base += 35.0
+                base -= len(common) * 0.001
+                return base
+
+            ranked = sorted(results, key=rank_key, reverse=True)
+            out: List[str] = []
+            seen: set[str] = set()
+            for r in ranked:
+                cn = r["common_name"]
+                if cn and cn not in seen:
+                    seen.add(cn)
+                    out.append(cn)
+                if len(out) >= max_options:
+                    break
+            return out
+
+    # --- global (unrestricted) ---
+    if len(q) < eff_min:
         return []
     tokens = q.split()
     if not tokens:
         return []
-    fields = ["common_name", "scientific_name"]
+    fields = ["common_name", "scientific_name", "taxonomy_group"]
     with whoosh_index.searcher() as searcher:
         mp = MultifieldParser(fields, whoosh_index.schema, group=OrGroup)
         try:
@@ -215,13 +401,13 @@ def whoosh_species_suggestions(
             return base
 
         ranked = sorted(results, key=rank_key, reverse=True)
-        out: List[str] = []
-        seen = set()
+        out2: List[str] = []
+        seen2: set[str] = set()
         for r in ranked:
             cn = r["common_name"]
-            if cn and cn not in seen:
-                seen.add(cn)
-                out.append(cn)
-            if len(out) >= max_options:
+            if cn and cn not in seen2:
+                seen2.add(cn)
+                out2.append(cn)
+            if len(out2) >= max_options:
                 break
-        return out
+        return out2

--- a/explorer/core/species_search.py
+++ b/explorer/core/species_search.py
@@ -3,7 +3,8 @@ Whoosh-backed species name suggestions for the map species picker (autocomplete-
 
 Pure helper with no UI imports: the app feeds suggestions into Streamlit widgets. Indexes store
 **common_name** and **scientific_name** so queries can match either field (eBird-like multi-token
-search).
+search). Optional **group** rows (eBird species-group labels such as “Australasian Robins”) support
+taxonomy-group type-ahead; rows have ``kind="group"`` and display as ``"{name} (group)"`` (refs #73).
 """
 
 from __future__ import annotations
@@ -16,22 +17,88 @@ from whoosh.fields import Schema, TEXT
 from whoosh.index import create_in
 from whoosh.qparser import MultifieldParser, OrGroup, QueryParser
 
+from explorer.core.species_family import build_base_species_to_family_map
+from explorer.core.species_logic import base_species_name
+
+GROUP_ROW_SUFFIX = " (group)"
+
 
 def species_whoosh_schema() -> Schema:
-    """Schema for species autocomplete (common + scientific names)."""
+    """Schema for species autocomplete (common + scientific names) and optional group labels."""
     ana = StemmingAnalyzer()
     return Schema(
         common_name=TEXT(stored=True, analyzer=ana),
         scientific_name=TEXT(stored=True, analyzer=ana),
+        kind=TEXT(stored=True),
     )
+
+
+def taxonomy_group_names_in_working_set(
+    species_list: Sequence[str],
+    name_map: Dict[str, str],
+    taxonomy_locale: str,
+) -> List[str]:
+    """Distinct eBird species-group names that have at least one species in *species_list*.
+
+    Uses the same base-species → group mapping as Rankings **Families**. Returns sorted
+    display names (excludes *Unmapped*). Empty when taxonomy cannot be loaded.
+    """
+    base_to_f = build_base_species_to_family_map(taxonomy_locale)
+    if not base_to_f:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for common in species_list:
+        sci = str(name_map.get(common, "") or "")
+        base = base_species_name(sci)
+        if not base:
+            continue
+        g = base_to_f.get(base)
+        if not g or str(g).strip() == "Unmapped":
+            continue
+        gn = str(g).strip()
+        if gn not in seen:
+            seen.add(gn)
+            out.append(gn)
+    out.sort(key=str.casefold)
+    return out
+
+
+def species_common_names_in_group(
+    species_list: Sequence[str],
+    name_map: Dict[str, str],
+    taxonomy_locale: str,
+    group_name: str,
+) -> List[str]:
+    """Common names in *species_list* whose taxonomy group equals *group_name*."""
+    base_to_f = build_base_species_to_family_map(taxonomy_locale)
+    if not base_to_f:
+        return []
+    want = str(group_name).strip()
+    out: list[str] = []
+    for common in species_list:
+        sci = str(name_map.get(common, "") or "")
+        base = base_species_name(sci)
+        if not base:
+            continue
+        g = base_to_f.get(base)
+        if g and str(g).strip() == want:
+            out.append(common)
+    out.sort(key=str.casefold)
+    return out
 
 
 def build_ram_species_whoosh_index(
     species_list: Sequence[str],
     name_map: Dict[str, str],
+    *,
+    taxonomy_group_names: Sequence[str] | None = None,
 ) -> Any:
     """
     Build a small Whoosh index from unique common names and common→scientific map.
+
+    When *taxonomy_group_names* is non-empty, each label is indexed as a synthetic row
+    ``"{label} (group)"`` so it appears in the same type-ahead as species (refs #73).
 
     Uses a temporary directory (cleaned up by the OS); fine for Streamlit session use
     per working-set rebuild. Notebook uses a persistent temp dir with the same schema.
@@ -41,7 +108,13 @@ def build_ram_species_whoosh_index(
     w = ix.writer()
     for common in species_list:
         sci = str(name_map.get(common, "") or "")
-        w.add_document(common_name=common, scientific_name=sci)
+        w.add_document(common_name=common, scientific_name=sci, kind="species")
+    for g in taxonomy_group_names or ():
+        label = str(g).strip()
+        if not label:
+            continue
+        display = f"{label}{GROUP_ROW_SUFFIX}"
+        w.add_document(common_name=display, scientific_name=label, kind="group")
     w.commit()
     return ix
 
@@ -121,6 +194,7 @@ def whoosh_species_suggestions(
         def rank_key(r):
             common = (r["common_name"] or "").lower()
             sci = (r.get("scientific_name") or "").lower()
+            kind = (r.get("kind") or "species").strip()
             # Base: Whoosh relevance (higher is better for BM25F default scoring)
             base = getattr(r, "score", None)
             if base is None:
@@ -133,6 +207,9 @@ def whoosh_species_suggestions(
                 sci.startswith(t) or f" {t}" in sci for t in tokens
             ):
                 base += 35.0
+            # Slight preference for species rows over taxonomy-group rows when scores are close
+            if kind == "group":
+                base -= 1.5
             # Prefer shorter display names when scores tie
             base -= len(common) * 0.001
             return base

--- a/explorer/core/working_set.py
+++ b/explorer/core/working_set.py
@@ -126,7 +126,7 @@ def rebuild_working_set_from_date_filter(
         w.delete_by_query(Every())
         for common in species_list:
             sci = str(name_map.get(common, "") or "")
-            w.add_document(common_name=common, scientific_name=sci, kind="species")
+            w.add_document(common_name=common, scientific_name=sci, taxonomy_group="")
         w.commit()
 
     return WorkingSet(

--- a/explorer/core/working_set.py
+++ b/explorer/core/working_set.py
@@ -126,7 +126,7 @@ def rebuild_working_set_from_date_filter(
         w.delete_by_query(Every())
         for common in species_list:
             sci = str(name_map.get(common, "") or "")
-            w.add_document(common_name=common, scientific_name=sci)
+            w.add_document(common_name=common, scientific_name=sci, kind="species")
         w.commit()
 
     return WorkingSet(

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -351,6 +351,18 @@ def build_all_species_banner_html(
     )
 
 
+def build_species_locations_awaiting_selection_banner_html(date_filter_status=None):
+    """Banner when **Species locations** has no species selected and pins are restricted to a species."""
+    date_block = _banner_muted_line(date_filter_status) if date_filter_status else ""
+    return (
+        f'<div class="pebird-map-banner" style="{_BANNER_POSITION}">'
+        f'<span class="pebird-map-banner__title">Species locations</span>'
+        f'<div class="pebird-map-banner__stats">Select a species in the sidebar to show pins.</div>'
+        f'{date_block}'
+        f'</div>'
+    )
+
+
 def build_lifer_locations_banner_html(
     n_lifer_species, n_locations, date_filter_status=None, include_subspecies: bool = False
 ):

--- a/tests/explorer/test_map_controller.py
+++ b/tests/explorer/test_map_controller.py
@@ -82,6 +82,37 @@ def test_all_species_builds_map_with_banner():
     assert "1 checklist" in html
 
 
+def test_species_view_no_selection_hide_only_empty_map():
+    df = _minimal_map_df()
+    r = build_species_overlay_map(
+        **_common_kwargs(df),
+        selected_species="",
+        map_view_mode="species",
+        hide_non_matching_locations=True,
+    )
+    assert r.warning is None
+    assert r.map is not None
+    html = r.map._repr_html_()
+    assert "Select a species in the sidebar" in html
+    assert "All species" not in html
+    assert "All locations" not in html
+
+
+def test_species_view_no_selection_show_all_matches_all_locations_banner():
+    df = _minimal_map_df()
+    r = build_species_overlay_map(
+        **_common_kwargs(df),
+        selected_species="",
+        map_view_mode="species",
+        hide_non_matching_locations=False,
+    )
+    assert r.warning is None
+    assert r.map is not None
+    html = r.map._repr_html_()
+    assert "All species" in html
+    assert "1 checklist" in html
+
+
 def test_lifer_map_mode_builds_banner():
     df = _minimal_map_df()
     kwargs = _common_kwargs(df)

--- a/tests/explorer/test_species_search.py
+++ b/tests/explorer/test_species_search.py
@@ -8,6 +8,9 @@ from whoosh.index import create_in
 
 from explorer.core.species_search import (
     build_ram_species_whoosh_index,
+    normalize_query_for_group_filtered_mode,
+    species_in_group_search_suggestions,
+    species_whoosh_schema,
     whoosh_common_name_suggestions,
     whoosh_species_suggestions,
 )
@@ -47,6 +50,24 @@ def test_whoosh_species_suggestions_matches_scientific_name():
     assert "Grey Teal" in out2
 
 
+def test_normalize_query_for_group_filtered_mode_strips_submitted_group_row():
+    g = "Australasian Robins"
+    assert normalize_query_for_group_filtered_mode(f"{g} (group)", g) == ""
+    assert normalize_query_for_group_filtered_mode(g, g) == ""
+    assert normalize_query_for_group_filtered_mode("Flame", g) == "Flame"
+
+
+def test_species_in_group_search_suggestions_empty_query_and_filter():
+    names = ["Scarlet Robin", "Flame Robin", "Pink Robin"]
+    assert species_in_group_search_suggestions(names, "", max_options=2) == ["Flame Robin", "Pink Robin"]
+    assert species_in_group_search_suggestions(names, "scar", max_options=6) == ["Scarlet Robin"]
+    assert species_in_group_search_suggestions(names, "rob", max_options=6) == [
+        "Flame Robin",
+        "Pink Robin",
+        "Scarlet Robin",
+    ]
+
+
 def test_whoosh_species_suggestions_includes_taxonomy_group_row():
     ix = build_ram_species_whoosh_index(
         ["Grey Teal"],
@@ -55,3 +76,35 @@ def test_whoosh_species_suggestions_includes_taxonomy_group_row():
     )
     out = whoosh_species_suggestions(ix, "duc", min_query_len=3)
     assert "Ducks (group)" in out
+
+
+def test_whoosh_species_suggestions_restrict_taxonomy_group_token_search():
+    """After picking a group, narrowing uses Whoosh tokens (common/sci), not raw substring (#73)."""
+    ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
+    w = ix.writer()
+    grp = "Australian Treecreepers"
+    w.add_document(
+        common_name="Brown Treecreeper",
+        scientific_name="Climacteris picumnus",
+        taxonomy_group=grp,
+        taxonomy_group_key=grp,
+        kind="species",
+    )
+    w.add_document(
+        common_name="Rufous Treecreeper",
+        scientific_name="Climacteris rufa",
+        taxonomy_group=grp,
+        taxonomy_group_key=grp,
+        kind="species",
+    )
+    w.commit()
+    out = whoosh_species_suggestions(
+        ix, "pic", restrict_taxonomy_group=grp, min_query_len=3
+    )
+    assert "Brown Treecreeper" in out
+    assert "Rufous Treecreeper" not in out
+
+    cleared = whoosh_species_suggestions(
+        ix, f"{grp} (group)", restrict_taxonomy_group=grp, min_query_len=3
+    )
+    assert set(cleared) == {"Brown Treecreeper", "Rufous Treecreeper"}

--- a/tests/explorer/test_species_search.py
+++ b/tests/explorer/test_species_search.py
@@ -8,8 +8,6 @@ from whoosh.index import create_in
 
 from explorer.core.species_search import (
     build_ram_species_whoosh_index,
-    normalize_query_for_group_filtered_mode,
-    species_in_group_search_suggestions,
     species_whoosh_schema,
     whoosh_common_name_suggestions,
     whoosh_species_suggestions,
@@ -50,61 +48,130 @@ def test_whoosh_species_suggestions_matches_scientific_name():
     assert "Grey Teal" in out2
 
 
-def test_normalize_query_for_group_filtered_mode_strips_submitted_group_row():
-    g = "Australasian Robins"
-    assert normalize_query_for_group_filtered_mode(f"{g} (group)", g) == ""
-    assert normalize_query_for_group_filtered_mode(g, g) == ""
-    assert normalize_query_for_group_filtered_mode("Flame", g) == "Flame"
-
-
-def test_species_in_group_search_suggestions_empty_query_and_filter():
-    names = ["Scarlet Robin", "Flame Robin", "Pink Robin"]
-    assert species_in_group_search_suggestions(names, "", max_options=2) == ["Flame Robin", "Pink Robin"]
-    assert species_in_group_search_suggestions(names, "scar", max_options=6) == ["Scarlet Robin"]
-    assert species_in_group_search_suggestions(names, "rob", max_options=6) == [
-        "Flame Robin",
-        "Pink Robin",
-        "Scarlet Robin",
-    ]
-
-
-def test_whoosh_species_suggestions_includes_taxonomy_group_row():
-    ix = build_ram_species_whoosh_index(
-        ["Grey Teal"],
-        {"Grey Teal": "Anas gracilis"},
-        taxonomy_group_names=["Ducks"],
-    )
-    out = whoosh_species_suggestions(ix, "duc", min_query_len=3)
-    assert "Ducks (group)" in out
-
-
-def test_whoosh_species_suggestions_restrict_taxonomy_group_token_search():
-    """After picking a group, narrowing uses Whoosh tokens (common/sci), not raw substring (#73)."""
+def test_whoosh_species_suggestions_uses_taxonomy_group_helper_weight():
     ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
     w = ix.writer()
-    grp = "Australian Treecreepers"
+    w.add_document(
+        common_name="Scarlet Robin",
+        scientific_name="Petroica boodang",
+        taxonomy_group="Australian Robins",
+    )
+    w.add_document(
+        common_name="Australian Pipit",
+        scientific_name="Anthus australis",
+        taxonomy_group="Pipits and Wagtails",
+    )
+    w.commit()
+    out = whoosh_species_suggestions(ix, "aus", min_query_len=3)
+    assert out
+    assert "Scarlet Robin" in out
+
+
+def test_whoosh_species_suggestions_has_no_synthetic_group_rows():
+    ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
+    w = ix.writer()
     w.add_document(
         common_name="Brown Treecreeper",
         scientific_name="Climacteris picumnus",
-        taxonomy_group=grp,
-        taxonomy_group_key=grp,
-        kind="species",
+        taxonomy_group="Australian Treecreepers",
     )
     w.add_document(
-        common_name="Rufous Treecreeper",
-        scientific_name="Climacteris rufa",
-        taxonomy_group=grp,
-        taxonomy_group_key=grp,
-        kind="species",
+        common_name="Australian Pipit",
+        scientific_name="Anthus australis",
+        taxonomy_group="Pipits and Wagtails",
     )
     w.commit()
-    out = whoosh_species_suggestions(
-        ix, "pic", restrict_taxonomy_group=grp, min_query_len=3
-    )
+    out = whoosh_species_suggestions(ix, "aus tree", min_query_len=3)
     assert "Brown Treecreeper" in out
-    assert "Rufous Treecreeper" not in out
+    assert all(not s.endswith(" (group)") for s in out)
 
-    cleared = whoosh_species_suggestions(
-        ix, f"{grp} (group)", restrict_taxonomy_group=grp, min_query_len=3
+
+def test_whoosh_species_suggestions_prefers_multi_token_coverage():
+    ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
+    w = ix.writer()
+    w.add_document(
+        common_name="Eastern Yellow Robin",
+        scientific_name="Eopsaltria australis",
+        taxonomy_group="Australasian Robins",
     )
-    assert set(cleared) == {"Brown Treecreeper", "Rufous Treecreeper"}
+    w.add_document(
+        common_name="Australian Pipit",
+        scientific_name="Anthus australis",
+        taxonomy_group="Pipits and Wagtails",
+    )
+    w.commit()
+    out = whoosh_species_suggestions(ix, "aus rob", min_query_len=3)
+    assert out
+    assert out[0] == "Eastern Yellow Robin"
+
+
+def test_whoosh_species_suggestions_prefers_common_name_token_over_sci_only():
+    ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
+    w = ix.writer()
+    w.add_document(
+        common_name="Eastern Yellow Robin",
+        scientific_name="Eopsaltria australis",
+        taxonomy_group="Australasian Robins",
+    )
+    w.add_document(
+        common_name="Australian Pipit",
+        scientific_name="Anthus australis",
+        taxonomy_group="Pipits and Wagtails",
+    )
+    w.commit()
+    out = whoosh_species_suggestions(ix, "austr", min_query_len=3)
+    assert out
+    assert out[0] == "Australian Pipit"
+
+
+def test_whoosh_species_suggestions_deprioritizes_spuh_sp_suffix():
+    ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
+    w = ix.writer()
+    w.add_document(
+        common_name="Australian Treecreeper sp.",
+        scientific_name="Climacteris sp.",
+        taxonomy_group="Australian Treecreepers",
+    )
+    w.add_document(
+        common_name="Brown Treecreeper",
+        scientific_name="Climacteris picumnus",
+        taxonomy_group="Australian Treecreepers",
+    )
+    w.commit()
+    out = whoosh_species_suggestions(ix, "aus tree", min_query_len=3)
+    assert out
+    assert out[0] == "Brown Treecreeper"
+
+
+def test_whoosh_species_suggestions_deprioritizes_trailing_paren_subspecies_form():
+    ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
+    w = ix.writer()
+    w.add_document(
+        common_name="Eastern Yellow Robin (Southeastern)",
+        scientific_name="Eopsaltria australis chrysorrhos",
+        taxonomy_group="Australasian Robins",
+    )
+    w.add_document(
+        common_name="Eastern Yellow Robin",
+        scientific_name="Eopsaltria australis",
+        taxonomy_group="Australasian Robins",
+    )
+    w.commit()
+    out = whoosh_species_suggestions(ix, "east yell rob", min_query_len=3)
+    assert out
+    assert out[0] == "Eastern Yellow Robin"
+
+
+def test_whoosh_species_suggestions_hyphenated_query_matches_plain_text():
+    ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
+    w = ix.writer()
+    w.add_document(
+        common_name="Noisy Scrub-bird",
+        scientific_name="Atrichornis clamosus",
+        taxonomy_group="Scrub-birds and Bowerbirds",
+    )
+    w.commit()
+    out_plain = whoosh_species_suggestions(ix, "scrub", min_query_len=3)
+    out_hyphen = whoosh_species_suggestions(ix, "scrub-bird", min_query_len=3)
+    assert "Noisy Scrub-bird" in out_plain
+    assert "Noisy Scrub-bird" in out_hyphen

--- a/tests/explorer/test_species_search.py
+++ b/tests/explorer/test_species_search.py
@@ -2,36 +2,31 @@
 
 import tempfile
 
-from whoosh.analysis import StemmingAnalyzer
-from whoosh.fields import TEXT, Schema
 from whoosh.index import create_in
 
 from explorer.core.species_search import (
     build_ram_species_whoosh_index,
     species_whoosh_schema,
-    whoosh_common_name_suggestions,
     whoosh_species_suggestions,
 )
 
 
 def test_whoosh_suggestions_short_query():
-    schema = Schema(common_name=TEXT(stored=True, analyzer=StemmingAnalyzer()))
-    ix = create_in(tempfile.mkdtemp(), schema)
+    ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
     w = ix.writer()
-    w.add_document(common_name="Grey Teal")
+    w.add_document(common_name="Grey Teal", scientific_name="", taxonomy_group="")
     w.commit()
-    assert whoosh_common_name_suggestions(ix, "gr", min_query_len=3) == []
-    assert whoosh_common_name_suggestions(ix, "gre", min_query_len=3) == ["Grey Teal"]
+    assert whoosh_species_suggestions(ix, "gr", min_query_len=3) == []
+    assert whoosh_species_suggestions(ix, "gre", min_query_len=3) == ["Grey Teal"]
 
 
 def test_whoosh_suggestions_ranking():
-    schema = Schema(common_name=TEXT(stored=True, analyzer=StemmingAnalyzer()))
-    ix = create_in(tempfile.mkdtemp(), schema)
+    ix = create_in(tempfile.mkdtemp(), species_whoosh_schema())
     w = ix.writer()
     for name in ("Great Egret", "Great Cormorant", "Green Pygmy-goose"):
-        w.add_document(common_name=name)
+        w.add_document(common_name=name, scientific_name="", taxonomy_group="")
     w.commit()
-    out = whoosh_common_name_suggestions(ix, "gre", max_options=6, min_query_len=3)
+    out = whoosh_species_suggestions(ix, "gre", max_options=6, min_query_len=3)
     assert len(out) >= 1
     assert all(isinstance(s, str) for s in out)
 

--- a/tests/explorer/test_species_search.py
+++ b/tests/explorer/test_species_search.py
@@ -45,3 +45,13 @@ def test_whoosh_species_suggestions_matches_scientific_name():
 
     out2 = whoosh_species_suggestions(ix, "anas gra", min_query_len=3)
     assert "Grey Teal" in out2
+
+
+def test_whoosh_species_suggestions_includes_taxonomy_group_row():
+    ix = build_ram_species_whoosh_index(
+        ["Grey Teal"],
+        {"Grey Teal": "Anas gracilis"},
+        taxonomy_group_names=["Ducks"],
+    )
+    out = whoosh_species_suggestions(ix, "duc", min_query_len=3)
+    assert "Ducks (group)" in out

--- a/tests/explorer/test_streamlit_ui_helpers.py
+++ b/tests/explorer/test_streamlit_ui_helpers.py
@@ -267,8 +267,18 @@ def test_static_map_cache_key_includes_species_overlay() -> None:
         species_selected_sci="Turdus migratorius",
         hide_non_matching_locations=True,
     )
+    empty_awaiting_species = static_map_cache_key(
+        df,
+        "species",
+        "",
+        "default",
+        ro,
+        taxonomy_locale="en_AU",
+        hide_non_matching_locations=True,
+    )
     assert no_species != with_species
     assert with_species != hide_on
+    assert empty_awaiting_species != no_species
 
 
 # --- app_data_loading / app_map_ui / streamlit_theme (refs #98; UI-surface regressions) ---

--- a/tests/explorer/test_working_set.py
+++ b/tests/explorer/test_working_set.py
@@ -89,7 +89,7 @@ def test_rebuild_whoosh_index_updated():
     index_dir = tempfile.mkdtemp()
     ix = create_in(index_dir, species_whoosh_schema())
     w = ix.writer()
-    w.add_document(common_name="Old Name", scientific_name="oldus nameus")
+    w.add_document(common_name="Old Name", scientific_name="oldus nameus", kind="species")
     w.commit()
 
     ws = rebuild_working_set_from_date_filter(
@@ -105,7 +105,7 @@ def test_rebuild_whoosh_index_updated():
     with ix.searcher() as searcher:
         assert searcher.doc_count() == 1
         assert list(searcher.all_stored_fields()) == [
-            {"common_name": "Grey Teal", "scientific_name": "Anas gracilis"}
+            {"common_name": "Grey Teal", "scientific_name": "Anas gracilis", "kind": "species"}
         ]
 
 

--- a/tests/explorer/test_working_set.py
+++ b/tests/explorer/test_working_set.py
@@ -89,7 +89,7 @@ def test_rebuild_whoosh_index_updated():
     index_dir = tempfile.mkdtemp()
     ix = create_in(index_dir, species_whoosh_schema())
     w = ix.writer()
-    w.add_document(common_name="Old Name", scientific_name="oldus nameus", kind="species")
+    w.add_document(common_name="Old Name", scientific_name="oldus nameus", taxonomy_group="")
     w.commit()
 
     ws = rebuild_working_set_from_date_filter(
@@ -105,7 +105,11 @@ def test_rebuild_whoosh_index_updated():
     with ix.searcher() as searcher:
         assert searcher.doc_count() == 1
         assert list(searcher.all_stored_fields()) == [
-            {"common_name": "Grey Teal", "scientific_name": "Anas gracilis", "kind": "species"}
+            {
+                "common_name": "Grey Teal",
+                "scientific_name": "Anas gracilis",
+                "taxonomy_group": "",
+            }
         ]
 
 


### PR DESCRIPTION
Focus of this batch of changes was to add family group searching to the species map.

Several ideas tested and abandoned (see commit messages)

https://github.com/jimchurches/myebirdstuff/commit/a6bf1ded9e45d2ef1e3256cb7304a9feb6bf6c58 shows prototype 1 that was replaced.

Final result is no stand-alone family search on speices page, instead the family group name is part of the whoosh weighting used to build the search results.  Search results remain the common name only.

Some UI tweaks also included in this batch of changes (#139)