### PR TITLE
Remove date filter line from map banners (refs #150)

### DIFF
--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -275,7 +275,8 @@ def render_prep_spinner_and_map_tab(
                                 MAP_CLUSTER_ALL_LOCATIONS_DEFAULT,
                             )
                         ),
-                        "date_filter_status": "" if is_lifer_view else date_filter_banner,
+                        # Banner: context + counts only; date filter stays in sidebar (refs #150).
+                        "date_filter_status": "",
                         "species_url_fn": species_url_fn,
                         "base_species_fn": base_species_for_lifer,
                         "taxonomy_locale": tax_locale_effective,

--- a/explorer/core/map_controller.py
+++ b/explorer/core/map_controller.py
@@ -90,8 +90,9 @@ def build_species_overlay_map(
     (session caches; same contract as the UI). Popup cache keys include
     *taxonomy_locale* so eBird species links refresh when the locale changes (Streamlit Settings).
 
-    *date_filter_status* is shown in banners (e.g. ``Date filter: Off``); pass
-    ``""`` to omit the extra line.
+    *date_filter_status*: optional extra muted line on map banners (e.g. date range). The Streamlit
+    app passes ``""`` so filter state stays in the sidebar only (refs #150); non-UI callers may
+    still pass a string for export or notebooks.
 
     *cluster_all_locations*: when there is no species filter (All locations view),
     group nearby pins with Leaflet.markercluster. Ignored for species and lifer maps.

--- a/tests/explorer/test_map_controller.py
+++ b/tests/explorer/test_map_controller.py
@@ -73,13 +73,13 @@ def test_all_species_builds_map_with_banner():
     r = build_species_overlay_map(
         **_common_kwargs(df),
         selected_species="",
-        date_filter_status="Date filter: Off",
     )
     assert r.warning is None
     assert r.map is not None
     html = r.map._repr_html_()
     assert "All species" in html
     assert "1 checklist" in html
+    assert "Date filter" not in html
 
 
 def test_species_view_no_selection_hide_only_empty_map():


### PR DESCRIPTION
Streamlit map build always passes empty date_filter_status so banners stay context + counts; date filter remains visible in the sidebar only.

Cache keys still use date_filter_banner for data slice invalidation. Docstring note on map_controller; test asserts banner HTML omits date filter.

Implements #126.

Made-with: Cursor