### PR TITLE
Explorer: show blank Family map before a family is selected

### DIFF
--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -69,7 +69,11 @@ from explorer.app.streamlit.streamlit_ui_constants import (
 )
 from explorer.app.streamlit.yearly_summary_streamlit_html import sync_yearly_summary_session_inputs
 from explorer.core.map_controller import build_species_overlay_map
-from explorer.core.map_prep import data_signature_for_caches, prepare_all_locations_map_context
+from explorer.core.map_prep import (
+    data_signature_for_caches,
+    mean_center_from_location_data,
+    prepare_all_locations_map_context,
+)
 from explorer.core.settings_schema_defaults import MAP_CLUSTER_ALL_LOCATIONS_DEFAULT
 from explorer.core.species_logic import base_species_for_lifer
 from explorer.core.family_map_compute import (
@@ -160,6 +164,7 @@ def render_prep_spinner_and_map_tab(
                 st.session_state.pop(FOLIUM_STATIC_MAP_CACHE_KEY, None)
 
             map_warning_text: str | None = None
+            map_hint_text: str | None = None
             map_for_folium = None
             folium_st_key: str | None = None
             try:
@@ -176,6 +181,7 @@ def render_prep_spinner_and_map_tab(
                     fams = set(bundle.get("families") or ())
                     work = bundle.get("work")
                     tax_merged = bundle.get("tax_merged")
+                    fam_default_center = mean_center_from_location_data(ctx["effective_location_data"])
 
                     if not fam:
                         result_map = build_family_composition_folium_map(
@@ -183,16 +189,20 @@ def render_prep_spinner_and_map_tab(
                             map_style=map_style,
                             height_px=int(map_height),
                             colour_scheme_index=int(family_colour_scheme),
+                            default_center=fam_default_center,
                         )
-                        result_warning = "Select a family in the sidebar to load the map."
+                        map_hint_text = "Select a family in the sidebar to load the map."
+                        result_warning = None
                     elif fam not in fams or work is None or getattr(work, "empty", True):
                         result_map = build_family_composition_folium_map(
                             (),
                             map_style=map_style,
                             height_px=int(map_height),
                             colour_scheme_index=int(family_colour_scheme),
+                            default_center=fam_default_center,
                         )
-                        result_warning = "No family data available (taxonomy may not have loaded)."
+                        map_hint_text = "No family data available (taxonomy may not have loaded)."
+                        result_warning = None
                     else:
                         wf = filter_work_to_family(work, fam)
                         metrics = (
@@ -243,6 +253,7 @@ def render_prep_spinner_and_map_tab(
                         "key": _ck,
                         "map": result_map,
                         "warning": result_warning,
+                        "hint": map_hint_text,
                     }
                 else:
                     overlay_common = (
@@ -365,6 +376,8 @@ def render_prep_spinner_and_map_tab(
                 if map_warning_text is not None:
                     st.warning(map_warning_text)
                 elif map_for_folium is not None and folium_st_key is not None:
+                    if map_hint_text:
+                        st.info(map_hint_text)
                     inject_map_folium_iframe_min_height_css(map_height)
                     try:
                         from streamlit_folium import st_folium

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -150,8 +150,12 @@ def build_family_composition_folium_map(
     species_url_fn: Callable[[str], str | None] | None = None,
     fit_bounds_highlight_only: bool = False,
     colour_scheme_index: int | None = None,
+    default_center: tuple[float, float] | None = None,
 ) -> folium.Map:
     """Draw the family-composition map: markers, injected banner/legend HTML, and initial ``fit_bounds``.
+
+    *default_center* — when there are no pins, centre the blank map here (e.g. mean of the user’s
+    locations). If omitted, a broad regional default is used.
 
     *location_page_url_fn* maps ``Location ID`` → hotspot URL; *species_url_fn* maps common name
     (as shown in the export) to species page URL.
@@ -176,7 +180,7 @@ def build_family_composition_folium_map(
             sum(p.longitude for p in _cent_src) / len(_cent_src),
         )
     else:
-        center = _default_au_center()
+        center = default_center if default_center is not None else _default_au_center()
 
     m = create_map(center, map_style, height_px=height_px)
     m.get_root().html.add_child(Element(map_overlay_theme_stylesheet()))

--- a/explorer/core/map_prep.py
+++ b/explorer/core/map_prep.py
@@ -17,6 +17,23 @@ from explorer.core.species_logic import base_species_for_lifer, countable_specie
 from explorer.core.stats import safe_count
 
 
+def mean_center_from_location_data(location_data: pd.DataFrame | None) -> tuple[float, float] | None:
+    """Mean ``(latitude, longitude)`` for default map centre (same idea as visit overlay empty map).
+
+    Returns ``None`` when *location_data* is missing, empty, or means are non-finite — callers fall back
+    to a regional default (e.g. family blank map).
+    """
+    if location_data is None or location_data.empty:
+        return None
+    if not {"Latitude", "Longitude"}.issubset(location_data.columns):
+        return None
+    lat = float(location_data["Latitude"].mean())
+    lon = float(location_data["Longitude"].mean())
+    if pd.isna(lat) or pd.isna(lon):
+        return None
+    return (lat, lon)
+
+
 def prepare_all_locations_map_context(
     df: pd.DataFrame,
     *,

--- a/tests/explorer/test_family_map_folium.py
+++ b/tests/explorer/test_family_map_folium.py
@@ -99,6 +99,12 @@ def test_build_family_map_empty_pins_still_returns_map():
     assert "folium" in html.lower() or "map" in html.lower()
 
 
+def test_build_family_map_empty_pins_uses_default_center_when_given():
+    m = build_family_composition_folium_map((), default_center=(-33.8, 151.2))
+    html = m._repr_html_()
+    assert "-33.8" in html and "151.2" in html
+
+
 def test_fit_bounds_highlight_only_uses_highlight_pins():
     pins = _sample_pins()
     m_all = build_family_composition_folium_map(pins, fit_bounds_highlight_only=False)

--- a/tests/explorer/test_streamlit_map_prep.py
+++ b/tests/explorer/test_streamlit_map_prep.py
@@ -9,6 +9,7 @@ from explorer.core.map_controller import build_species_overlay_map
 from explorer.core.species_logic import base_species_for_lifer
 from explorer.core.map_prep import (
     data_signature_for_caches,
+    mean_center_from_location_data,
     prepare_all_locations_map_context,
 )
 
@@ -62,3 +63,17 @@ def test_prepare_empty_raises():
 def test_data_signature_for_caches():
     df = _tiny_df()
     assert data_signature_for_caches(df, "disk") == ("disk", 1, "S1")
+
+
+def test_mean_center_from_location_data():
+    df = _tiny_df()
+    ctx = prepare_all_locations_map_context(df)
+    c = mean_center_from_location_data(ctx["effective_location_data"])
+    assert c is not None
+    assert c[0] == pytest.approx(-35.0)
+    assert c[1] == pytest.approx(149.0)
+
+
+def test_mean_center_from_location_data_empty_returns_none():
+    assert mean_center_from_location_data(pd.DataFrame()) is None
+    assert mean_center_from_location_data(None) is None


### PR DESCRIPTION
Family locations now embeds Folium immediately with no pins. Informational copy uses st.info instead of result_warning so the map is not suppressed.

Blank-map centre uses mean lat/lon from effective_location_data (same idea as other map modes); family_map_folium accepts default_center when pins are empty.

Resolves #148
Refs #126

Made-with: Cursor