### PR TITLE
Explorer: align main chrome tabs and header (#149)

### DIFF
--- a/explorer/app/streamlit/app_landing_ui.py
+++ b/explorer/app/streamlit/app_landing_ui.py
@@ -16,6 +16,7 @@ from explorer.app.streamlit.app_constants import (
 )
 from explorer.app.streamlit.app_data_loading import load_dataframe
 from explorer.app.streamlit.app_map_ui import sidebar_footer_links
+from explorer.app.streamlit.streamlit_theme import inject_app_header_css
 
 _APP_LOGO_SVG = Path(REPO_ROOT) / "docs" / "explorer" / "assets" / "personal-ebird-explorer-logo.svg"
 
@@ -32,13 +33,13 @@ def title_with_logo() -> None:
             .replace(">", "&gt;")
         )
         st.html(
-            "<div style='display:flex;flex-direction:row;align-items:flex-start;justify-content:space-between;"
-            "flex-wrap:wrap;column-gap:0.75rem;row-gap:0.35rem;margin:0;padding:0 0 0.5rem 0;'>"
+            "<div class='pebird-app-header' style='display:flex;flex-direction:row;align-items:flex-start;"
+            "justify-content:space-between;flex-wrap:wrap;column-gap:0.75rem;row-gap:0.35rem;"
+            "margin:0;padding:0;'>"
             "<div style='flex:1;min-width:min(100%,12rem);margin:0;padding:0;'>"
             "<h1 style='margin:0;padding:0;font-size:clamp(1.35rem,3.5vw,2.25rem);"
             "line-height:1.15;font-weight:600;'>Personal eBird Explorer</h1>"
-            "<p style='margin:0.25rem 0 0 0;padding:0;font-size:1rem;line-height:1.45;"
-            "color:rgb(49,51,63);'>"
+            "<p style='margin:0.25rem 0 0 0;padding:0;font-size:1rem;line-height:1.45;'>"
             f"{tagline_esc}</p></div>"
             f"<img src='data:image/svg+xml;base64,{b64}' alt='' width='64' "
             "style='width:64px;max-width:min(64px,16vw);height:auto;display:block;margin:0.15rem 0 0 0;"
@@ -46,8 +47,22 @@ def title_with_logo() -> None:
             "</div>"
         )
     else:
