### PR TITLE
Explorer: improve main navigation tab strip visibility

### DIFF
--- a/explorer/app/streamlit/streamlit_theme.py
+++ b/explorer/app/streamlit/streamlit_theme.py
@@ -4,12 +4,19 @@ Single source for checklist-style Streamlit HTML tab surface theme (green vs eBi
 Tab modules use :func:`inject_streamlit_checklist_css` (refs #96) for table + tab-surface injection, or
 compose ``CHECKLIST_STATS_TABLE_CSS`` + :data:`CHECKLIST_STATS_HTML_TAB_SURFACE_CSS` plus any tab-specific
 rules. Changing only the surface CSS here rethemes every tab; local extra CSS blocks remain additive overlays.
+
+Primary ``st.tabs`` in the main column (Map, Checklist Statistics, …) are styled via
+:data:`MAIN_TAB_STRIP_NAV_CSS` (refs #149). Tab **labels** render inside ``stMarkdownContainer``; **size**
+needs rules on that node (theme ``fontSize`` on the label). **Colour** is also set there with
+``!important`` so nested markdown does not keep Streamlit ``bodyText`` instead of the tab strip palette.
+Nested tabs inside a panel use the same rules for consistency.
 """
 
 from __future__ import annotations
 
 import streamlit as st
 
+from explorer.app.streamlit.defaults import THEME_PRIMARY_HEX, THEME_TEXT_HEX
 from explorer.presentation.checklist_stats_display import (
     CHECKLIST_STATS_STREAMLIT_HTML_TAB_CSS,
     CHECKLIST_STATS_STREAMLIT_HTML_TAB_CSS_BLUE,
@@ -35,10 +42,58 @@ section[data-testid="stMain"] div[role="tabpanel"] {
 }
 """
 
+# Main tab strip: inactive uses theme body text (``config.toml`` / :data:`THEME_TEXT_HEX`); hover stays green.
+_MAIN_TAB_HOVER_HEX = "#156248"
+# Match Streamlit app chrome + checklist HTML (``app_constants`` / ``map_renderer.EXPLORER_UI_FONT_STACK``).
+_MAIN_TAB_LABEL_FONT_STACK = (
+    '"Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+)
+
+MAIN_TAB_STRIP_NAV_CSS = f"""
+section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"],
+section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"] {{
+  color: {THEME_TEXT_HEX} !important;
+}}
+section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"][aria-selected="true"],
+section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"][aria-selected="true"] {{
+  color: {THEME_PRIMARY_HEX} !important;
+}}
+section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"]:hover,
+section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"]:hover {{
+  color: {_MAIN_TAB_HOVER_HEX} !important;
+}}
+section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"][aria-selected="true"]:hover,
+section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"][aria-selected="true"]:hover {{
+  color: {THEME_PRIMARY_HEX} !important;
+}}
+section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"] [data-testid="stMarkdownContainer"],
+section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"] [data-testid="stMarkdownContainer"] {{
+  font-family: {_MAIN_TAB_LABEL_FONT_STACK} !important;
+  font-size: 1rem !important;
+  font-weight: 400 !important;
+}}
+section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"]:not([aria-selected="true"]) [data-testid="stMarkdownContainer"],
+section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"]:not([aria-selected="true"]) [data-testid="stMarkdownContainer"] {{
+  color: {THEME_TEXT_HEX} !important;
+}}
+section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"][aria-selected="true"] [data-testid="stMarkdownContainer"],
+section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"][aria-selected="true"] [data-testid="stMarkdownContainer"] {{
+  color: {THEME_PRIMARY_HEX} !important;
+  font-weight: 600 !important;
+}}
+section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"]:not([aria-selected="true"]):hover [data-testid="stMarkdownContainer"],
+section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"]:not([aria-selected="true"]):hover [data-testid="stMarkdownContainer"] {{
+  color: {_MAIN_TAB_HOVER_HEX} !important;
+}}
+section[data-testid="stMain"] [data-testid="stTabs"] [data-testid="stMarkdownContainer"] p {{
+  color: inherit !important;
+}}
+"""
+
 
 def inject_main_tab_panel_top_compact_css() -> None:
-    """Tighten default top inset for primary ``st.tabs`` panels in the main column (refs #132)."""
-    st.html(f"<style>{MAIN_TAB_PANEL_TOP_COMPACT_CSS}</style>")
+    """Tighten tab panel inset and improve main tab strip visibility (refs #132, #149)."""
+    st.html(f"<style>{MAIN_TAB_PANEL_TOP_COMPACT_CSS}{MAIN_TAB_STRIP_NAV_CSS}</style>")
 
 
 def inject_streamlit_checklist_css(extra_css: str = "") -> None:


### PR DESCRIPTION
Primary st.tabs labels are styled on stMarkdownContainer so font size, weight, and colours apply reliably (tab button alone does not paint markdown bodyText).

Inactive tabs use THEME_TEXT_HEX; selected and selected-hover use primary green; unselected hover uses the theme green. Font stack matches app chrome.

Resolves #149
Refs #126

Made-with: Cursor