### PR TITLE
Update/improve species pop-ups on species map [#145]

### DIFF
--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -41,7 +41,10 @@ MAP_PIN_FILL_OPACITY_ALL_LOCATIONS = 1.0
 MAP_PIN_FILL_OPACITY_EMPHASIS = 0.9
 MAP_LEGEND_PIN_DOT_PX = 8
 MAP_LEGEND_PIN_BORDER_PX = 2
-MAP_POPUP_MAX_WIDTH_PX = 800
+MAP_POPUP_MAX_WIDTH_PX = 420  # Folium L.popup maxWidth; card-like popups (refs #145).
+# Character shown for Macaulay Library media links in map popups (refs #145).
+# Possible alternatives for user testing: ⧉ (two joined squares, U+29C9); ⊕ (circled plus, U+2295).
+MAP_POPUP_MACAULAY_LINK_SYMBOL = "↗"
 
 # ---------------------------------------------------------------------------
 # Map UI (session-only; not persisted in embedded YAML)

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -30,7 +30,7 @@ SPECIES_SEARCH_PLACEHOLDER = "Type species name…"
 # Map sidebar “Search tips” expander: paragraphs separated by blank lines; rendered with ``st.caption``.
 SPECIES_SEARCH_CAPTION = """Start typing to search for a species.
 
-You can use common names, scientific names, or bird groups (e.g. Australasian Robins).
+You can use common names, scientific names, or family groups (e.g. Australasian Robins).
 
 Tip: "Show only selected species" defaults to on for performance; turn it off to see all locations with the selected species highlighted."""
 # Sidebar expander title (Map → Species locations); body is SPECIES_SEARCH_CAPTION.

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -23,7 +23,12 @@ from explorer.core.family_map_compute import (
     FamilyMapBannerMetrics,
     format_family_location_popup_html,
 )
-from explorer.presentation.map_renderer import build_legend_html, create_map, map_overlay_theme_stylesheet
+from explorer.presentation.map_renderer import (
+    build_legend_html,
+    create_map,
+    map_overlay_theme_stylesheet,
+    map_popup_width_fix_script,
+)
 
 # Match species-map banner placement (``map_renderer``).
 _FAMILY_MAP_BANNER_POSITION = "position:fixed;top:10px;right:10px;z-index:1000;"
@@ -184,6 +189,7 @@ def build_family_composition_folium_map(
 
     m = create_map(center, map_style, height_px=height_px)
     m.get_root().html.add_child(Element(map_overlay_theme_stylesheet()))
+    m.get_root().html.add_child(Element(map_popup_width_fix_script()))
 
     if banner_html and str(banner_html).strip():
         m.get_root().html.add_child(Element(str(banner_html).strip()))

--- a/explorer/core/map_overlay_theme.py
+++ b/explorer/core/map_overlay_theme.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import folium
 from branca.element import Element
 
-from explorer.presentation.map_renderer import map_overlay_theme_stylesheet
+from explorer.presentation.map_renderer import map_overlay_theme_stylesheet, map_popup_width_fix_script
 
 
 def inject_map_overlay_theme(map_obj: folium.Map) -> None:
-    """Add theme stylesheet to *map_obj* (popups, fixed banner/legend chrome)."""
-    map_obj.get_root().html.add_child(Element(map_overlay_theme_stylesheet()))
+    """Add theme stylesheet + popup width script to *map_obj* (popups, fixed banner/legend chrome)."""
+    html = map_obj.get_root().html
+    html.add_child(Element(map_overlay_theme_stylesheet()))
+    html.add_child(Element(map_popup_width_fix_script()))

--- a/explorer/core/map_overlay_visit_map.py
+++ b/explorer/core/map_overlay_visit_map.py
@@ -29,10 +29,10 @@ from explorer.presentation.map_renderer import (
     build_location_popup_html,
     build_species_banner_html,
     build_species_locations_awaiting_selection_banner_html,
+    build_species_map_location_popup_html,
     build_visit_info_html,
     classify_locations,
     create_map,
-    format_sighting_row,
     format_visit_time,
     popup_scroll_script,
     resolve_lifer_last_seen,
@@ -305,17 +305,23 @@ def build_visit_overlay_map(
                     "datetime", ascending=popup_ascending
                 )
                 visit_info = build_visit_info_html(visit_records, format_visit_time)
-                sightings_html = ""
+                n_visits = int(len(visit_records))
                 if row["has_species_match"]:
                     species_sightings = filtered_by_loc.get(loc_id, pd.DataFrame()).sort_values(
                         "datetime", ascending=popup_ascending
                     )
-                    sightings_html = "".join(
-                        format_sighting_row(r) for _, r in species_sightings.iterrows()
+                    popup_html_cache[popup_key] = build_species_map_location_popup_html(
+                        row["Location"],
+                        loc_id,
+                        species_sightings,
+                        visit_info,
+                        visit_record_count=n_visits,
+                        popup_ascending=popup_ascending,
                     )
-                popup_html_cache[popup_key] = build_location_popup_html(
-                    row["Location"], loc_id, visit_info, sightings_html
-                )
+                else:
+                    popup_html_cache[popup_key] = build_location_popup_html(
+                        row["Location"], loc_id, visit_info, ""
+                    )
             popup_html = popup_html_cache[popup_key]
             popup_content = folium.Popup(popup_html, max_width=MAP_POPUP_MAX_WIDTH_PX)
 

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -20,6 +20,7 @@ import pandas as pd
 from branca.element import MacroElement
 from folium.template import Template
 
+from explorer.core.stats import safe_count
 from explorer.presentation.stats_html_helpers import esc_attr, esc_text
 from explorer.app.streamlit.defaults import (
     MAP_HEIGHT_PX_DEFAULT,
@@ -27,6 +28,8 @@ from explorer.app.streamlit.defaults import (
     MAP_HEIGHT_PX_MIN,
     MAP_LEGEND_PIN_BORDER_PX,
     MAP_LEGEND_PIN_DOT_PX,
+    MAP_POPUP_MACAULAY_LINK_SYMBOL,
+    MAP_POPUP_MAX_WIDTH_PX,
 )
 
 # ---------------------------------------------------------------------------
@@ -41,19 +44,42 @@ EXPLORER_UI_PRIMARY_GREEN = "#1f6f54"
 EXPLORER_UI_PANEL_BG = "rgba(250, 252, 250, 0.97)"
 EXPLORER_UI_PANEL_BG_SOLID = "#eef4f0"
 EXPLORER_UI_MUTED = "rgba(26, 46, 34, 0.55)"
+# ``<details>`` ▶/▼ in map popups. Lighter than ``EXPLORER_UI_MUTED``; revert to that constant if preferred.
+EXPLORER_UI_POPUP_DETAILS_CHEVRON = "rgba(26, 46, 34, 0.36)"
 EXPLORER_UI_BORDER_PANEL = "rgba(31, 111, 84, 0.18)"
 
 
 def map_popup_theme_stylesheet() -> str:
     """Return a ``<style>`` block for Leaflet popups (injected once per map via ``branca.element.Element``).
 
-    Targets ``.pebird-map-popup`` wrappers from ``build_location_popup_html``. Font size matches the
-    checklist HTML tab panel (~0.8125rem); links use the same primary green as Streamlit theme fallbacks.
+    Typography matches the checklist HTML tab (~0.8125rem). CSS shrink-wraps Leaflet’s content box;
+    :func:`map_popup_width_fix_script` reapplies widths after ``Popup._updateLayout`` (refs #145).
     """
     return f"""
 <style>
+/* Shrink-wrap: Leaflet sets pixel width on .leaflet-popup-content; wrapper must match (refs #145). */
+.leaflet-popup .leaflet-popup-content-wrapper,
+.leaflet-popup .leaflet-popup-content {{
+  width: fit-content !important;
+  max-width: min({MAP_POPUP_MAX_WIDTH_PX}px, calc(100vw - 40px)) !important;
+  box-sizing: border-box !important;
+}}
 .leaflet-popup-content .pebird-map-popup,
 .leaflet-popup-content .pebird-map-popup * {{
+  box-sizing: border-box;
+}}
+/* Block-level inner box stretches to Leaflet's wide .leaflet-popup-content; shrink-wrap so width can match text. */
+.leaflet-popup-content .pebird-map-popup {{
+  display: inline-block;
+  width: max-content;
+  max-width: min({MAP_POPUP_MAX_WIDTH_PX}px, calc(100vw - 40px));
+  vertical-align: top;
+}}
+.pebird-map-popup__heading-row,
+.pebird-map-popup__scroll {{
+  width: fit-content;
+  max-width: 100%;
+  min-width: 0;
   box-sizing: border-box;
 }}
 .pebird-map-popup {{
@@ -76,11 +102,155 @@ def map_popup_theme_stylesheet() -> str:
 .pebird-map-popup a:hover {{
   text-decoration: underline;
 }}
+.pebird-map-popup a.pebird-map-popup__media-link {{
+  color: {EXPLORER_UI_MUTED};
+  font-weight: 400;
+  text-decoration: none;
+  font-size: 0.92em;
+}}
+.pebird-map-popup a.pebird-map-popup__media-link:hover {{
+  color: {EXPLORER_UI_PRIMARY_GREEN};
+  text-decoration: none;
+}}
 /* Location title link: heavier than body links (refs #70). */
 .pebird-map-popup a.pebird-map-popup__location-heading {{
   font-weight: 600;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}}
+/* Section labels: same weight/colour as banner stats line (``pebird-map-banner__stats``), not title. */
+.pebird-map-popup .pebird-map-popup__section-label {{
+  font-weight: 400;
+  color: {EXPLORER_UI_TEXT_COLOR};
+  font-size: inherit;
+  line-height: inherit;
+}}
+.pebird-map-popup__obs-count {{
+  color: {EXPLORER_UI_MUTED};
+  font-weight: 400;
+}}
+/* Species-map: one line per visit (datetime + count + optional media). No table — avoids wide
+   column / intrinsic-width fights with Leaflet (refs #145). */
+.pebird-map-popup__obs-list {{
+  margin: 0;
+  padding: 0;
+}}
+.pebird-map-popup__obs-line {{
+  display: block;
+  margin: 0 0 0.15rem 0;
+}}
+.pebird-map-popup__obs-line:last-child {{
+  margin-bottom: 0;
+}}
+.pebird-map-popup details.pebird-map-popup__species-seen {{
+  margin: 0 0 0.55rem 0;
+}}
+.pebird-map-popup details.pebird-map-popup__species-seen .pebird-map-popup__obs-list {{
+  margin-top: 0.2rem;
+}}
+.pebird-map-popup details.pebird-map-popup__all-visits {{
+  margin-top: 0.45rem;
+}}
+.pebird-map-popup details.pebird-map-popup__all-visits summary,
+.pebird-map-popup details.pebird-map-popup__species-seen summary {{
+  cursor: pointer;
+  font-weight: 400;
+  color: {EXPLORER_UI_TEXT_COLOR};
+  list-style: none;
+}}
+.pebird-map-popup details.pebird-map-popup__all-visits summary::-webkit-details-marker,
+.pebird-map-popup details.pebird-map-popup__species-seen summary::-webkit-details-marker {{
+  display: none;
+}}
+/* Custom disclosure chevron (refs #145). Colour: ``EXPLORER_UI_POPUP_DETAILS_CHEVRON``. */
+.pebird-map-popup details.pebird-map-popup__all-visits summary::before,
+.pebird-map-popup details.pebird-map-popup__species-seen summary::before {{
+  content: '▶';
+  display: inline-block;
+  margin-right: 0.35em;
+  font-size: 0.62em;
+  vertical-align: 0.05em;
+  color: {EXPLORER_UI_POPUP_DETAILS_CHEVRON};
+}}
+.pebird-map-popup details.pebird-map-popup__all-visits[open] summary::before,
+.pebird-map-popup details.pebird-map-popup__species-seen[open] summary::before {{
+  content: '▼';
+}}
+.pebird-map-popup details.pebird-map-popup__all-visits .pebird-map-popup__visit-list-inner {{
+  margin-top: 0.35rem;
 }}
 </style>
+"""
+
+
+def map_popup_width_fix_script() -> str:
+    """Return a ``<script>`` that shrink-wraps Leaflet popups after JS layout.
+
+    Folium passes ``maxWidth``; Leaflet's ``Popup._updateLayout`` sets a pixel width on
+    ``.leaflet-popup-content`` (often ``maxWidth``). A **block** ``.pebird-map-popup`` then **stretches**
+    to that width, so ``fit-content`` on the parent cannot shrink. We use **inline-block** inner (CSS)
+    and set **content + wrapper** to the measured inner width in px after Leaflet runs (refs #145).
+    """
+    w = MAP_POPUP_MAX_WIDTH_PX
+    return f"""
+<script>
+(function() {{
+  var MAX_PX = {w};
+
+  function capW() {{
+    return Math.min(MAX_PX, Math.max(80, window.innerWidth - 40));
+  }}
+
+  function shrinkPebirdPopups() {{
+    var pops = document.querySelectorAll('.leaflet-popup-pane .leaflet-popup');
+    var cap = capW();
+    for (var i = 0; i < pops.length; i++) {{
+      var pop = pops[i];
+      var content = pop.querySelector('.leaflet-popup-content');
+      var wrap = pop.querySelector('.leaflet-popup-content-wrapper');
+      var inner = pop.querySelector('.pebird-map-popup');
+      if (!content || !wrap || !inner) continue;
+
+      content.style.removeProperty('width');
+      content.style.removeProperty('white-space');
+      wrap.style.removeProperty('width');
+
+      var innerPx = Math.ceil(inner.scrollWidth);
+      if (innerPx < 2) innerPx = Math.ceil(inner.getBoundingClientRect().width);
+      var target = Math.min(innerPx, cap);
+      content.style.setProperty('width', target + 'px', 'important');
+      content.style.setProperty('max-width', cap + 'px', 'important');
+      wrap.style.setProperty('width', target + 'px', 'important');
+      wrap.style.setProperty('max-width', cap + 'px', 'important');
+    }}
+  }}
+
+  function scheduleShrink() {{
+    requestAnimationFrame(function() {{
+      requestAnimationFrame(function() {{
+        shrinkPebirdPopups();
+      }});
+    }});
+    var delays = [0, 30, 80, 150, 260, 400];
+    for (var k = 0; k < delays.length; k++) {{
+      setTimeout(shrinkPebirdPopups, delays[k]);
+    }}
+  }}
+
+  var mo = new MutationObserver(function(muts) {{
+    for (var i = 0; i < muts.length; i++) {{
+      for (var j = 0; j < muts[i].addedNodes.length; j++) {{
+        var node = muts[i].addedNodes[j];
+        if (node.nodeType === 1 && node.classList && node.classList.contains('leaflet-popup')) {{
+          scheduleShrink();
+          return;
+        }}
+      }}
+    }}
+  }});
+  mo.observe(document.body, {{ childList: true, subtree: true }});
+}})();
+</script>
 """
 
 
@@ -169,6 +339,14 @@ def map_overlay_theme_stylesheet() -> str:
 # Popup content formatters
 # ---------------------------------------------------------------------------
 
+def _macaulay_media_anchor_html(esc_asset: str) -> str:
+    """Leading space + Macaulay Library link; *esc_asset* must be ``esc_attr``-safe for the URL path."""
+    return (
+        f' <a class="pebird-map-popup__media-link" href="https://macaulaylibrary.org/asset/{esc_asset}"'
+        f' target="_blank" rel="noopener noreferrer" title="media">{MAP_POPUP_MACAULAY_LINK_SYMBOL}</a>'
+    )
+
+
 def format_visit_time(r):
     """Format a single visit record's date/time for popup display.
 
@@ -203,14 +381,70 @@ def format_sighting_row(r):
     if pd.notna(ml) and str(ml).strip():
         first_ml = str(ml).strip().split()[0]
         esc_asset = esc_attr(first_ml)
-        media_html = (
-            f' <a href="https://macaulaylibrary.org/asset/{esc_asset}"'
-            f' target="_blank" rel="noopener noreferrer" title="View media">📷</a>'
-        )
+        media_html = _macaulay_media_anchor_html(esc_asset)
     return (
         f'<br><a href="{esc_attr(checklist_url)}" target="_blank" rel="noopener noreferrer">'
         f"{esc_text(text)}</a>{media_html}"
     )
+
+
+def format_species_map_sighting_row(r: pd.Series) -> str:
+    """Format one species-map observation: one line with datetime link, (Observed: n), optional media.
+
+    Omits species name — rows are grouped under per–common-name headings (refs #145).
+    """
+    if "datetime" in r.index and pd.notna(r.get("datetime")):
+        dt = r["datetime"]
+        link_text = dt.strftime("%Y-%m-%d %H:%M")
+    else:
+        date_str = r["Date"].strftime("%Y-%m-%d") if pd.notna(r.get("Date")) else "unknown"
+        time_str = str(r["Time"]) if pd.notna(r.get("Time")) else "unknown"
+        link_text = f"{date_str} {time_str}"
+    n = safe_count(r.get("Count"))
+    cid = str(r.get("Submission ID", "") or "").strip()
+    checklist_url = f"https://ebird.org/checklist/{cid}" if cid else "#"
+    media_html = ""
+    ml = r.get("ML Catalog Numbers")
+    if pd.notna(ml) and str(ml).strip():
+        first_ml = str(ml).strip().split()[0]
+        esc_asset = esc_attr(first_ml)
+        media_html = _macaulay_media_anchor_html(esc_asset)
+    return (
+        '<div class="pebird-map-popup__obs-line">'
+        f'<a href="{esc_attr(checklist_url)}" target="_blank" rel="noopener noreferrer">'
+        f"{esc_text(link_text)}</a> "
+        f'<span class="pebird-map-popup__obs-count">(Observed: {n})</span>{media_html}'
+        f"</div>"
+    )
+
+
+def build_species_seen_sections_html(species_sightings: pd.DataFrame, *, ascending: bool) -> str:
+    """Group *species_sightings* by ``Common Name``; one ``<details>`` block per taxon (refs #145).
+
+    Multiple taxa: sections start **collapsed**. A single taxon: that section has the HTML ``open``
+    attribute so observations show immediately.
+    """
+    if species_sightings.empty or "Common Name" not in species_sightings.columns:
+        return ""
+    work = species_sightings.copy()
+    work["Common Name"] = work["Common Name"].fillna("Unknown")
+    names = sorted(work["Common Name"].unique(), key=lambda x: str(x).lower())
+    n_taxa = len(names)
+    parts: list[str] = []
+    for common_name in names:
+        sub = work[work["Common Name"] == common_name]
+        if "datetime" in sub.columns:
+            sub = sub.sort_values("datetime", ascending=ascending)
+        rows = "".join(format_species_map_sighting_row(r) for _, r in sub.iterrows())
+        esc_name = esc_text(str(common_name))
+        open_attr = " open" if n_taxa == 1 else ""
+        parts.append(
+            f'<details class="pebird-map-popup__species-seen"{open_attr}>'
+            f'<summary class="pebird-map-popup__section-label">{esc_name}:</summary>'
+            f'<div class="pebird-map-popup__obs-list">{rows}</div>'
+            f"</details>"
+        )
+    return "".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -245,7 +479,9 @@ def build_location_popup_html(
     sightings_html="",
     lifer_species_html="",
     show_visit_history: bool = True,
-    lifer_heading_html: str = "<b>Lifers (first recorded here):</b>",
+    lifer_heading_html: str = (
+        '<div class="pebird-map-popup__section-label">Lifers (first recorded here):</div>'
+    ),
     location_heading_margin_px: int = 6,
 ):
     """Build the full popup HTML for a single map marker.
@@ -277,10 +513,16 @@ def build_location_popup_html(
     if lifer_species_html:
         extra_section = f"{lifer_heading_html}{lifer_species_html}" if lifer_heading_html else lifer_species_html
     elif sightings_html:
-        extra_section = f"<b>Seen:</b>{sightings_html}"
+        extra_section = (
+            f'<div class="pebird-map-popup__section-label">Seen:</div>{sightings_html}'
+        )
     else:
         extra_section = ""
-    visited_section = f"<b>Visited:</b><br>{visit_info_html}" if show_visit_history else ""
+    visited_section = (
+        f'<div class="pebird-map-popup__section-label">Visited:</div><br>{visit_info_html}'
+        if show_visit_history
+        else ""
+    )
     # If both sections are present, add a separator line break.
     if visited_section and extra_section:
         inner_html = visited_section + "<br>" + extra_section
@@ -288,10 +530,50 @@ def build_location_popup_html(
         inner_html = visited_section + extra_section
     return (
         f'<div class="pebird-map-popup popup-scroll-wrapper" style="position:relative;">'
-        f'<div style="margin-bottom:{int(location_heading_margin_px)}px;">{loc_link}</div>'
-        f'<div style="max-height:300px;overflow-y:auto;">'
+        f'<div class="pebird-map-popup__heading-row" style="margin-bottom:{int(location_heading_margin_px)}px;">{loc_link}</div>'
+        f'<div class="pebird-map-popup__scroll" style="max-height:300px;overflow-y:auto;">'
         f"{inner_html}"
         f'</div></div>'
+    )
+
+
+def build_species_map_location_popup_html(
+    loc_name: str,
+    loc_id: str,
+    species_sightings: pd.DataFrame,
+    visit_info_html: str,
+    *,
+    visit_record_count: int,
+    popup_ascending: bool,
+    location_heading_margin_px: int = 6,
+) -> str:
+    """Popup for **species-matching** markers on the species map: species sections first, visits in ``<details>``.
+
+    Non-matching pins use :func:`build_location_popup_html` without species sections (refs #145).
+    """
+    loc_url = f"https://ebird.org/lifelist/{loc_id}"
+    esc_loc = _html_module.escape(str(loc_name), quote=False)
+    loc_link = (
+        f'<a class="pebird-map-popup__location-heading" href="{loc_url}" '
+        f'target="_blank" rel="noopener noreferrer">{esc_loc}</a>'
+    )
+    sections_html = build_species_seen_sections_html(species_sightings, ascending=popup_ascending)
+    summary_text = f"Visited: ({visit_record_count})"
+    esc_summary = esc_text(summary_text)
+    inner_visits = visit_info_html if (visit_info_html and str(visit_info_html).strip()) else ""
+    details_block = (
+        f'<details class="pebird-map-popup__all-visits">'
+        f'<summary class="pebird-map-popup__section-label">{esc_summary}</summary>'
+        f'<div class="pebird-map-popup__visit-list-inner">{inner_visits}</div>'
+        f"</details>"
+    )
+    inner_html = sections_html + details_block
+    return (
+        f'<div class="pebird-map-popup popup-scroll-wrapper" style="position:relative;">'
+        f'<div class="pebird-map-popup__heading-row" style="margin-bottom:{int(location_heading_margin_px)}px;">{loc_link}</div>'
+        f'<div class="pebird-map-popup__scroll" style="max-height:300px;overflow-y:auto;">'
+        f"{inner_html}"
+        f"</div></div>"
     )
 
 
@@ -541,7 +823,7 @@ def popup_scroll_script(scroll_hint, scroll_to_bottom):
 
   function onPopupOpen() {{
     setTimeout(function() {{
-      var scrollable = document.querySelector('.leaflet-popup-content div[style*="overflow-y"]');
+      var scrollable = document.querySelector('.leaflet-popup-content .pebird-map-popup__scroll');
       if (!scrollable) return;
       var wrapper = scrollable.parentElement;
       if (wrapper.dataset.popupSetup) return;

--- a/explorer/presentation/map_ui_constants.py
+++ b/explorer/presentation/map_ui_constants.py
@@ -1,12 +1,12 @@
 """
 Folium / map chrome used by ``map_controller`` and ``map_renderer``.
 
-**Popup width** is defined in :mod:`explorer.app.streamlit.defaults` (``MAP_POPUP_MAX_WIDTH_PX``);
+**Popup chrome** (width, Macaulay link symbol) is defined in :mod:`explorer.app.streamlit.defaults`;
 re-exported here so call sites can keep importing from this module.
 """
 
 from __future__ import annotations
 
-from explorer.app.streamlit.defaults import MAP_POPUP_MAX_WIDTH_PX
+from explorer.app.streamlit.defaults import MAP_POPUP_MACAULAY_LINK_SYMBOL, MAP_POPUP_MAX_WIDTH_PX
 
-__all__ = ["MAP_POPUP_MAX_WIDTH_PX"]
+__all__ = ["MAP_POPUP_MACAULAY_LINK_SYMBOL", "MAP_POPUP_MAX_WIDTH_PX"]

--- a/tests/explorer/test_map_renderer.py
+++ b/tests/explorer/test_map_renderer.py
@@ -3,19 +3,24 @@
 import folium
 import pandas as pd
 
+from explorer.app.streamlit.defaults import MAP_POPUP_MACAULAY_LINK_SYMBOL, MAP_POPUP_MAX_WIDTH_PX
 from explorer.presentation.map_renderer import (
-    create_map,
-    format_visit_time,
-    format_sighting_row,
-    popup_scroll_script,
-    pin_legend_item,
+    build_species_map_location_popup_html,
+    build_species_seen_sections_html,
+    build_visit_info_html,
     build_all_species_banner_html,
     build_species_banner_html,
     build_legend_html,
-    build_visit_info_html,
     build_location_popup_html,
-    resolve_lifer_last_seen,
     classify_locations,
+    create_map,
+    format_species_map_sighting_row,
+    format_sighting_row,
+    format_visit_time,
+    map_popup_width_fix_script,
+    pin_legend_item,
+    popup_scroll_script,
+    resolve_lifer_last_seen,
 )
 
 
@@ -79,7 +84,8 @@ def test_format_sighting_row_with_media():
     })
     html = format_sighting_row(row)
     assert "macaulaylibrary.org/asset/ML12345" in html
-    assert "📷" in html
+    assert "pebird-map-popup__media-link" in html and MAP_POPUP_MACAULAY_LINK_SYMBOL in html
+    assert 'title="media"' in html
 
 
 def test_format_sighting_row_no_submission_id():
@@ -109,6 +115,91 @@ def test_format_sighting_row_with_datetime():
 
 
 # ---------------------------------------------------------------------------
+# format_species_map_sighting_row / build_species_seen_sections_html (refs #145)
+# ---------------------------------------------------------------------------
+
+def test_format_species_map_sighting_row_omits_common_name():
+    row = pd.Series({
+        "Date": pd.Timestamp("2024-11-12"),
+        "Time": "05:54",
+        "Common Name": "Pacific Golden Plover",
+        "Count": 1,
+        "Submission ID": "SCHK1",
+        "ML Catalog Numbers": None,
+        "datetime": pd.Timestamp("2024-11-12 05:54"),
+    })
+    html = format_species_map_sighting_row(row)
+    assert "Pacific Golden Plover" not in html
+    assert "pebird-map-popup__obs-line" in html
+    assert "2024-11-12 05:54" in html
+    assert "(Observed: 1)" in html
+    assert "ebird.org/checklist/SCHK1" in html
+
+
+def test_format_species_map_sighting_row_media():
+    row = pd.Series({
+        "Date": pd.Timestamp("2024-11-12"),
+        "Time": "05:54",
+        "Common Name": "X",
+        "Count": 2,
+        "Submission ID": "S2",
+        "ML Catalog Numbers": "ML999",
+        "datetime": pd.Timestamp("2024-11-12 05:54"),
+    })
+    html = format_species_map_sighting_row(row)
+    assert "pebird-map-popup__obs-line" in html
+    assert "macaulaylibrary.org/asset/ML999" in html
+    assert "pebird-map-popup__media-link" in html and MAP_POPUP_MACAULAY_LINK_SYMBOL in html
+    assert 'title="media"' in html
+
+
+def test_build_species_seen_sections_two_common_names():
+    df = pd.DataFrame({
+        "Common Name": ["Grey Teal", "Pacific Golden Plover", "Grey Teal"],
+        "datetime": [
+            pd.Timestamp("2025-01-01 08:00"),
+            pd.Timestamp("2025-02-01 09:00"),
+            pd.Timestamp("2025-01-02 10:00"),
+        ],
+        "Count": [1, 2, 3],
+        "Submission ID": ["A", "B", "C"],
+        "ML Catalog Numbers": [None, None, None],
+    })
+    html = build_species_seen_sections_html(df, ascending=True)
+    assert html.count('<details class="pebird-map-popup__species-seen">') == 2
+    assert '<details class="pebird-map-popup__species-seen" open>' not in html
+    assert 'pebird-map-popup__section-label">Grey Teal:</summary>' in html
+    assert 'pebird-map-popup__section-label">Pacific Golden Plover:</summary>' in html
+    assert "pebird-map-popup__obs-list" in html
+    assert html.index("Grey Teal") < html.index("Pacific Golden Plover")
+
+
+def test_build_species_map_location_popup_html_collapsed_visits():
+    species_df = pd.DataFrame({
+        "Common Name": ["Bird X"],
+        "datetime": [pd.Timestamp("2025-06-01 12:00")],
+        "Count": [5],
+        "Submission ID": ["SID1"],
+        "ML Catalog Numbers": [None],
+    })
+    visit_fragment = '<a href="https://ebird.org/checklist/V1">2025-01-01</a>'
+    html = build_species_map_location_popup_html(
+        "Hotspot",
+        "L99",
+        species_df,
+        visit_fragment,
+        visit_record_count=3,
+        popup_ascending=True,
+    )
+    assert '<details class="pebird-map-popup__species-seen" open>' in html
+    assert "details" in html and "pebird-map-popup__all-visits" in html
+    assert "Visited: (3)" in html
+    assert visit_fragment in html
+    # Species map uses <summary>, not the standalone Visited block from build_location_popup_html.
+    assert '<div class="pebird-map-popup__section-label">Visited:</div>' not in html
+
+
+# ---------------------------------------------------------------------------
 # popup_scroll_script
 # ---------------------------------------------------------------------------
 
@@ -132,6 +223,12 @@ def test_popup_scroll_script_scroll_to_bottom():
 def test_popup_scroll_script_none_hint():
     result = popup_scroll_script(None, False)
     assert "None" in result
+
+
+def test_map_popup_width_fix_script_embeds_max_width():
+    s = map_popup_width_fix_script()
+    assert "<script>" in s and "shrinkPebirdPopups" in s
+    assert f"var MAX_PX = {MAP_POPUP_MAX_WIDTH_PX}" in s
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…ions

Resolves #145. Implemented in #126.

Species-matching markers use dedicated HTML: per–common-name headings (details open when a single taxon, collapsed when multiple), observation lines with optional Macaulay link (glyph from MAP_POPUP_MACAULAY_LINK_SYMBOL), and visit history in a Visited details block. Non-matching pins keep the prior visit-only popup.

Popup width is capped (420px), with CSS shrink-wrap and a small script so Leaflet does not leave excess whitespace; the same script is injected on the family map.

Also: section-label typography, custom disclosure chevrons, configurable chevron colour, and search help copy (family groups).

Made-with: Cursor