### PR TITLE
beta-next: map popups, families banner, taxonomy URLs, and species UI

### DIFF
--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -404,7 +404,7 @@ def species_searchbox_fragment() -> None:
         _search,
         key=_species_searchbox_widget_key(),
         placeholder=SPECIES_SEARCH_PLACEHOLDER,
-        label="Species",
+        label=None,
         default=search_default,
         default_searchterm=default_searchterm,
         debounce=SPECIES_SEARCH_DEBOUNCE_MS,

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -285,11 +285,6 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
 
         with st.sidebar:
             st.markdown("**Species**")
-            with st.expander(SPECIES_SEARCH_HELP_EXPANDER_LABEL, expanded=False):
-                # Match Yearly Summary helper line (``st.caption`` for “Showing results…”).
-                for _para in (p.strip() for p in SPECIES_SEARCH_CAPTION.split("\n\n")):
-                    if _para:
-                        st.caption(_para)
             species_searchbox_fragment()
             if STREAMLIT_SPECIES_HIDE_ONLY_KEY not in st.session_state:
                 st.session_state[STREAMLIT_SPECIES_HIDE_ONLY_KEY] = MAP_SPECIES_HIDE_ONLY_DEFAULT
@@ -297,6 +292,11 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 "Show only selected species",
                 key=STREAMLIT_SPECIES_HIDE_ONLY_KEY,
             )