-        st.title("Personal eBird Explorer")
-        st.markdown(APP_TAGLINE)
+        tagline_esc = (
+            APP_TAGLINE.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        )
+        st.html(
+            "<div class='pebird-app-header' style='display:flex;flex-direction:row;align-items:flex-start;"
+            "justify-content:space-between;flex-wrap:wrap;column-gap:0.75rem;row-gap:0.35rem;"
+            "margin:0;padding:0;'>"
+            "<div style='flex:1;min-width:min(100%,12rem);margin:0;padding:0;'>"
+            "<h1 style='margin:0;padding:0;font-size:clamp(1.35rem,3.5vw,2.25rem);"
+            "line-height:1.15;font-weight:600;'>Personal eBird Explorer</h1>"
+            f"<p style='margin:0.25rem 0 0 0;padding:0;font-size:1rem;line-height:1.45;'>{tagline_esc}</p>"
+            "</div></div>"
+        )
+    inject_app_header_css()
 
 
 def load_dataframe_after_landing(

--- a/explorer/app/streamlit/streamlit_theme.py
+++ b/explorer/app/streamlit/streamlit_theme.py
@@ -6,17 +6,19 @@ compose ``CHECKLIST_STATS_TABLE_CSS`` + :data:`CHECKLIST_STATS_HTML_TAB_SURFACE_
 rules. Changing only the surface CSS here rethemes every tab; local extra CSS blocks remain additive overlays.
 
 Primary ``st.tabs`` in the main column (Map, Checklist Statistics, …) are styled via
-:data:`MAIN_TAB_STRIP_NAV_CSS` (refs #149). Tab **labels** render inside ``stMarkdownContainer``; **size**
-needs rules on that node (theme ``fontSize`` on the label). **Colour** is also set there with
-``!important`` so nested markdown does not keep Streamlit ``bodyText`` instead of the tab strip palette.
-Nested tabs inside a panel use the same rules for consistency.
+:data:`MAIN_TAB_STRIP_NAV_CSS` (refs #149): muted inactive grey-green, primary green when selected,
+``0.9375rem`` labels, weight 500/400. Tab **labels** render inside ``stMarkdownContainer``; **size** and
+**colour** need rules on that node with ``!important``. Nested tabs inside a panel use the same rules.
+
+The app title + tagline (``pebird-app-header`` in :mod:`~explorer.app.streamlit.app_landing_ui`) use
+:data:`MAIN_APP_HEADER_CSS`: dark green title and muted tagline aligned with the tab palette (#149).
 """
 
 from __future__ import annotations
 
 import streamlit as st
 
-from explorer.app.streamlit.defaults import THEME_PRIMARY_HEX, THEME_TEXT_HEX
+from explorer.app.streamlit.defaults import THEME_PRIMARY_HEX
 from explorer.presentation.checklist_stats_display import (
     CHECKLIST_STATS_STREAMLIT_HTML_TAB_CSS,
     CHECKLIST_STATS_STREAMLIT_HTML_TAB_CSS_BLUE,
@@ -42,8 +44,10 @@ section[data-testid="stMain"] div[role="tabpanel"] {
 }
 """
 
-# Main tab strip: inactive uses theme body text (``config.toml`` / :data:`THEME_TEXT_HEX`); hover stays green.
+# Main tab strip: “calm” palette — softer inactive grey-green; primary on selected (refs #149).
+_MAIN_TAB_INACTIVE_MUTED_HEX = "#6b7f77"
 _MAIN_TAB_HOVER_HEX = "#156248"
+_MAIN_TAB_LABEL_REM = "0.9375rem"
 # Match Streamlit app chrome + checklist HTML (``app_constants`` / ``map_renderer.EXPLORER_UI_FONT_STACK``).
 _MAIN_TAB_LABEL_FONT_STACK = (
     '"Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
@@ -52,7 +56,7 @@ _MAIN_TAB_LABEL_FONT_STACK = (
 MAIN_TAB_STRIP_NAV_CSS = f"""
 section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"],
 section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"] {{
-  color: {THEME_TEXT_HEX} !important;
+  color: {_MAIN_TAB_INACTIVE_MUTED_HEX} !important;
 }}
 section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"][aria-selected="true"],
 section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"][aria-selected="true"] {{
@@ -69,17 +73,17 @@ section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"][aria-sel
 section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"] [data-testid="stMarkdownContainer"],
 section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"] [data-testid="stMarkdownContainer"] {{
   font-family: {_MAIN_TAB_LABEL_FONT_STACK} !important;
-  font-size: 1rem !important;
+  font-size: {_MAIN_TAB_LABEL_REM} !important;
   font-weight: 400 !important;
 }}
 section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"]:not([aria-selected="true"]) [data-testid="stMarkdownContainer"],
 section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"]:not([aria-selected="true"]) [data-testid="stMarkdownContainer"] {{
-  color: {THEME_TEXT_HEX} !important;
+  color: {_MAIN_TAB_INACTIVE_MUTED_HEX} !important;
 }}
 section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"][aria-selected="true"] [data-testid="stMarkdownContainer"],
 section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"][aria-selected="true"] [data-testid="stMarkdownContainer"] {{
   color: {THEME_PRIMARY_HEX} !important;
-  font-weight: 600 !important;
+  font-weight: 500 !important;
 }}
 section[data-testid="stMain"] [data-testid="stTabs"] [data-baseweb="tab"]:not([aria-selected="true"]):hover [data-testid="stMarkdownContainer"],
 section[data-testid="stMain"] [data-testid="stTabs"] button[role="tab"]:not([aria-selected="true"]):hover [data-testid="stMarkdownContainer"] {{
@@ -90,10 +94,39 @@ section[data-testid="stMain"] [data-testid="stTabs"] [data-testid="stMarkdownCon
 }}
 """
 
+# App shell heading (``title_with_logo``): same green family as tabs — strong structure, not near-black.
+_MAIN_APP_HEADER_TITLE_HEX = "#1f3d2b"
+# Align tagline with tab inactive muted so title → subtitle → tabs read as one system.
+_MAIN_APP_HEADER_TAGLINE_HEX = _MAIN_TAB_INACTIVE_MUTED_HEX
+
+MAIN_APP_HEADER_CSS = f"""
+section[data-testid="stMain"] .pebird-app-header {{
+  /* Tuck primary tab strip closer to tagline; logo row unchanged (flex, no vertical shift of image). */
+  padding-bottom: 0.2rem !important;
+  margin-bottom: -0.45rem !important;
+}}
+section[data-testid="stMain"] .pebird-app-header h1 {{
+  color: {_MAIN_APP_HEADER_TITLE_HEX} !important;
+  font-weight: 600 !important;
+}}
+section[data-testid="stMain"] .pebird-app-header p {{
+  color: {_MAIN_APP_HEADER_TAGLINE_HEX} !important;
+}}
+"""
+
 
 def inject_main_tab_panel_top_compact_css() -> None:
-    """Tighten tab panel inset and improve main tab strip visibility (refs #132, #149)."""
+    """Tighten tab panel inset and main tab strip (refs #132, #149).
+
+    App title/tagline colours are injected from :func:`~explorer.app.streamlit.app_landing_ui.title_with_logo`
+    via :func:`inject_app_header_css` so the landing page (no tabs) still gets the same header treatment.
+    """
     st.html(f"<style>{MAIN_TAB_PANEL_TOP_COMPACT_CSS}{MAIN_TAB_STRIP_NAV_CSS}</style>")
+
+
+def inject_app_header_css() -> None:
+    """Apply ``MAIN_APP_HEADER_CSS`` (call from ``title_with_logo`` after the header HTML)."""
+    st.html(f"<style>{MAIN_APP_HEADER_CSS}</style>")
 
 
 def inject_streamlit_checklist_css(extra_css: str = "") -> None:

--- a/tests/explorer/test_streamlit_ui_helpers.py
+++ b/tests/explorer/test_streamlit_ui_helpers.py
@@ -469,6 +469,17 @@ def test_inject_main_tab_panel_top_compact_css_emits_selectors(streamlit_stub) -
     assert "padding-top:" in blob
 
 
+def test_inject_app_header_css_emits_pebird_header(streamlit_stub) -> None:
+    from explorer.app.streamlit import streamlit_theme
+
+    streamlit_stub.html_calls.clear()
+    streamlit_theme.inject_app_header_css()
+    blob = streamlit_stub.html_calls[-1]
+    assert ".pebird-app-header" in blob
+    assert "h1" in blob and "p" in blob
+    assert "margin-bottom" in blob and "padding-bottom" in blob
+
+
 def test_sidebar_footer_links_include_profile_urls(streamlit_stub, monkeypatch) -> None:
     from explorer.app.streamlit.app_map_ui import sidebar_footer_links
     from explorer.app.streamlit.streamlit_ui_constants import (


### PR DESCRIPTION
- Primary st.tabs: muted inactive, primary selected, 0.9375rem labels, weight 400/500; colours on stMarkdownContainer with !important.
- App title/tagline: pebird-app-header + MAIN_APP_HEADER_CSS (dark green title, muted tagline); inject_app_header_css from title_with_logo so landing matches dashboard.
- Tighter gap between tagline and primary tab strip (padding + negative margin on header block).
- Remove temporary tab_style_lab demo script.

Resolves #149
Implemented #126

Made-with: Cursor