+            with st.expander(SPECIES_SEARCH_HELP_EXPANDER_LABEL, expanded=False):
+                # Match Yearly Summary helper line (``st.caption`` for “Showing results…”).
+                for _para in (p.strip() for p in SPECIES_SEARCH_CAPTION.split("\n\n")):
+                    if _para:
+                        st.caption(_para)
 
         species_pick_common = st.session_state.get(SESSION_SPECIES_PICK_KEY)
         if species_pick_common:

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -72,6 +72,7 @@ from explorer.core.family_map_compute import (
     build_family_location_pins,
     compute_family_map_banner_metrics,
     filter_work_to_family,
+    selected_species_checklist_individual_counts,
 )
 from explorer.app.streamlit.defaults import active_map_marker_colour_scheme
 from explorer.core.family_map_folium import (
@@ -206,7 +207,20 @@ def render_prep_spinner_and_map_tab(
                             wf,
                             highlight_base_species=hl or None,
                         )
-                        banner = build_family_map_banner_overlay_html(metrics) if metrics else ""
+                        sel_counts = (
+                            selected_species_checklist_individual_counts(wf, hl)
+                            if hl and metrics
+                            else None
+                        )
+                        banner = (
+                            build_family_map_banner_overlay_html(
+                                metrics,
+                                selected_species_n_checklists=sel_counts[0] if sel_counts else None,
+                                selected_species_n_individuals=sel_counts[1] if sel_counts else None,
+                            )
+                            if metrics
+                            else ""
+                        )
                         base_to_common = bundle.get("base_to_common") or {}
                         hl_label = (base_to_common.get(hl) or hl) if hl else ""
                         hl_species_url = None

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -207,6 +207,8 @@ def render_prep_spinner_and_map_tab(
                             wf,
                             highlight_base_species=hl or None,
                         )
+                        base_to_common = bundle.get("base_to_common") or {}
+                        hl_label = (base_to_common.get(hl) or hl) if hl else ""
                         sel_counts = (
                             selected_species_checklist_individual_counts(wf, hl)
                             if hl and metrics
@@ -217,12 +219,11 @@ def render_prep_spinner_and_map_tab(
                                 metrics,
                                 selected_species_n_checklists=sel_counts[0] if sel_counts else None,
                                 selected_species_n_individuals=sel_counts[1] if sel_counts else None,
+                                selected_species_display_name=hl_label or None,
                             )
                             if metrics
                             else ""
                         )
-                        base_to_common = bundle.get("base_to_common") or {}
-                        hl_label = (base_to_common.get(hl) or hl) if hl else ""
                         hl_species_url = None
                         if hl and hl_label:
                             _u = species_url_fn(hl_label)

--- a/explorer/core/family_map_compute.py
+++ b/explorer/core/family_map_compute.py
@@ -20,7 +20,8 @@ from typing import Iterable
 
 import pandas as pd
 
-from explorer.core.species_logic import countable_species_vectorized
+from explorer.core.species_logic import countable_species_vectorized, filter_species
+from explorer.core.stats import safe_count
 
 UNMAPPED_FAMILY_LABEL = "Unmapped"
 
@@ -131,6 +132,29 @@ def taxonomy_species_count_for_family(taxonomy_merged: pd.DataFrame, family_name
     if sub.empty or "base_species" not in sub.columns:
         return 0
     return int(sub["base_species"].nunique())
+
+
+def selected_species_checklist_individual_counts(
+    work_family: pd.DataFrame,
+    highlight_base_species: str,
+) -> tuple[int, int] | None:
+    """Checklist and individual totals for the highlighted base species, same rules as the species map.
+
+    Uses :func:`~explorer.core.species_logic.filter_species` on *work_family* so subspecies rows
+    roll up to the base. Returns ``None`` when *highlight_base_species* is empty or there are no
+    matching rows.
+    """
+    hb = (highlight_base_species or "").strip().lower()
+    if not hb:
+        return None
+    if work_family is None or getattr(work_family, "empty", True):
+        return None
+    sub = filter_species(work_family, hb)
+    if sub.empty:
+        return None
+    n_ck = int(sub["Submission ID"].nunique())
+    n_ind = int(sub["Count"].apply(safe_count).sum())
+    return (n_ck, n_ind)
 
 
 def compute_family_map_banner_metrics(

--- a/explorer/core/family_map_compute.py
+++ b/explorer/core/family_map_compute.py
@@ -295,9 +295,18 @@ def format_family_location_popup_html(
     esc_title = html_module.escape(title)
     if location_page_url and str(location_page_url).strip():
         esc_href = html_module.escape(str(location_page_url).strip(), quote=True)
-        head = f'<div style="font-weight:600;margin-bottom:0.35em;"><a href="{esc_href}" target="_blank" rel="noopener noreferrer">{esc_title}</a></div>'
+        head = (
+            '<div class="pebird-map-popup__heading-row" style="margin-bottom:4px;">'
+            f'<a class="pebird-map-popup__location-heading" href="{esc_href}" '
+            f'target="_blank" rel="noopener noreferrer">{esc_title}</a>'
+            "</div>"
+        )
     else:
-        head = f'<div style="font-weight:600;margin-bottom:0.35em;">{esc_title}</div>'
+        head = (
+            '<div class="pebird-map-popup__heading-row" style="margin-bottom:4px;">'
+            f'<span class="pebird-map-popup__location-heading">{esc_title}</span>'
+            "</div>"
+        )
     lines: list[str] = []
     url_map = species_url_by_common or {}
     for name in pin.common_name_lines:

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -98,13 +98,15 @@ def build_family_map_banner_overlay_html(
     *,
     selected_species_n_checklists: int | None = None,
     selected_species_n_individuals: int | None = None,
+    selected_species_display_name: str | None = None,
 ) -> str:
     """Return HTML for the fixed top-right banner: family title plus taxonomy / recording summary.
 
     Reuses the shared ``pebird-map-banner`` layout used on other maps.
 
     When *selected_species_n_checklists* and *selected_species_n_individuals* are both set (species
-    highlight active), a third line repeats the species-map primary stats for continuity.
+    highlight active), a third line repeats the species-map primary stats for continuity. When
+    *selected_species_display_name* is non-empty, it is shown as ``Name: N checklists · M individuals``.
     """
     title = html_module.escape(metrics.family_name, quote=False)
     stats = html_module.escape(
@@ -115,10 +117,15 @@ def build_family_map_banner_overlay_html(
     )
     extra = ""
     if selected_species_n_checklists is not None and selected_species_n_individuals is not None:
-        inner = checklist_individual_stats_banner_fragment(
+        frag = checklist_individual_stats_banner_fragment(
             selected_species_n_checklists,
             selected_species_n_individuals,
         )
+        dn = (selected_species_display_name or "").strip()
+        if dn:
+            inner = f"{html_module.escape(dn, quote=False)}: {frag}"
+        else:
+            inner = frag
         extra = f'<span class="pebird-map-banner__family-selected-summary">{inner}</span>'
     return (
         f'<div class="pebird-map-banner" style="{_FAMILY_MAP_BANNER_POSITION}">'

--- a/explorer/core/family_map_folium.py
+++ b/explorer/core/family_map_folium.py
@@ -40,6 +40,7 @@ from explorer.core.map_marker_colour_resolve import (
 )
 from explorer.presentation.map_renderer import (
     build_legend_html,
+    checklist_individual_stats_banner_fragment,
     create_map,
     map_overlay_theme_stylesheet,
     map_popup_width_fix_script,
@@ -92,10 +93,18 @@ def _family_map_banner_recorded_clause(metrics: FamilyMapBannerMetrics) -> str:
     return f"{u} recorded"
 
 
-def build_family_map_banner_overlay_html(metrics: FamilyMapBannerMetrics) -> str:
+def build_family_map_banner_overlay_html(
+    metrics: FamilyMapBannerMetrics,
+    *,
+    selected_species_n_checklists: int | None = None,
+    selected_species_n_individuals: int | None = None,
+) -> str:
     """Return HTML for the fixed top-right banner: family title plus taxonomy / recording summary.
 
     Reuses the shared ``pebird-map-banner`` layout used on other maps.
+
+    When *selected_species_n_checklists* and *selected_species_n_individuals* are both set (species
+    highlight active), a third line repeats the species-map primary stats for continuity.
     """
     title = html_module.escape(metrics.family_name, quote=False)
     stats = html_module.escape(
@@ -104,10 +113,18 @@ def build_family_map_banner_overlay_html(metrics: FamilyMapBannerMetrics) -> str
         f"{metrics.locations_with_records} locations",
         quote=False,
     )
+    extra = ""
+    if selected_species_n_checklists is not None and selected_species_n_individuals is not None:
+        inner = checklist_individual_stats_banner_fragment(
+            selected_species_n_checklists,
+            selected_species_n_individuals,
+        )
+        extra = f'<span class="pebird-map-banner__family-selected-summary">{inner}</span>'
     return (
         f'<div class="pebird-map-banner" style="{_FAMILY_MAP_BANNER_POSITION}">'
         f'<span class="pebird-map-banner__title">{title}</span>'
         f'<div class="pebird-map-banner__stats">{stats}</div>'
+        f"{extra}"
         f"</div>"
     )
 

--- a/explorer/core/stats.py
+++ b/explorer/core/stats.py
@@ -39,6 +39,40 @@ def safe_count(x):
         return 0
 
 
+def format_observed_count_for_map_popup(raw) -> str:
+    """Format a ``Count`` cell for map marker popups (species / all-locations ``Seen:`` lines).
+
+    :func:`safe_count` maps ``X`` and unparseable values to ``0`` so checklist and
+    species totals stay consistent with eBird. For **display**, we must not show
+    ``Observed: 0`` when the export meant "present but uncounted" or the value
+    was missing — use ``x`` or ``unknown`` instead. A literal ``0`` in the data
+    still renders as ``0``.
+
+    Aggregations are unchanged; only popup HTML should call this.
+    """
+    if raw is None:
+        return "unknown"
+    try:
+        if pd.isna(raw):
+            return "unknown"
+    except TypeError:
+        pass
+    if isinstance(raw, str):
+        s = raw.strip()
+        if not s:
+            return "unknown"
+        if s.upper() == "X":
+            return "x"
+        try:
+            return str(int(s, 10))
+        except ValueError:
+            return "unknown"
+    try:
+        return str(int(raw))
+    except (ValueError, TypeError):
+        return "unknown"
+
+
 # ---------------------------------------------------------------------------
 # Region helpers
 # ---------------------------------------------------------------------------

--- a/explorer/core/taxonomy.py
+++ b/explorer/core/taxonomy.py
@@ -70,6 +70,47 @@ def load_taxonomy(locale: str | None = None) -> bool:
     return True
 
 
+def _hyphen_space_lookup_variants(name: str) -> tuple[str, ...]:
+    """Alternate spellings swapping spaces and hyphens between word parts.
+
+    eBird uses different conventions by locale (e.g. *en_US* ``Jacky-winter`` vs *en_AU*
+    ``Jacky Winter``). Checklist exports follow the observer's regional names, which may not
+    match :func:`load_taxonomy`'s locale — try both forms before giving up (#156).
+
+    Note: swapping ``' '`` → ``'-'`` preserves per-word casing, so ``Jacky Winter`` becomes
+    ``Jacky-Winter`` while the CSV may use ``Jacky-winter``; :func:`_code_for_common_name`
+    falls back to normalized matching when direct key lookups miss.
+    """
+    key = str(name).strip()
+    alts: list[str] = []
+    if " " in key:
+        alts.append(key.replace(" ", "-"))
+    if "-" in key:
+        alts.append(key.replace("-", " "))
+    return tuple(alts)
+
+
+def _normalize_common_name_for_lookup(name: str) -> str:
+    """Collapse hyphen vs space and case differences for fuzzy species-name matching (#156)."""
+    s = str(name).strip().replace("-", " ")
+    while "  " in s:
+        s = s.replace("  ", " ")
+    return s.casefold()
+
+
+def _code_by_normalized_common_name(common_name: str) -> str | None:
+    """Linear scan: same species may differ only by hyphen/spaces/casing in the CSV vs query."""
+    if _common_to_code is None:
+        return None
+    target = _normalize_common_name_for_lookup(common_name)
+    if not target:
+        return None
+    for k, code in _common_to_code.items():
+        if _normalize_common_name_for_lookup(k) == target:
+            return code
+    return None
+
+
 def _base_common_name(common_name: str) -> str | None:
     """Strip trailing ' (Subspecies)' from common name so subspecies link to main species page.
 
@@ -95,9 +136,25 @@ def _code_for_common_name(common_name: str) -> str | None:
     code = _common_to_code.get(key)
     if code:
         return code
+    for alt in _hyphen_space_lookup_variants(key):
+        code = _common_to_code.get(alt)
+        if code:
+            return code
+    code = _code_by_normalized_common_name(key)
+    if code:
+        return code
     base = _base_common_name(common_name)
     if base:
-        return _common_to_code.get(base)
+        code = _common_to_code.get(base)
+        if code:
+            return code
+        for alt in _hyphen_space_lookup_variants(base):
+            code = _common_to_code.get(alt)
+            if code:
+                return code
+        code = _code_by_normalized_common_name(base)
+        if code:
+            return code
     return None
 
 

--- a/explorer/core/taxonomy.py
+++ b/explorer/core/taxonomy.py
@@ -75,7 +75,7 @@ def _hyphen_space_lookup_variants(name: str) -> tuple[str, ...]:
 
     eBird uses different conventions by locale (e.g. *en_US* ``Jacky-winter`` vs *en_AU*
     ``Jacky Winter``). Checklist exports follow the observer's regional names, which may not
-    match :func:`load_taxonomy`'s locale — try both forms before giving up (#156).
+    match :func:`load_taxonomy`'s locale, so we try both separator forms before giving up.
 
     Note: swapping ``' '`` → ``'-'`` preserves per-word casing, so ``Jacky Winter`` becomes
     ``Jacky-Winter`` while the CSV may use ``Jacky-winter``; :func:`_code_for_common_name`
@@ -91,7 +91,12 @@ def _hyphen_space_lookup_variants(name: str) -> tuple[str, ...]:
 
 
 def _normalize_common_name_for_lookup(name: str) -> str:
-    """Collapse hyphen vs space and case differences for fuzzy species-name matching (#156)."""
+    """Collapse hyphen vs space and case so two spellings of the same name compare equal.
+
+    Needed when naive space-to-hyphen substitution yields the wrong letter case after a
+    hyphen (e.g. ``Jacky-Winter``) while the taxonomy row uses eBird's casing (e.g.
+    ``Jacky-winter``), or when locale and export strings disagree on spaces vs hyphens.
+    """
     s = str(name).strip().replace("-", " ")
     while "  " in s:
         s = s.replace("  ", " ")

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -317,6 +317,14 @@ def map_banner_and_legend_theme_stylesheet() -> str:
 .pebird-map-banner__stats-secondary {{
   font-size: calc(1em - 3px);
 }}
+/* Families map: optional line under family metrics when a species is highlighted (matches species-map wording). */
+.pebird-map-banner__family-selected-summary {{
+  display: block;
+  font-size: calc(1em - 2px);
+  font-weight: 400;
+  color: {EXPLORER_UI_MUTED};
+  margin-top: 6px;
+}}
 .pebird-map-banner__stats a {{
   color: inherit;
   text-decoration: none;
@@ -615,6 +623,15 @@ def _banner_sep() -> str:
     return '<span class="pebird-map-banner__sep" aria-hidden="true">·</span>'
 
 
+def checklist_individual_stats_banner_fragment(n_checklists: int, n_individuals: int) -> str:
+    """HTML fragment for the species-map primary stats line (checklists and individuals)."""
+    sep_dot = _banner_sep()
+    return (
+        f'{n_checklists} checklist{"s" if n_checklists != 1 else ""}'
+        f'{sep_dot}{n_individuals} individual{"s" if n_individuals != 1 else ""}'
+    )
+
+
 def _banner_muted_line(text: str | None) -> str:
     if not text:
         return ""
@@ -748,11 +765,8 @@ def build_species_banner_html(
         if species_url
         else title_esc
     )
+    line2 = checklist_individual_stats_banner_fragment(n_checklists, n_individuals)
     sep_dot = _banner_sep()
-    line2 = (
-        f'{n_checklists} checklist{"s" if n_checklists != 1 else ""}'
-        f'{sep_dot}{n_individuals} individual{"s" if n_individuals != 1 else ""}'
-    )
     line3_parts = []
     if first_seen_date:
         line3_parts.append(f"First seen: {_maybe_link(first_seen_date, first_seen_checklist_url)}")

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -48,6 +48,11 @@ EXPLORER_UI_MUTED = "rgba(26, 46, 34, 0.55)"
 EXPLORER_UI_POPUP_DETAILS_CHEVRON = "rgba(26, 46, 34, 0.36)"
 EXPLORER_UI_BORDER_PANEL = "rgba(31, 111, 84, 0.18)"
 
+# Species-map location popup: leave <details> open only for short lists so the popup stays scannable.
+# Per species section: open when this many observation rows or fewer (not number of taxa at the pin).
+SPECIES_MAP_POPUP_OPEN_SPECIES_SECTION_MAX_OBSERVATIONS = 3
+SPECIES_MAP_POPUP_OPEN_VISIT_LIST_MAX_CHECKLISTS = 1
+
 
 def map_popup_theme_stylesheet() -> str:
     """Return a ``<style>`` block for Leaflet popups (injected once per map via ``branca.element.Element``).
@@ -449,26 +454,35 @@ def format_species_map_sighting_row(r: pd.Series) -> str:
 def build_species_seen_sections_html(species_sightings: pd.DataFrame, *, ascending: bool) -> str:
     """Group *species_sightings* by ``Common Name``; one ``<details>`` block per taxon (refs #145).
 
-    Multiple taxa: sections start **collapsed**. A single taxon: that section has the HTML ``open``
-    attribute so observations show immediately.
+    The summary line matches the visit list pattern, ``Name: (n)``, where *n* is the number of
+    observation rows for that species at this pin (not the sum of ``Count``).
+
+    Each section gets the HTML ``open`` attribute when that species has at most
+    :data:`SPECIES_MAP_POPUP_OPEN_SPECIES_SECTION_MAX_OBSERVATIONS` rows at this location. Longer
+    lists start collapsed so the popup is not filled with one species' history.
     """
     if species_sightings.empty or "Common Name" not in species_sightings.columns:
         return ""
     work = species_sightings.copy()
     work["Common Name"] = work["Common Name"].fillna("Unknown")
     names = sorted(work["Common Name"].unique(), key=lambda x: str(x).lower())
-    n_taxa = len(names)
     parts: list[str] = []
     for common_name in names:
         sub = work[work["Common Name"] == common_name]
         if "datetime" in sub.columns:
             sub = sub.sort_values("datetime", ascending=ascending)
+        n_obs = len(sub)
         rows = "".join(format_species_map_sighting_row(r) for _, r in sub.iterrows())
-        esc_name = esc_text(str(common_name))
-        open_attr = " open" if n_taxa == 1 else ""
+        # Match ``Visited: (n)`` on the visit list: observation count = rows at this pin, not sum(Count).
+        summary_label = esc_text(f"{common_name}: ({n_obs})")
+        open_attr = (
+            " open"
+            if n_obs <= SPECIES_MAP_POPUP_OPEN_SPECIES_SECTION_MAX_OBSERVATIONS
+            else ""
+        )
         parts.append(
             f'<details class="pebird-map-popup__species-seen"{open_attr}>'
-            f'<summary class="pebird-map-popup__section-label">{esc_name}:</summary>'
+            f'<summary class="pebird-map-popup__section-label">{summary_label}</summary>'
             f'<div class="pebird-map-popup__obs-list">{rows}</div>'
             f"</details>"
         )
@@ -582,6 +596,10 @@ def build_species_map_location_popup_html(
 ) -> str:
     """Popup for **species-matching** markers on the species map: species sections first, visits in ``<details>``.
 
+    Species ``<details>`` blocks use :data:`SPECIES_MAP_POPUP_OPEN_SPECIES_SECTION_MAX_OBSERVATIONS` rows per
+    taxon; the visit list uses :data:`SPECIES_MAP_POPUP_OPEN_VISIT_LIST_MAX_CHECKLISTS` for when to leave
+    that block open.
+
     Non-matching pins use :func:`build_location_popup_html` without species sections (refs #145).
     """
     loc_url = f"https://ebird.org/lifelist/{loc_id}"
@@ -594,8 +612,13 @@ def build_species_map_location_popup_html(
     summary_text = f"Visited: ({visit_record_count})"
     esc_summary = esc_text(summary_text)
     inner_visits = visit_info_html if (visit_info_html and str(visit_info_html).strip()) else ""
+    visits_open = (
+        " open"
+        if visit_record_count <= SPECIES_MAP_POPUP_OPEN_VISIT_LIST_MAX_CHECKLISTS
+        else ""
+    )
     details_block = (
-        f'<details class="pebird-map-popup__all-visits">'
+        f'<details class="pebird-map-popup__all-visits"{visits_open}>'
         f'<summary class="pebird-map-popup__section-label">{esc_summary}</summary>'
         f'<div class="pebird-map-popup__visit-list-inner">{inner_visits}</div>'
         f"</details>"

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -298,6 +298,10 @@ def map_banner_and_legend_theme_stylesheet() -> str:
   font-weight: 400;
   margin: 0;
 }}
+/* Species map only: secondary stats (first/last seen, high count) below the primary summary line (#162). */
+.pebird-map-banner__stats-secondary {{
+  font-size: calc(1em - 3px);
+}}
 .pebird-map-banner__stats a {{
   color: inherit;
   text-decoration: none;
@@ -741,7 +745,11 @@ def build_species_banner_html(
     return (
         f'<div class="pebird-map-banner" style="{_BANNER_POSITION}">'
         f'<span class="pebird-map-banner__title">{title_html}</span>'
-        f'<div class="pebird-map-banner__stats">{line2}<br>{line3}<br>{line4}</div>'
+        f'<div class="pebird-map-banner__stats">'
+        f'<span class="pebird-map-banner__stats-primary">{line2}</span><br>'
+        f'<span class="pebird-map-banner__stats-secondary">{line3}</span><br>'
+        f'<span class="pebird-map-banner__stats-secondary">{line4}</span>'
+        f'</div>'
         f'{date_block}'
         f'</div>'
     )

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -125,6 +125,21 @@ def map_popup_theme_stylesheet() -> str:
   font-size: inherit;
   line-height: inherit;
 }}
+/* Family map / no-URL title: match linked ``.pebird-map-popup__location-heading`` colour (#158). */
+.pebird-map-popup span.pebird-map-popup__location-heading {{
+  color: {EXPLORER_UI_PRIMARY_GREEN};
+  font-weight: 600;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}}
+/* All-locations visit list: tight gap between section label and date links (#158). */
+.pebird-map-popup__visited-block .pebird-map-popup__section-label {{
+  margin: 0 0 0.15em 0;
+}}
+.pebird-map-popup__visit-dates {{
+  margin: 0;
+  padding: 0;
+}}
 .pebird-map-popup__obs-count {{
   color: {EXPLORER_UI_MUTED};
   font-weight: 400;
@@ -486,7 +501,7 @@ def build_location_popup_html(
     lifer_heading_html: str = (
         '<div class="pebird-map-popup__section-label">Lifers (first recorded here):</div>'
     ),
-    location_heading_margin_px: int = 6,
+    location_heading_margin_px: int = 4,
 ):
     """Build the full popup HTML for a single map marker.
 
@@ -504,6 +519,8 @@ def build_location_popup_html(
             (used by the lifer-map popup simplification; refs #104).
         lifer_heading_html: Optional heading HTML prepended when *lifer_species_html*
             is provided. Pass ``""`` to omit the heading (used by lifer-map popups).
+        location_heading_margin_px: Gap below the location title row (default ``4``). Species-map
+            popups use ``6`` via :func:`build_species_map_location_popup_html` (#158).
 
     Returns:
         Complete popup HTML string with scroll wrapper.
@@ -523,7 +540,10 @@ def build_location_popup_html(
     else:
         extra_section = ""
     visited_section = (
-        f'<div class="pebird-map-popup__section-label">Visited:</div><br>{visit_info_html}'
+        '<div class="pebird-map-popup__visited-block">'
+        '<div class="pebird-map-popup__section-label">Visited:</div>'
+        f'<div class="pebird-map-popup__visit-dates">{visit_info_html}</div>'
+        "</div>"
         if show_visit_history
         else ""
     )

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -20,7 +20,7 @@ import pandas as pd
 from branca.element import MacroElement
 from folium.template import Template
 
-from explorer.core.stats import safe_count
+from explorer.core.stats import format_observed_count_for_map_popup
 from explorer.presentation.stats_html_helpers import esc_attr, esc_text
 from explorer.app.streamlit.defaults import (
     MAP_HEIGHT_PX_DEFAULT,
@@ -400,7 +400,8 @@ def format_sighting_row(r):
     else:
         date_str = r["Date"].strftime("%Y-%m-%d") if pd.notna(r["Date"]) else "unknown"
         time_str = str(r["Time"]) if pd.notna(r["Time"]) else "unknown"
-    text = f"{date_str} {time_str} — {r['Common Name']} ({r['Count']})"
+    count_disp = format_observed_count_for_map_popup(r.get("Count"))
+    text = f"{date_str} {time_str} — {r['Common Name']} ({count_disp})"
     cid = str(r.get("Submission ID", "") or "").strip()
     checklist_url = f"https://ebird.org/checklist/{cid}" if cid else "#"
     media_html = ""
@@ -427,7 +428,7 @@ def format_species_map_sighting_row(r: pd.Series) -> str:
         date_str = r["Date"].strftime("%Y-%m-%d") if pd.notna(r.get("Date")) else "unknown"
         time_str = str(r["Time"]) if pd.notna(r.get("Time")) else "unknown"
         link_text = f"{date_str} {time_str}"
-    n = safe_count(r.get("Count"))
+    n = format_observed_count_for_map_popup(r.get("Count"))
     cid = str(r.get("Submission ID", "") or "").strip()
     checklist_url = f"https://ebird.org/checklist/{cid}" if cid else "#"
     media_html = ""
@@ -440,7 +441,7 @@ def format_species_map_sighting_row(r: pd.Series) -> str:
         '<div class="pebird-map-popup__obs-line">'
         f'<a href="{esc_attr(checklist_url)}" target="_blank" rel="noopener noreferrer">'
         f"{esc_text(link_text)}</a> "
-        f'<span class="pebird-map-popup__obs-count">(Observed: {n})</span>{media_html}'
+        f'<span class="pebird-map-popup__obs-count">(Observed: {esc_text(n)})</span>{media_html}'
         f"</div>"
     )
 

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -80,7 +80,14 @@ def map_popup_theme_stylesheet() -> str:
   max-width: min({MAP_POPUP_MAX_WIDTH_PX}px, calc(100vw - 40px));
   vertical-align: top;
 }}
-.pebird-map-popup__heading-row,
+.pebird-map-popup__heading-row {{
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  /* Leaflet's close control sits top-right; long titles must not run under it. */
+  padding-right: 2rem;
+}}
 .pebird-map-popup__scroll {{
   width: fit-content;
   max-width: 100%;
@@ -117,8 +124,13 @@ def map_popup_theme_stylesheet() -> str:
   color: {EXPLORER_UI_PRIMARY_GREEN};
   text-decoration: none;
 }}
-/* Location title link: heavier than body links (refs #70). */
+/* Location title link: heavier than body links (refs #70). Block + full row width so wrapping
+   respects the popup box (inline + fit-content chain was letting long names spill past the card). */
 .pebird-map-popup a.pebird-map-popup__location-heading {{
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
   font-weight: 600;
   overflow-wrap: anywhere;
   word-break: break-word;

--- a/tests/explorer/test_family_map_compute.py
+++ b/tests/explorer/test_family_map_compute.py
@@ -250,3 +250,5 @@ def test_format_family_location_popup_html_links():
     assert "Bird A" in html
     assert "species/foo" in html
     assert "Bird B" in html
+    assert "pebird-map-popup__location-heading" in html
+    assert "pebird-map-popup__heading-row" in html

--- a/tests/explorer/test_family_map_compute.py
+++ b/tests/explorer/test_family_map_compute.py
@@ -18,6 +18,7 @@ from explorer.core.family_map_compute import (
     highlight_species_choices_alphabetical,
     merge_taxonomy_detail_for_family_map,
     prepare_family_map_work_frame,
+    selected_species_checklist_individual_counts,
     taxonomy_species_count_for_family,
 )
 
@@ -100,6 +101,18 @@ def test_taxonomy_species_count_for_family():
     assert taxonomy_species_count_for_family(tax, "G1") == 3
     assert taxonomy_species_count_for_family(tax, "G2") == 1
     assert taxonomy_species_count_for_family(tax, "None") == 0
+
+
+def test_selected_species_checklist_individual_counts_matches_filter_species():
+    """Highlight totals use the same species filter as the species map (base + subspecies rows)."""
+    df = _tiny_export_rows()
+    work = prepare_family_map_work_frame(df, _base_to_family_stub())
+    wf = filter_work_to_family(work, "Whistlers and Allies")
+    # Rufous: two rows, one checklist (Submission ID C)
+    assert selected_species_checklist_individual_counts(wf, "pachycephala rufiventris") == (1, 2)
+    # Golden Whistler (Eastern) subspecies → base pachycephala pectoralis
+    assert selected_species_checklist_individual_counts(wf, "pachycephala pectoralis") == (1, 1)
+    assert selected_species_checklist_individual_counts(wf, "") is None
 
 
 def test_banner_metrics():

--- a/tests/explorer/test_family_map_folium.py
+++ b/tests/explorer/test_family_map_folium.py
@@ -117,11 +117,29 @@ def test_family_map_banner_optional_selected_species_summary_line():
         ),
         selected_species_n_checklists=4,
         selected_species_n_individuals=9,
+        selected_species_display_name="Golden Whistler",
     )
     assert "12 in taxonomy" in banner
     assert "pebird-map-banner__family-selected-summary" in banner
+    assert "Golden Whistler:" in banner
     assert "4 checklists" in banner
     assert "9 individuals" in banner
+
+
+def test_family_map_banner_selected_species_display_name_escapes_html():
+    banner = build_family_map_banner_overlay_html(
+        FamilyMapBannerMetrics(
+            family_name="F",
+            total_species_taxonomy=1,
+            species_recorded_user=1,
+            locations_with_records=1,
+        ),
+        selected_species_n_checklists=1,
+        selected_species_n_individuals=2,
+        selected_species_display_name="A & B <test>",
+    )
+    assert "A &amp; B &lt;test&gt;:" in banner
+    assert "<test>" not in banner
 
 
 def test_build_family_map_empty_pins_still_returns_map():

--- a/tests/explorer/test_family_map_folium.py
+++ b/tests/explorer/test_family_map_folium.py
@@ -107,6 +107,23 @@ def test_family_map_banner_percent_omits_when_taxonomy_total_is_zero():
     assert "%" not in banner
 
 
+def test_family_map_banner_optional_selected_species_summary_line():
+    banner = build_family_map_banner_overlay_html(
+        FamilyMapBannerMetrics(
+            family_name="Whistlers",
+            total_species_taxonomy=12,
+            species_recorded_user=5,
+            locations_with_records=2,
+        ),
+        selected_species_n_checklists=4,
+        selected_species_n_individuals=9,
+    )
+    assert "12 in taxonomy" in banner
+    assert "pebird-map-banner__family-selected-summary" in banner
+    assert "4 checklists" in banner
+    assert "9 individuals" in banner
+
+
 def test_build_family_map_empty_pins_still_returns_map():
     m = build_family_composition_folium_map(())
     html = m._repr_html_()

--- a/tests/explorer/test_map_renderer.py
+++ b/tests/explorer/test_map_renderer.py
@@ -355,6 +355,8 @@ def test_build_species_banner_html_full():
     assert "20-Feb-2026</a>" in html
     assert 'High count: <a href="https://ebird.org/checklist/S3"' in html
     assert "05-Mar-2025</a> (8)" in html
+    assert "pebird-map-banner__stats-primary" in html
+    assert html.count("pebird-map-banner__stats-secondary") == 2
 
 
 def test_build_species_banner_html_no_dates():

--- a/tests/explorer/test_map_renderer.py
+++ b/tests/explorer/test_map_renderer.py
@@ -153,6 +153,21 @@ def test_format_species_map_sighting_row_media():
     assert 'title="media"' in html
 
 
+def test_format_species_map_sighting_row_count_x_not_zero():
+    row = pd.Series({
+        "Date": pd.Timestamp("2022-01-17"),
+        "Time": "23:59",
+        "Common Name": "Some Bird",
+        "Count": "X",
+        "Submission ID": "SCHK",
+        "ML Catalog Numbers": None,
+        "datetime": pd.Timestamp("2022-01-17 23:59"),
+    })
+    html = format_species_map_sighting_row(row)
+    assert "(Observed: x)" in html
+    assert "(Observed: 0)" not in html
+
+
 def test_build_species_seen_sections_two_common_names():
     df = pd.DataFrame({
         "Common Name": ["Grey Teal", "Pacific Golden Plover", "Grey Teal"],

--- a/tests/explorer/test_map_renderer.py
+++ b/tests/explorer/test_map_renderer.py
@@ -447,6 +447,8 @@ def test_build_location_popup_html_visits_only():
     assert "My Park" in html
     assert "ebird.org/lifelist/L12345" in html
     assert "Visited:" in html
+    assert "pebird-map-popup__visited-block" in html
+    assert "pebird-map-popup__visit-dates" in html
     assert "Seen:" not in html
     assert "popup-scroll-wrapper" in html
 

--- a/tests/explorer/test_map_renderer.py
+++ b/tests/explorer/test_map_renderer.py
@@ -181,12 +181,37 @@ def test_build_species_seen_sections_two_common_names():
         "ML Catalog Numbers": [None, None, None],
     })
     html = build_species_seen_sections_html(df, ascending=True)
-    assert html.count('<details class="pebird-map-popup__species-seen">') == 2
-    assert '<details class="pebird-map-popup__species-seen" open>' not in html
-    assert 'pebird-map-popup__section-label">Grey Teal:</summary>' in html
-    assert 'pebird-map-popup__section-label">Pacific Golden Plover:</summary>' in html
+    assert html.count('<details class="pebird-map-popup__species-seen" open>') == 2
+    assert 'pebird-map-popup__section-label">Grey Teal: (2)</summary>' in html
+    assert 'pebird-map-popup__section-label">Pacific Golden Plover: (1)</summary>' in html
     assert "pebird-map-popup__obs-list" in html
     assert html.index("Grey Teal") < html.index("Pacific Golden Plover")
+
+
+def test_build_species_seen_sections_many_observations_collapsed():
+    df = pd.DataFrame({
+        "Common Name": ["Red Wattlebird"] * 4,
+        "datetime": [pd.Timestamp(f"2025-01-{i:02d} 08:00") for i in range(1, 5)],
+        "Count": [1, 1, 1, 1],
+        "Submission ID": ["S1", "S2", "S3", "S4"],
+        "ML Catalog Numbers": [None, None, None, None],
+    })
+    html = build_species_seen_sections_html(df, ascending=True)
+    assert '<details class="pebird-map-popup__species-seen" open>' not in html
+    assert 'pebird-map-popup__section-label">Red Wattlebird: (4)</summary>' in html
+
+
+def test_build_species_seen_sections_three_observations_still_open():
+    df = pd.DataFrame({
+        "Common Name": ["Red Wattlebird"] * 3,
+        "datetime": [pd.Timestamp(f"2025-01-{i:02d} 08:00") for i in range(1, 4)],
+        "Count": [1, 1, 1],
+        "Submission ID": ["S1", "S2", "S3"],
+        "ML Catalog Numbers": [None, None, None],
+    })
+    html = build_species_seen_sections_html(df, ascending=True)
+    assert '<details class="pebird-map-popup__species-seen" open>' in html
+    assert 'pebird-map-popup__section-label">Red Wattlebird: (3)</summary>' in html
 
 
 def test_build_species_map_location_popup_html_collapsed_visits():
@@ -207,11 +232,33 @@ def test_build_species_map_location_popup_html_collapsed_visits():
         popup_ascending=True,
     )
     assert '<details class="pebird-map-popup__species-seen" open>' in html
+    assert '<details class="pebird-map-popup__all-visits" open>' not in html
     assert "details" in html and "pebird-map-popup__all-visits" in html
     assert "Visited: (3)" in html
     assert visit_fragment in html
     # Species map uses <summary>, not the standalone Visited block from build_location_popup_html.
     assert '<div class="pebird-map-popup__section-label">Visited:</div>' not in html
+
+
+def test_build_species_map_location_popup_html_visits_open_when_single_checklist():
+    species_df = pd.DataFrame({
+        "Common Name": ["Bird X"],
+        "datetime": [pd.Timestamp("2025-06-01 12:00")],
+        "Count": [5],
+        "Submission ID": ["SID1"],
+        "ML Catalog Numbers": [None],
+    })
+    visit_fragment = '<a href="https://ebird.org/checklist/V1">2025-01-01</a>'
+    html = build_species_map_location_popup_html(
+        "Hotspot",
+        "L99",
+        species_df,
+        visit_fragment,
+        visit_record_count=1,
+        popup_ascending=True,
+    )
+    assert '<details class="pebird-map-popup__all-visits" open>' in html
+    assert "Visited: (1)" in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/explorer/test_stats.py
+++ b/tests/explorer/test_stats.py
@@ -5,6 +5,7 @@ import pandas as pd
 from explorer.core.stats import (
     checklist_country_keys,
     country_summary_stats,
+    format_observed_count_for_map_popup,
     safe_count,
     longest_streak,
     region_column,
@@ -41,6 +42,28 @@ class TestSafeCount:
 
     def test_plain_int(self):
         assert safe_count(42) == 42
+
+
+# ---------------------------------------------------------------------------
+# format_observed_count_for_map_popup
+# ---------------------------------------------------------------------------
+
+class TestFormatObservedCountForMapPopup:
+    def test_x_is_lowercase_x(self):
+        assert format_observed_count_for_map_popup("X") == "x"
+        assert format_observed_count_for_map_popup(" x ") == "x"
+
+    def test_numeric_strings(self):
+        assert format_observed_count_for_map_popup("5") == "5"
+        assert format_observed_count_for_map_popup(0) == "0"
+        assert format_observed_count_for_map_popup("0") == "0"
+
+    def test_missing_or_unparseable_not_zero(self):
+        assert format_observed_count_for_map_popup(None) == "unknown"
+        assert format_observed_count_for_map_popup(float("nan")) == "unknown"
+        assert format_observed_count_for_map_popup("") == "unknown"
+        assert format_observed_count_for_map_popup("   ") == "unknown"
+        assert format_observed_count_for_map_popup("nope") == "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/explorer/test_taxonomy.py
+++ b/tests/explorer/test_taxonomy.py
@@ -128,3 +128,22 @@ def test_subspecies_links_to_main_species():
         assert taxonomy.get_species_url("Eastern Barn Owl") == "https://ebird.org/species/easbar1"
     finally:
         taxonomy._common_to_code = None
+
+
+def test_hyphen_vs_space_locale_mismatch_jacky_winter():
+    """Spaced export name matches hyphenated taxonomy row (e.g. en_US vs en_AU) (#156)."""
+    taxonomy._common_to_code = {"Jacky-winter": "jacwin1"}
+    try:
+        assert taxonomy.get_species_url("Jacky Winter") == "https://ebird.org/species/jacwin1"
+        assert taxonomy.get_species_lifelist_url("Jacky Winter") == "https://ebird.org/lifelist?spp=jacwin1"
+    finally:
+        taxonomy._common_to_code = None
+
+
+def test_hyphen_vs_space_reverse_lookup():
+    """Hyphenated query matches spaced taxonomy row."""
+    taxonomy._common_to_code = {"Jacky Winter": "jacwin1"}
+    try:
+        assert taxonomy.get_species_url("Jacky-winter") == "https://ebird.org/species/jacwin1"
+    finally:
+        taxonomy._common_to_code = None

--- a/tests/explorer/test_taxonomy.py
+++ b/tests/explorer/test_taxonomy.py
@@ -131,7 +131,11 @@ def test_subspecies_links_to_main_species():
 
 
 def test_hyphen_vs_space_locale_mismatch_jacky_winter():
-    """Spaced export name matches hyphenated taxonomy row (e.g. en_US vs en_AU) (#156)."""
+    """Spaced name from UI/export resolves when the loaded taxonomy only has a hyphenated key.
+
+    Mirrors locale skew: export wording can differ from the common-name column in the CSV
+    loaded for URLs (hyphen vs space, and letter case after hyphens).
+    """
     taxonomy._common_to_code = {"Jacky-winter": "jacwin1"}
     try:
         assert taxonomy.get_species_url("Jacky Winter") == "https://ebird.org/species/jacwin1"


### PR DESCRIPTION
## Summary

Integration branch bringing **map UI, popups, families banner, taxonomy URL handling, and Streamlit species controls** into `beta-next`. Work spans several issues (see below); details are in commit messages.

## Changes

- **Species map popups:** Show `x` / `unknown` instead of misleading `Observed: 0` for eBird `X` counts (`format_observed_count_for_map_popup`); align all-locations “Seen” lines. Per-species `<details>` open only for short observation lists; `Visited` block open only for a single checklist; species summaries show `Common Name: (n)` observation rows; long location titles wrap inside the card with space for Leaflet’s close control.
- **Families map:** Highlight/banner copy and checklist/individual summary behaviour (#161 area).
- **Taxonomy:** Species URL resolution when CSV vs UI strings differ by hyphen/case/locale (#156).
- **Map chrome:** Family popup alignment with visit styling (#158); species banner secondary stats (#162); sidebar species control order / duplicate label (#163).
- **Meta:** Empty marker commit tying #159 / #126 as recorded in history.

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (441 passed)

## Notes

- Pop-up behaviour was iterated with manual map checks; threshold for auto-open species sections is tunable via constants in `explorer/presentation/map_renderer.py`.

## Issues

Refs #126, #156, #158, #159, #160, #162, #163
