### PR TITLE
Improve all-locations map area controls and focused default viewport

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: bug
 assignees: ''
 ---
 
-The following is a guide on how to give developer(s) enough information to find, reproduce and fix a reported bug.  Treat this as a guide and not perscriptive; we will understand if not all information is included on a simple bug that is easy to find/explain for example.
+The following is a guide on how to give developer(s) enough information to find, reproduce and fix a reported bug.  Treat this as a guide and not prescriptive; we will understand if not all information is included on a simple bug that is easy to find/explain for example.
 
 Feel free to remove text below that is not required.  Clear and consice is better than verbose and cluttered.
 

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -155,12 +155,8 @@ STREAMLIT_MARK_LAST_SEEN_KEY = "streamlit_mark_last_seen"
 # All-locations map only (species / lifer maps never cluster).
 # Runtime: sidebar toggle; map build + cache signature.
 STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY = "streamlit_map_cluster_all_locations"
-# All locations: viewport framing, geographic focus, preserved pan/zoom (refs #166).
-STREAMLIT_ALL_LOCATIONS_FRAMING_KEY = "streamlit_all_locations_framing"
-STREAMLIT_ALL_LOCATIONS_FOCUS_KEY = "streamlit_all_locations_focus_country"
-STREAMLIT_ALL_LOCATIONS_RESET_VIEW_BTN_KEY = "streamlit_all_locations_reset_view_btn"
-STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY = "_streamlit_all_locations_preserved_center_zoom"
-STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY = "_streamlit_all_locations_reset_nonce"
+# All locations map: single control — fit all / centre of gravity / per-country fit (refs #166).
+STREAMLIT_ALL_LOCATIONS_SCOPE_KEY = "streamlit_all_locations_scope"
 # Settings → Apply map settings: defer syncing this key until next run (before sidebar widget; refs Streamlit widget rules).
 STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_APPLY_PENDING_KEY = "_streamlit_map_cluster_apply_from_settings_pending"
 # Persisted default: Settings form + Save settings / YAML (may differ from runtime after sidebar).

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -155,6 +155,12 @@ STREAMLIT_MARK_LAST_SEEN_KEY = "streamlit_mark_last_seen"
 # All-locations map only (species / lifer maps never cluster).
 # Runtime: sidebar toggle; map build + cache signature.
 STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY = "streamlit_map_cluster_all_locations"
+# All locations: viewport framing, geographic focus, preserved pan/zoom (refs #166).
+STREAMLIT_ALL_LOCATIONS_FRAMING_KEY = "streamlit_all_locations_framing"
+STREAMLIT_ALL_LOCATIONS_FOCUS_KEY = "streamlit_all_locations_focus_country"
+STREAMLIT_ALL_LOCATIONS_RESET_VIEW_BTN_KEY = "streamlit_all_locations_reset_view_btn"
+STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY = "_streamlit_all_locations_preserved_center_zoom"
+STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY = "_streamlit_all_locations_reset_nonce"
 # Settings → Apply map settings: defer syncing this key until next run (before sidebar widget; refs Streamlit widget rules).
 STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_APPLY_PENDING_KEY = "_streamlit_map_cluster_apply_from_settings_pending"
 # Persisted default: Settings form + Save settings / YAML (may differ from runtime after sidebar).

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -30,6 +30,11 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_MAP_BASEMAP_KEY,
     STREAMLIT_MAP_BASEMAP_SAVED_KEY,
     STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
+    STREAMLIT_ALL_LOCATIONS_FOCUS_KEY,
+    STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
+    STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY,
+    STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY,
+    STREAMLIT_ALL_LOCATIONS_RESET_VIEW_BTN_KEY,
     STREAMLIT_MAP_DATE_FILTER_KEY,
     STREAMLIT_MAP_DATE_RANGE_KEY,
     STREAMLIT_MAP_HEIGHT_PX_KEY,
@@ -74,6 +79,13 @@ from explorer.app.streamlit.streamlit_ui_constants import (
     SPECIES_SEARCH_CAPTION,
     SPECIES_SEARCH_HELP_EXPANDER_LABEL,
 )
+from explorer.core.all_locations_viewport import (
+    ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
+    ALL_LOCATIONS_FRAMING_FIT_ALL,
+    ALL_LOCATIONS_FRAMING_LAST_VIEWED,
+    sorted_country_labels_from_work,
+)
+from explorer.core.region_display import map_focus_key_for_display
 from explorer.core.species_search import (
     SPECIES_WHOOSH_INDEX_VERSION,
     build_ram_species_whoosh_index,
@@ -214,6 +226,40 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 key=STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
                 help="Clusters nearby pins at low zoom. Session-only (save in Settings to persist).",
             )
+            _framing_labels = {
+                ALL_LOCATIONS_FRAMING_FIT_ALL: "Show all locations",
+                ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY: "My centre",
+                ALL_LOCATIONS_FRAMING_LAST_VIEWED: "Last viewed",
+            }
+            st.selectbox(
+                "Location framing",
+                options=[
+                    ALL_LOCATIONS_FRAMING_FIT_ALL,
+                    ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
+                    ALL_LOCATIONS_FRAMING_LAST_VIEWED,
+                ],
+                format_func=lambda v: _framing_labels.get(v, v),
+                key=STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
+            )
+            _focus_countries = sorted_country_labels_from_work(df_full)
+            st.selectbox(
+                "Focus",
+                options=[""] + _focus_countries,
+                format_func=lambda c: (
+                    "All locations" if c == "" else map_focus_key_for_display(c)
+                ),
+                key=STREAMLIT_ALL_LOCATIONS_FOCUS_KEY,
+            )
+            if st.button(
+                "Reset view",
+                key=STREAMLIT_ALL_LOCATIONS_RESET_VIEW_BTN_KEY,
+                help="Clear saved pan/zoom for “Last viewed” and re-apply the current framing mode.",
+            ):
+                st.session_state.pop(STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY, None)
+                st.session_state[STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY] = int(
+                    st.session_state.get(STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY, 0)
+                ) + 1
+                invalidate_folium_map_embed_cache()
 
     # Working set is still date-filtered for checklist stats and other tabs.
     # Family map ignores date filtering (v1), but we preserve the date filter controls and state.

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -30,11 +30,7 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_MAP_BASEMAP_KEY,
     STREAMLIT_MAP_BASEMAP_SAVED_KEY,
     STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
-    STREAMLIT_ALL_LOCATIONS_FOCUS_KEY,
-    STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
-    STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY,
-    STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY,
-    STREAMLIT_ALL_LOCATIONS_RESET_VIEW_BTN_KEY,
+    STREAMLIT_ALL_LOCATIONS_SCOPE_KEY,
     STREAMLIT_MAP_DATE_FILTER_KEY,
     STREAMLIT_MAP_DATE_RANGE_KEY,
     STREAMLIT_MAP_HEIGHT_PX_KEY,
@@ -82,8 +78,7 @@ from explorer.app.streamlit.streamlit_ui_constants import (
 from explorer.core.all_locations_viewport import (
     ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
     ALL_LOCATIONS_FRAMING_FIT_ALL,
-    ALL_LOCATIONS_FRAMING_LAST_VIEWED,
-    sorted_country_labels_from_work,
+    all_locations_scope_option_values,
 )
 from explorer.core.region_display import map_focus_key_for_display
 from explorer.core.species_search import (
@@ -226,40 +221,6 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 key=STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
                 help="Clusters nearby pins at low zoom. Session-only (save in Settings to persist).",
             )
-            _framing_labels = {
-                ALL_LOCATIONS_FRAMING_FIT_ALL: "Show all locations",
-                ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY: "My centre",
-                ALL_LOCATIONS_FRAMING_LAST_VIEWED: "Last viewed",
-            }
-            st.selectbox(
-                "Location framing",
-                options=[
-                    ALL_LOCATIONS_FRAMING_FIT_ALL,
-                    ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
-                    ALL_LOCATIONS_FRAMING_LAST_VIEWED,
-                ],
-                format_func=lambda v: _framing_labels.get(v, v),
-                key=STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
-            )
-            _focus_countries = sorted_country_labels_from_work(df_full)
-            st.selectbox(
-                "Focus",
-                options=[""] + _focus_countries,
-                format_func=lambda c: (
-                    "All locations" if c == "" else map_focus_key_for_display(c)
-                ),
-                key=STREAMLIT_ALL_LOCATIONS_FOCUS_KEY,
-            )
-            if st.button(
-                "Reset view",
-                key=STREAMLIT_ALL_LOCATIONS_RESET_VIEW_BTN_KEY,
-                help="Clear saved pan/zoom for “Last viewed” and re-apply the current framing mode.",
-            ):
-                st.session_state.pop(STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY, None)
-                st.session_state[STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY] = int(
-                    st.session_state.get(STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY, 0)
-                ) + 1
-                invalidate_folium_map_embed_cache()
 
     # Working set is still date-filtered for checklist stats and other tabs.
     # Family map ignores date filtering (v1), but we preserve the date filter controls and state.
@@ -287,6 +248,25 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             ),
         )
     work_df = ws.df
+
+    if map_view_mode == "all":
+        with st.sidebar:
+            _scope_opts = all_locations_scope_option_values(work_df)
+            _cur_scope = st.session_state.get(STREAMLIT_ALL_LOCATIONS_SCOPE_KEY)
+            if _cur_scope not in _scope_opts:
+                st.session_state[STREAMLIT_ALL_LOCATIONS_SCOPE_KEY] = ALL_LOCATIONS_FRAMING_FIT_ALL
+            st.selectbox(
+                "Map area",
+                options=_scope_opts,
+                format_func=lambda v: (
+                    "All locations"
+                    if v == ALL_LOCATIONS_FRAMING_FIT_ALL
+                    else "My centre"
+                    if v == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY
+                    else map_focus_key_for_display(v)
+                ),
+                key=STREAMLIT_ALL_LOCATIONS_SCOPE_KEY,
+            )
 
     hide_non_matching_locations = False
     species_pick_common: str | None = None

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -78,6 +78,7 @@ from explorer.app.streamlit.streamlit_ui_constants import (
 from explorer.core.all_locations_viewport import (
     ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
     ALL_LOCATIONS_FRAMING_FIT_ALL,
+    ALL_LOCATIONS_SCOPE_FOCUSED,
     all_locations_scope_option_values,
 )
 from explorer.core.region_display import map_focus_key_for_display
@@ -254,19 +255,26 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             _scope_opts = all_locations_scope_option_values(work_df)
             _cur_scope = st.session_state.get(STREAMLIT_ALL_LOCATIONS_SCOPE_KEY)
             if _cur_scope not in _scope_opts:
-                st.session_state[STREAMLIT_ALL_LOCATIONS_SCOPE_KEY] = ALL_LOCATIONS_FRAMING_FIT_ALL
+                st.session_state[STREAMLIT_ALL_LOCATIONS_SCOPE_KEY] = ALL_LOCATIONS_SCOPE_FOCUSED
             st.selectbox(
-                "Map area",
+                "Map focus",
                 options=_scope_opts,
                 format_func=lambda v: (
                     "All locations"
                     if v == ALL_LOCATIONS_FRAMING_FIT_ALL
-                    else "My centre"
+                    else "Focused"
+                    if v == ALL_LOCATIONS_SCOPE_FOCUSED
+                    else "My activity centre"
                     if v == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY
                     else map_focus_key_for_display(v)
                 ),
                 key=STREAMLIT_ALL_LOCATIONS_SCOPE_KEY,
             )
+            if st.session_state.get(STREAMLIT_ALL_LOCATIONS_SCOPE_KEY) == ALL_LOCATIONS_SCOPE_FOCUSED:
+                st.caption(
+                    "Focused view shows your main birding regions. "
+                    "Smaller or infrequent locations may be hidden."
+                )
 
     hide_non_matching_locations = False
     species_pick_common: str | None = None

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -34,10 +34,7 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_HIGH_COUNT_SORT_KEY,
     STREAMLIT_HIGH_COUNT_TIE_BREAK_KEY,
     STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
-    STREAMLIT_ALL_LOCATIONS_FOCUS_KEY,
-    STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
-    STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY,
-    STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY,
+    STREAMLIT_ALL_LOCATIONS_SCOPE_KEY,
     STREAMLIT_RANKINGS_TOP_N_KEY,
 )
 from explorer.app.streamlit.app_map_ui import (
@@ -65,8 +62,8 @@ from explorer.app.streamlit.streamlit_ui_constants import (
 )
 from explorer.app.streamlit.yearly_summary_streamlit_html import sync_yearly_summary_session_inputs
 from explorer.core.all_locations_viewport import (
+    ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
     ALL_LOCATIONS_FRAMING_FIT_ALL,
-    ALL_LOCATIONS_FRAMING_LAST_VIEWED,
     location_id_to_country_map,
 )
 from explorer.core.map_controller import build_species_overlay_map
@@ -89,43 +86,6 @@ from explorer.core.family_map_folium import (
     build_family_map_banner_overlay_html,
     build_family_map_legend_overlay_html_for_pins,
 )
-
-
-def _preserved_view_from_st_folium_out(out: Any) -> tuple[tuple[float, float], int] | None:
-    """Centre + zoom from streamlit-folium return dict (``zoom`` + ``bounds``)."""
-    if not isinstance(out, dict):
-        return None
-    z_raw = out.get("zoom")
-    b = out.get("bounds")
-    if z_raw is None or b is None or not isinstance(b, dict):
-        return None
-    # Folium may leave zoom as a non-scalar in defaults; ignore until Leaflet reports a level.
-    if isinstance(z_raw, (dict, list)):
-        return None
-    try:
-        zi = int(z_raw)
-    except (TypeError, ValueError):
-        return None
-    sw = b.get("_southWest") or {}
-    ne = b.get("_northEast") or {}
-    try:
-        lat0 = float(sw["lat"])
-        lat1 = float(ne["lat"])
-        lng0 = float(sw["lng"])
-        lng1 = float(ne["lng"])
-    except (KeyError, TypeError, ValueError):
-        return None
-    return ((lat0 + lat1) / 2.0, (lng0 + lng1) / 2.0), zi
-
-
-def _preserved_view_is_plausible(pv: tuple[tuple[float, float], int]) -> bool:
-    """Drop bogus viewport snapshots (e.g. whole-world bounds) that would replace a good fit."""
-    (lat, lon), z = pv
-    if z < 1 or z > 22:
-        return False
-    if not (-90.0 <= lat <= 90.0) or not (-180.0 <= lon <= 180.0):
-        return False
-    return True
 
 
 def render_prep_spinner_and_map_tab(
@@ -201,14 +161,11 @@ def render_prep_spinner_and_map_tab(
                 st.session_state[POPUP_HTML_CACHE_KEY] = {}
                 st.session_state[FILTERED_BY_LOC_CACHE_KEY] = OrderedDict()
                 st.session_state.pop(FOLIUM_STATIC_MAP_CACHE_KEY, None)
-                st.session_state.pop(STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY, None)
 
             map_warning_text: str | None = None
             map_hint_text: str | None = None
             map_for_folium = None
             folium_st_key: str | None = None
-            folium_center_for_embed: tuple[float, float] | None = None
-            folium_zoom_for_embed: int | None = None
             capture_all_locations_view = False
             try:
                 ctx = prepare_all_locations_map_context(work_df, full_df=df_full)
@@ -353,43 +310,24 @@ def render_prep_spinner_and_map_tab(
                         "visit_marker_scheme": _visit_sch,
                     }
                     if capture_all_locations_view:
-                        _al_fr = str(
+                        _valid = {
+                            ALL_LOCATIONS_FRAMING_FIT_ALL,
+                            ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
+                        } | set(location_id_to_country_map(ctx["df"]).values())
+                        _scope = str(
                             st.session_state.get(
-                                STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
+                                STREAMLIT_ALL_LOCATIONS_SCOPE_KEY,
                                 ALL_LOCATIONS_FRAMING_FIT_ALL,
                             )
                             or ALL_LOCATIONS_FRAMING_FIT_ALL
                         ).strip()
-                        _al_fc = str(
-                            st.session_state.get(STREAMLIT_ALL_LOCATIONS_FOCUS_KEY, "") or ""
-                        ).strip()
-                        _map_kw["all_locations_framing"] = _al_fr
-                        _map_kw["all_locations_focus_country"] = _al_fc
+                        if _scope not in _valid:
+                            _scope = ALL_LOCATIONS_FRAMING_FIT_ALL
+                            st.session_state[STREAMLIT_ALL_LOCATIONS_SCOPE_KEY] = _scope
+                        _map_kw["all_locations_scope"] = _scope
                         _map_kw["all_locations_location_country"] = location_id_to_country_map(
                             ctx["df"]
                         )
-                        _pv = st.session_state.get(STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY)
-                        if _al_fr == ALL_LOCATIONS_FRAMING_LAST_VIEWED and isinstance(
-                            _pv, tuple
-                        ) and len(_pv) == 2:
-                            _ll, _zz = _pv
-                            if (
-                                isinstance(_ll, (tuple, list))
-                                and len(_ll) == 2
-                                and _zz is not None
-                            ):
-                                try:
-                                    _map_kw["all_locations_preserved_center_zoom"] = (
-                                        (float(_ll[0]), float(_ll[1])),
-                                        int(_zz),
-                                    )
-                                    folium_center_for_embed = (
-                                        float(_ll[0]),
-                                        float(_ll[1]),
-                                    )
-                                    folium_zoom_for_embed = int(_zz)
-                                except (TypeError, ValueError):
-                                    pass
                     _render_opts_sig = (
                         popup_sort_order,
                         popup_scroll_hint,
@@ -406,19 +344,13 @@ def render_prep_spinner_and_map_tab(
                         int(family_colour_scheme),
                         str(
                             st.session_state.get(
-                                STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
+                                STREAMLIT_ALL_LOCATIONS_SCOPE_KEY,
                                 ALL_LOCATIONS_FRAMING_FIT_ALL,
                             )
                             or ALL_LOCATIONS_FRAMING_FIT_ALL
                         )
                         if capture_all_locations_view
                         else "",
-                        str(st.session_state.get(STREAMLIT_ALL_LOCATIONS_FOCUS_KEY, "") or "")
-                        if capture_all_locations_view
-                        else "",
-                        int(st.session_state.get(STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY, 0))
-                        if capture_all_locations_view
-                        else 0,
                     )
                     _species_selected = bool(overlay_sci)
                     _ck = static_map_cache_key(
@@ -483,39 +415,14 @@ def render_prep_spinner_and_map_tab(
                             "`requirements.txt` at the repo root."
                         )
                         st.stop()
-                    # Only request bounds/zoom from the component in "Last viewed" mode; otherwise
-                    # keep returned_objects=[] like pre-#166 (avoids a post-load snap). Only persist
-                    # session when framing is Last viewed so Show all / My centre are not overwritten.
-                    _framing_now = str(
-                        st.session_state.get(
-                            STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
-                            ALL_LOCATIONS_FRAMING_FIT_ALL,
-                        )
-                        or ALL_LOCATIONS_FRAMING_FIT_ALL
-                    ).strip()
-                    _needs_folium_bounds = (
-                        capture_all_locations_view
-                        and _framing_now == ALL_LOCATIONS_FRAMING_LAST_VIEWED
+                    st_folium(
+                        map_for_folium,
+                        use_container_width=True,
+                        height=map_height,
+                        key=folium_st_key,
+                        returned_objects=[],
+                        return_on_hover=False,
                     )
-                    _folium_returned_objs = (
-                        ["zoom", "bounds"] if _needs_folium_bounds else []
-                    )
-                    _folium_kw: dict[str, Any] = {
-                        "use_container_width": True,
-                        "height": map_height,
-                        "key": folium_st_key,
-                        "returned_objects": _folium_returned_objs,
-                        "return_on_hover": False,
-                    }
-                    if _needs_folium_bounds and folium_center_for_embed is not None:
-                        _folium_kw["center"] = folium_center_for_embed
-                    if _needs_folium_bounds and folium_zoom_for_embed is not None:
-                        _folium_kw["zoom"] = folium_zoom_for_embed
-                    _folium_out = st_folium(map_for_folium, **_folium_kw)
-                    if _needs_folium_bounds:
-                        _pv_new = _preserved_view_from_st_folium_out(_folium_out)
-                        if _pv_new is not None and _preserved_view_is_plausible(_pv_new):
-                            st.session_state[STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY] = _pv_new
 
         _spinner_emoji_placeholder.empty()
         _has_map_export = bool(st.session_state.get(EXPLORER_MAP_HTML_BYTES_KEY))

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -64,6 +64,7 @@ from explorer.app.streamlit.yearly_summary_streamlit_html import sync_yearly_sum
 from explorer.core.all_locations_viewport import (
     ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
     ALL_LOCATIONS_FRAMING_FIT_ALL,
+    ALL_LOCATIONS_SCOPE_FOCUSED,
     location_id_to_country_map,
 )
 from explorer.core.map_controller import build_species_overlay_map
@@ -312,17 +313,18 @@ def render_prep_spinner_and_map_tab(
                     if capture_all_locations_view:
                         _valid = {
                             ALL_LOCATIONS_FRAMING_FIT_ALL,
+                            ALL_LOCATIONS_SCOPE_FOCUSED,
                             ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
                         } | set(location_id_to_country_map(ctx["df"]).values())
                         _scope = str(
                             st.session_state.get(
                                 STREAMLIT_ALL_LOCATIONS_SCOPE_KEY,
-                                ALL_LOCATIONS_FRAMING_FIT_ALL,
+                                ALL_LOCATIONS_SCOPE_FOCUSED,
                             )
-                            or ALL_LOCATIONS_FRAMING_FIT_ALL
+                            or ALL_LOCATIONS_SCOPE_FOCUSED
                         ).strip()
                         if _scope not in _valid:
-                            _scope = ALL_LOCATIONS_FRAMING_FIT_ALL
+                            _scope = ALL_LOCATIONS_SCOPE_FOCUSED
                             st.session_state[STREAMLIT_ALL_LOCATIONS_SCOPE_KEY] = _scope
                         _map_kw["all_locations_scope"] = _scope
                         _map_kw["all_locations_location_country"] = location_id_to_country_map(
@@ -345,9 +347,9 @@ def render_prep_spinner_and_map_tab(
                         str(
                             st.session_state.get(
                                 STREAMLIT_ALL_LOCATIONS_SCOPE_KEY,
-                                ALL_LOCATIONS_FRAMING_FIT_ALL,
+                                ALL_LOCATIONS_SCOPE_FOCUSED,
                             )
-                            or ALL_LOCATIONS_FRAMING_FIT_ALL
+                            or ALL_LOCATIONS_SCOPE_FOCUSED
                         )
                         if capture_all_locations_view
                         else "",

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -34,6 +34,10 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_HIGH_COUNT_SORT_KEY,
     STREAMLIT_HIGH_COUNT_TIE_BREAK_KEY,
     STREAMLIT_MAP_CLUSTER_ALL_LOCATIONS_KEY,
+    STREAMLIT_ALL_LOCATIONS_FOCUS_KEY,
+    STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
+    STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY,
+    STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY,
     STREAMLIT_RANKINGS_TOP_N_KEY,
 )
 from explorer.app.streamlit.app_map_ui import (
@@ -60,6 +64,11 @@ from explorer.app.streamlit.streamlit_ui_constants import (
     SIDEBAR_FOOTER_LINK_HEX,
 )
 from explorer.app.streamlit.yearly_summary_streamlit_html import sync_yearly_summary_session_inputs
+from explorer.core.all_locations_viewport import (
+    ALL_LOCATIONS_FRAMING_FIT_ALL,
+    ALL_LOCATIONS_FRAMING_LAST_VIEWED,
+    location_id_to_country_map,
+)
 from explorer.core.map_controller import build_species_overlay_map
 from explorer.core.map_prep import (
     data_signature_for_caches,
@@ -80,6 +89,43 @@ from explorer.core.family_map_folium import (
     build_family_map_banner_overlay_html,
     build_family_map_legend_overlay_html_for_pins,
 )
+
+
+def _preserved_view_from_st_folium_out(out: Any) -> tuple[tuple[float, float], int] | None:
+    """Centre + zoom from streamlit-folium return dict (``zoom`` + ``bounds``)."""
+    if not isinstance(out, dict):
+        return None
+    z_raw = out.get("zoom")
+    b = out.get("bounds")
+    if z_raw is None or b is None or not isinstance(b, dict):
+        return None
+    # Folium may leave zoom as a non-scalar in defaults; ignore until Leaflet reports a level.
+    if isinstance(z_raw, (dict, list)):
+        return None
+    try:
+        zi = int(z_raw)
+    except (TypeError, ValueError):
+        return None
+    sw = b.get("_southWest") or {}
+    ne = b.get("_northEast") or {}
+    try:
+        lat0 = float(sw["lat"])
+        lat1 = float(ne["lat"])
+        lng0 = float(sw["lng"])
+        lng1 = float(ne["lng"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return ((lat0 + lat1) / 2.0, (lng0 + lng1) / 2.0), zi
+
+
+def _preserved_view_is_plausible(pv: tuple[tuple[float, float], int]) -> bool:
+    """Drop bogus viewport snapshots (e.g. whole-world bounds) that would replace a good fit."""
+    (lat, lon), z = pv
+    if z < 1 or z > 22:
+        return False
+    if not (-90.0 <= lat <= 90.0) or not (-180.0 <= lon <= 180.0):
+        return False
+    return True
 
 
 def render_prep_spinner_and_map_tab(
@@ -155,11 +201,15 @@ def render_prep_spinner_and_map_tab(
                 st.session_state[POPUP_HTML_CACHE_KEY] = {}
                 st.session_state[FILTERED_BY_LOC_CACHE_KEY] = OrderedDict()
                 st.session_state.pop(FOLIUM_STATIC_MAP_CACHE_KEY, None)
+                st.session_state.pop(STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY, None)
 
             map_warning_text: str | None = None
             map_hint_text: str | None = None
             map_for_folium = None
             folium_st_key: str | None = None
+            folium_center_for_embed: tuple[float, float] | None = None
+            folium_zoom_for_embed: int | None = None
+            capture_all_locations_view = False
             try:
                 ctx = prepare_all_locations_map_context(work_df, full_df=df_full)
             except ValueError as e:
@@ -270,6 +320,7 @@ def render_prep_spinner_and_map_tab(
                     hide_nm = (
                         map_view_mode == "species" and bool(hide_non_matching_locations)
                     )
+                    capture_all_locations_view = map_view_mode == "all" and not overlay_sci
                     _visit_sch = active_map_marker_colour_scheme(int(family_colour_scheme))
                     _map_kw = {
                         **ctx,
@@ -301,6 +352,44 @@ def render_prep_spinner_and_map_tab(
                         "map_height_px": int(map_height),
                         "visit_marker_scheme": _visit_sch,
                     }
+                    if capture_all_locations_view:
+                        _al_fr = str(
+                            st.session_state.get(
+                                STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
+                                ALL_LOCATIONS_FRAMING_FIT_ALL,
+                            )
+                            or ALL_LOCATIONS_FRAMING_FIT_ALL
+                        ).strip()
+                        _al_fc = str(
+                            st.session_state.get(STREAMLIT_ALL_LOCATIONS_FOCUS_KEY, "") or ""
+                        ).strip()
+                        _map_kw["all_locations_framing"] = _al_fr
+                        _map_kw["all_locations_focus_country"] = _al_fc
+                        _map_kw["all_locations_location_country"] = location_id_to_country_map(
+                            ctx["df"]
+                        )
+                        _pv = st.session_state.get(STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY)
+                        if _al_fr == ALL_LOCATIONS_FRAMING_LAST_VIEWED and isinstance(
+                            _pv, tuple
+                        ) and len(_pv) == 2:
+                            _ll, _zz = _pv
+                            if (
+                                isinstance(_ll, (tuple, list))
+                                and len(_ll) == 2
+                                and _zz is not None
+                            ):
+                                try:
+                                    _map_kw["all_locations_preserved_center_zoom"] = (
+                                        (float(_ll[0]), float(_ll[1])),
+                                        int(_zz),
+                                    )
+                                    folium_center_for_embed = (
+                                        float(_ll[0]),
+                                        float(_ll[1]),
+                                    )
+                                    folium_zoom_for_embed = int(_zz)
+                                except (TypeError, ValueError):
+                                    pass
                     _render_opts_sig = (
                         popup_sort_order,
                         popup_scroll_hint,
@@ -315,6 +404,21 @@ def render_prep_spinner_and_map_tab(
                         bool(st.session_state.get(STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY, False)),
                         int(map_height),
                         int(family_colour_scheme),
+                        str(
+                            st.session_state.get(
+                                STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
+                                ALL_LOCATIONS_FRAMING_FIT_ALL,
+                            )
+                            or ALL_LOCATIONS_FRAMING_FIT_ALL
+                        )
+                        if capture_all_locations_view
+                        else "",
+                        str(st.session_state.get(STREAMLIT_ALL_LOCATIONS_FOCUS_KEY, "") or "")
+                        if capture_all_locations_view
+                        else "",
+                        int(st.session_state.get(STREAMLIT_ALL_LOCATIONS_RESET_NONCE_KEY, 0))
+                        if capture_all_locations_view
+                        else 0,
                     )
                     _species_selected = bool(overlay_sci)
                     _ck = static_map_cache_key(
@@ -379,18 +483,39 @@ def render_prep_spinner_and_map_tab(
                             "`requirements.txt` at the repo root."
                         )
                         st.stop()
-                    st_folium(
-                        map_for_folium,
-                        use_container_width=True,
-                        height=map_height,
-                        # Cache key includes *map_view_mode* so All vs Species builds stay distinct (refs #147).
-                        # *map_view_mode* + *FOLIUM_MAP_MOUNT_NONCE_KEY* force a
-                        # distinct streamlit-folium component identity when the sidebar layout changes
-                        # (All↔Species); see invalidation block above.
-                        key=folium_st_key,
-                        returned_objects=[],
-                        return_on_hover=False,
+                    # Only request bounds/zoom from the component in "Last viewed" mode; otherwise
+                    # keep returned_objects=[] like pre-#166 (avoids a post-load snap). Only persist
+                    # session when framing is Last viewed so Show all / My centre are not overwritten.
+                    _framing_now = str(
+                        st.session_state.get(
+                            STREAMLIT_ALL_LOCATIONS_FRAMING_KEY,
+                            ALL_LOCATIONS_FRAMING_FIT_ALL,
+                        )
+                        or ALL_LOCATIONS_FRAMING_FIT_ALL
+                    ).strip()
+                    _needs_folium_bounds = (
+                        capture_all_locations_view
+                        and _framing_now == ALL_LOCATIONS_FRAMING_LAST_VIEWED
                     )
+                    _folium_returned_objs = (
+                        ["zoom", "bounds"] if _needs_folium_bounds else []
+                    )
+                    _folium_kw: dict[str, Any] = {
+                        "use_container_width": True,
+                        "height": map_height,
+                        "key": folium_st_key,
+                        "returned_objects": _folium_returned_objs,
+                        "return_on_hover": False,
+                    }
+                    if _needs_folium_bounds and folium_center_for_embed is not None:
+                        _folium_kw["center"] = folium_center_for_embed
+                    if _needs_folium_bounds and folium_zoom_for_embed is not None:
+                        _folium_kw["zoom"] = folium_zoom_for_embed
+                    _folium_out = st_folium(map_for_folium, **_folium_kw)
+                    if _needs_folium_bounds:
+                        _pv_new = _preserved_view_from_st_folium_out(_folium_out)
+                        if _pv_new is not None and _preserved_view_is_plausible(_pv_new):
+                            st.session_state[STREAMLIT_ALL_LOCATIONS_PRESERVED_VIEW_KEY] = _pv_new
 
         _spinner_emoji_placeholder.empty()
         _has_map_export = bool(st.session_state.get(EXPLORER_MAP_HTML_BYTES_KEY))

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -43,7 +43,7 @@ MAP_DEFAULT_LOCATION_CLUSTER_SPIDERFY_ON_MAX_ZOOM = False
 MAP_DEFAULT_LOCATION_CLUSTER_REMOVE_OUTSIDE_VISIBLE_BOUNDS = False
 
 # Debug-only map overlay (live zoom readout). Listed in :func:`debug_defaults_enabled` for CI warnings.
-MAP_DEBUG_SHOW_ZOOM_LEVEL = False
+MAP_DEBUG_SHOW_ZOOM_LEVEL = True
 
 # ---------------------------------------------------------------------------
 # Pin geometry — Folium ``CircleMarker`` + legend sample dots; popup width
@@ -67,7 +67,15 @@ MAP_ALL_LOCATIONS_FIT_BOUNDS_MAX_ZOOM = 6
 # When centre-of-gravity framing is selected, fixed initial zoom (not fit_bounds).
 MAP_ALL_LOCATIONS_CENTRE_OF_GRAVITY_ZOOM = 5
 # Single-location (or degenerate) extent: avoid fitBounds zooming in too far.
-MAP_ALL_LOCATIONS_SINGLE_POINT_ZOOM = 9
+MAP_ALL_LOCATIONS_SINGLE_POINT_ZOOM = 6
+# "Focused" map focus: trim fit_bounds inputs to lat/lon inside these quantiles (each axis
+# independently). Symmetric 98% ≈ 1st–99th percentiles. Dev-only tunable (not user settings).
+MAP_ALL_LOCATIONS_FOCUSED_QUANTILE_LOW = 0.01
+MAP_ALL_LOCATIONS_FOCUSED_QUANTILE_HIGH = 0.99
+# In addition to quantile trimming, include every pin whose map country key has at least this many
+# species rows in the current working *df* (same checklist rows as the explorer). Set to 0 to
+# disable the rule (quantiles only).
+MAP_ALL_LOCATIONS_FOCUSED_MIN_OBSERVATIONS_PER_COUNTRY = 20
 
 # Character shown for Macaulay Library media links in map popups (refs #145).
 # Possible alternatives for user testing: ⧉ (two joined squares, U+29C9); ⊕ (circled plus, U+2295).

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -56,6 +56,15 @@ MAP_FAMILY_MAP_POPUP_MAX_WIDTH_PX = 320
 MAP_FAMILY_MAP_FIT_BOUNDS_PADDING_PX = 48
 MAP_FAMILY_MAP_FIT_BOUNDS_MAX_ZOOM = 6
 MAP_FAMILY_MAP_FIT_BOUNDS_MAX_ZOOM_HIGHLIGHT = 8
+
+# All-locations map: viewport behaviour (fit_bounds / centre / preserve); not colour-scheme settings.
+MAP_ALL_LOCATIONS_FIT_BOUNDS_PADDING_PX = 48
+MAP_ALL_LOCATIONS_FIT_BOUNDS_MAX_ZOOM = 6
+# When centre-of-gravity framing is selected, fixed initial zoom (not fit_bounds).
+MAP_ALL_LOCATIONS_CENTRE_OF_GRAVITY_ZOOM = 5
+# Single-location (or degenerate) extent: avoid fitBounds zooming in too far.
+MAP_ALL_LOCATIONS_SINGLE_POINT_ZOOM = 9
+
 # Character shown for Macaulay Library media links in map popups (refs #145).
 # Possible alternatives for user testing: ⧉ (two joined squares, U+29C9); ⊕ (circled plus, U+2295).
 MAP_POPUP_MACAULAY_LINK_SYMBOL = "↗"

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -37,6 +37,10 @@ from explorer.core.map_marker_scheme_model import (
 MAP_DEFAULT_LOCATION_CLUSTER_MAX_RADIUS_PX = 40
 MAP_DEFAULT_LOCATION_CLUSTER_DISABLE_AT_ZOOM = 9
 MAP_DEFAULT_LOCATION_CLUSTER_SPIDERFY_ON_MAX_ZOOM = False
+# When True (plugin default), markers outside the viewport are removed for performance; after
+# programmatic ``fitBounds`` some markers can fail to appear until the user zooms/pans. False keeps
+# all cluster children in the layer so the map matches expectations (refs #166).
+MAP_DEFAULT_LOCATION_CLUSTER_REMOVE_OUTSIDE_VISIBLE_BOUNDS = False
 
 # Debug-only map overlay (live zoom readout). Listed in :func:`debug_defaults_enabled` for CI warnings.
 MAP_DEBUG_SHOW_ZOOM_LEVEL = False

--- a/explorer/core/all_locations_viewport.py
+++ b/explorer/core/all_locations_viewport.py
@@ -10,12 +10,12 @@ from typing import Hashable
 
 import pandas as pd
 
+from explorer.core.region_display import map_focus_key_for_display
 from explorer.core.stats import checklist_country_keys
 
-# Framing mode strings (Streamlit session and map overlay API).
+# Map area / viewport mode (Streamlit session values and map overlay API).
 ALL_LOCATIONS_FRAMING_FIT_ALL = "fit_all"
 ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY = "centre_of_gravity"
-ALL_LOCATIONS_FRAMING_LAST_VIEWED = "preserve_view"
 
 # Focus: empty string means all locations (no country filter).
 ALL_LOCATIONS_FOCUS_ALL = ""
@@ -51,12 +51,24 @@ def location_id_to_country_map(df: pd.DataFrame) -> dict[Hashable, str]:
 
 
 def sorted_country_labels_from_work(df: pd.DataFrame) -> list[str]:
-    """Unique country labels from *df*, sorted case-insensitively, for Focus UI."""
-    m = location_id_to_country_map(df)
-    if not m:
+    """Unique region keys from *df* (excluding ``_UNKNOWN``), sorted by display name."""
+    return sorted_country_keys_by_display_name(df)
+
+
+def sorted_country_keys_by_display_name(df: pd.DataFrame) -> list[str]:
+    """Distinct map-focus keys from *df*, sorted by :func:`map_focus_key_for_display` (case-insensitive)."""
+    keys = set(location_id_to_country_map(df).values())
+    if not keys:
         return []
-    labels = sorted(set(m.values()), key=lambda x: str(x).lower())
-    return labels
+    return sorted(keys, key=lambda k: map_focus_key_for_display(k).lower())
+
+
+def all_locations_scope_option_values(df: pd.DataFrame) -> list[str]:
+    """Selectbox options: All locations, My centre, then countries/regions from *df* (filtered data)."""
+    return [
+        ALL_LOCATIONS_FRAMING_FIT_ALL,
+        ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
+    ] + sorted_country_keys_by_display_name(df)
 
 
 def filter_location_rows_by_focus_country(

--- a/explorer/core/all_locations_viewport.py
+++ b/explorer/core/all_locations_viewport.py
@@ -1,0 +1,117 @@
+"""Helpers for All locations map viewport: focus by country, bounds points, framing modes.
+
+Pure functions — no Streamlit imports. Used by :mod:`explorer.core.map_overlay_visit_map`
+and tests.
+"""
+
+from __future__ import annotations
+
+from typing import Hashable
+
+import pandas as pd
+
+from explorer.core.stats import checklist_country_keys
+
+# Framing mode strings (Streamlit session and map overlay API).
+ALL_LOCATIONS_FRAMING_FIT_ALL = "fit_all"
+ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY = "centre_of_gravity"
+ALL_LOCATIONS_FRAMING_LAST_VIEWED = "preserve_view"
+
+# Focus: empty string means all locations (no country filter).
+ALL_LOCATIONS_FOCUS_ALL = ""
+
+
+def location_id_to_country_map(df: pd.DataFrame) -> dict[Hashable, str]:
+    """Map each ``Location ID`` to a region key for Focus (same logic as the Country tab).
+
+    Uses :func:`~explorer.core.stats.checklist_country_keys`: prefer ``Country`` when present;
+    otherwise derive from ``State/Province`` (e.g. ``AU-NSW`` → ``AU``). Rows mapped to
+    ``_UNKNOWN`` are skipped. Returns ``{}`` if neither column exists.
+    """
+    if df is None or df.empty or "Location ID" not in df.columns:
+        return {}
+    if "Country" not in df.columns and "State/Province" not in df.columns:
+        return {}
+    keys = checklist_country_keys(df)
+    work = df.loc[df["Location ID"].notna()].copy()
+    work["_map_focus_key"] = keys
+    work = work[work["_map_focus_key"].astype(str) != "_UNKNOWN"]
+    work = work[work["_map_focus_key"].notna()]
+    if work.empty:
+        return {}
+    out: dict[Hashable, str] = {}
+    for lid, grp in work.groupby("Location ID", sort=False):
+        if lid is None or (isinstance(lid, float) and pd.isna(lid)):
+            continue
+        first = grp["_map_focus_key"].iloc[0]
+        s = str(first).strip()
+        if s and s != "_UNKNOWN":
+            out[lid] = s
+    return out
+
+
+def sorted_country_labels_from_work(df: pd.DataFrame) -> list[str]:
+    """Unique country labels from *df*, sorted case-insensitively, for Focus UI."""
+    m = location_id_to_country_map(df)
+    if not m:
+        return []
+    labels = sorted(set(m.values()), key=lambda x: str(x).lower())
+    return labels
+
+
+def filter_location_rows_by_focus_country(
+    effective_location_data: pd.DataFrame,
+    *,
+    location_id_to_country: dict[Hashable, str],
+    focus_country: str | None,
+) -> pd.DataFrame:
+    """Return rows whose Location ID maps to *focus_country*.
+
+    If *focus_country* is falsy (all locations), return *effective_location_data* unchanged.
+    If no rows match, returns an empty DataFrame.
+    """
+    if effective_location_data is None or effective_location_data.empty:
+        return effective_location_data
+    fc = (focus_country or "").strip()
+    if not fc:
+        return effective_location_data
+    if not location_id_to_country:
+        return pd.DataFrame(columns=effective_location_data.columns)
+    mask = effective_location_data["Location ID"].map(
+        lambda lid: location_id_to_country.get(lid, "") == fc
+    )
+    return effective_location_data.loc[mask].copy()
+
+
+def coordinate_pairs_for_viewport(
+    effective_location_data: pd.DataFrame,
+    *,
+    location_id_to_country: dict[Hashable, str] | None,
+    focus_country: str | None,
+) -> list[list[float]]:
+    """Lat/lng pairs for fit-bounds or centre-of-gravity (same subset as Focus)."""
+    loc_id_country = location_id_to_country or {}
+    sub = filter_location_rows_by_focus_country(
+        effective_location_data,
+        location_id_to_country=loc_id_country,
+        focus_country=focus_country,
+    )
+    if sub.empty:
+        return []
+    out: list[list[float]] = []
+    for _, row in sub.iterrows():
+        lat, lon = float(row["Latitude"]), float(row["Longitude"])
+        if pd.isna(lat) or pd.isna(lon):
+            continue
+        out.append([lat, lon])
+    return out
+
+
+def mean_center_from_pairs(pairs: list[list[float]]) -> tuple[float, float] | None:
+    """Mean (lat, lon) for centre-of-gravity framing."""
+    if not pairs:
+        return None
+    s_lat = sum(p[0] for p in pairs)
+    s_lon = sum(p[1] for p in pairs)
+    n = len(pairs)
+    return (s_lat / n, s_lon / n)

--- a/explorer/core/all_locations_viewport.py
+++ b/explorer/core/all_locations_viewport.py
@@ -13,8 +13,10 @@ import pandas as pd
 from explorer.core.region_display import map_focus_key_for_display
 from explorer.core.stats import checklist_country_keys
 
-# Map area / viewport mode (Streamlit session values and map overlay API).
+# Map focust / viewport mode (Streamlit session values and map overlay API).
 ALL_LOCATIONS_FRAMING_FIT_ALL = "fit_all"
+# Default scope: quantile-trimmed bounds plus optional full inclusion of well-sampled countries.
+ALL_LOCATIONS_SCOPE_FOCUSED = "focused"
 ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY = "centre_of_gravity"
 
 # Focus: empty string means all locations (no country filter).
@@ -64,11 +66,117 @@ def sorted_country_keys_by_display_name(df: pd.DataFrame) -> list[str]:
 
 
 def all_locations_scope_option_values(df: pd.DataFrame) -> list[str]:
-    """Selectbox options: All locations, My centre, then countries/regions from *df* (filtered data)."""
+    """Selectbox order: All locations, Focused (trimmed), My activity centre, then countries."""
     return [
         ALL_LOCATIONS_FRAMING_FIT_ALL,
+        ALL_LOCATIONS_SCOPE_FOCUSED,
         ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
     ] + sorted_country_keys_by_display_name(df)
+
+
+def trim_coordinate_pairs_to_central_extent(
+    pairs: list[list[float]],
+    *,
+    quantile_low: float = 0.025,
+    quantile_high: float = 0.975,
+    min_points_to_trim: int = 4,
+) -> list[list[float]]:
+    """Keep points whose lat/lon fall inside independent quantile bands (central ~95% by default).
+
+    If there are fewer than *min_points_to_trim* pairs, returns a copy of *pairs* unchanged.
+    If trimming would remove everything, returns a copy of *pairs*.
+    """
+    if len(pairs) < min_points_to_trim:
+        return [p[:] for p in pairs]
+    lats = [float(p[0]) for p in pairs]
+    lons = [float(p[1]) for p in pairs]
+    lat_lo = float(pd.Series(lats).quantile(quantile_low))
+    lat_hi = float(pd.Series(lats).quantile(quantile_high))
+    lon_lo = float(pd.Series(lons).quantile(quantile_low))
+    lon_hi = float(pd.Series(lons).quantile(quantile_high))
+    if lat_lo >= lat_hi or lon_lo >= lon_hi:
+        return [p[:] for p in pairs]
+    out = [
+        [la, lo]
+        for la, lo in pairs
+        if lat_lo <= float(la) <= lat_hi and lon_lo <= float(lo) <= lon_hi
+    ]
+    return out if out else [p[:] for p in pairs]
+
+
+def observation_row_counts_by_country_key(df: pd.DataFrame) -> dict[str, int]:
+    """Count species/checklist rows per map country key (same keys as :func:`location_id_to_country_map`).
+
+    Uses :func:`~explorer.core.stats.checklist_country_keys` per row; excludes ``_UNKNOWN``.
+    """
+    if df is None or df.empty:
+        return {}
+    keys = checklist_country_keys(df)
+    s = keys[keys.astype(str) != "_UNKNOWN"]
+    if s.empty:
+        return {}
+    vc = s.value_counts()
+    return {str(k): int(v) for k, v in vc.items()}
+
+
+def _lat_lon_key(lat: float, lon: float) -> tuple[float, float]:
+    return (round(float(lat), 5), round(float(lon), 5))
+
+
+def coordinate_pairs_focused_viewport(
+    effective_location_data: pd.DataFrame,
+    *,
+    location_id_to_country: dict[Hashable, str],
+    observation_counts_by_country: dict[str, int],
+    quantile_low: float,
+    quantile_high: float,
+    min_observations_full_country: int,
+) -> list[list[float]]:
+    """Bounds points for **Focused**: quantile band on all pins, plus every pin in countries with enough rows.
+
+    Rows counted in *observation_counts_by_country* should match the same export scope as *df*
+    passed to :func:`observation_row_counts_by_country_key`. Country keys must align with
+    *location_id_to_country* values. When *min_observations_full_country* is ``<= 0``, only
+    quantile trimming applies.
+    """
+    triples: list[tuple[float, float, str]] = []
+    loc_c = location_id_to_country or {}
+    for _, row in effective_location_data.iterrows():
+        lat, lon = float(row["Latitude"]), float(row["Longitude"])
+        if pd.isna(lat) or pd.isna(lon):
+            continue
+        lid = row["Location ID"]
+        c_raw = loc_c.get(lid, "")
+        c = str(c_raw).strip() if c_raw is not None and str(c_raw).strip() else ""
+        triples.append((lat, lon, c))
+    if not triples:
+        return []
+    full_pairs = [[t[0], t[1]] for t in triples]
+    trimmed = trim_coordinate_pairs_to_central_extent(
+        full_pairs,
+        quantile_low=quantile_low,
+        quantile_high=quantile_high,
+    )
+    if min_observations_full_country <= 0 or not observation_counts_by_country:
+        return trimmed
+
+    high = {
+        k
+        for k, n in observation_counts_by_country.items()
+        if n >= min_observations_full_country and str(k).strip() and str(k) != "_UNKNOWN"
+    }
+    if not high:
+        return trimmed
+
+    seen: set[tuple[float, float]] = {_lat_lon_key(p[0], p[1]) for p in trimmed}
+    out: list[list[float]] = [p[:] for p in trimmed]
+    for la, lo, c in triples:
+        if c in high:
+            key = _lat_lon_key(la, lo)
+            if key not in seen:
+                seen.add(key)
+                out.append([la, lo])
+    return out
 
 
 def filter_location_rows_by_focus_country(

--- a/explorer/core/map_controller.py
+++ b/explorer/core/map_controller.py
@@ -73,10 +73,8 @@ def build_species_overlay_map(
     show_subspecies_lifers: bool = False,
     map_height_px: int = MAP_HEIGHT_PX_DEFAULT,
     visit_marker_scheme: MapMarkerColourScheme,
-    all_locations_framing: str | None = None,
-    all_locations_focus_country: str = "",
+    all_locations_scope: str | None = None,
     all_locations_location_country: dict[Hashable, str] | None = None,
-    all_locations_preserved_center_zoom: tuple[tuple[float, float], int] | None = None,
 ) -> MapOverlayResult:
     """Build the Folium map for all-species, one-species, or lifer-locations overlay.
 
@@ -166,8 +164,6 @@ def build_species_overlay_map(
         map_height_px=map_height_px,
         visit_marker_scheme=visit_marker_scheme,
         map_view_mode=mode,
-        all_locations_framing=all_locations_framing or ALL_LOCATIONS_FRAMING_FIT_ALL,
-        all_locations_focus_country=all_locations_focus_country,
+        all_locations_scope=all_locations_scope or ALL_LOCATIONS_FRAMING_FIT_ALL,
         all_locations_location_country=all_locations_location_country,
-        all_locations_preserved_center_zoom=all_locations_preserved_center_zoom,
     )

--- a/explorer/core/map_controller.py
+++ b/explorer/core/map_controller.py
@@ -30,6 +30,7 @@ from explorer.core.map_overlay_types import (
     SpeciesUrlFn,
     VALID_MAP_VIEWS,
 )
+from explorer.core.all_locations_viewport import ALL_LOCATIONS_FRAMING_FIT_ALL
 from explorer.core.map_overlay_visit_map import build_visit_overlay_map
 from explorer.core.species_logic import base_species_for_lifer
 
@@ -72,6 +73,10 @@ def build_species_overlay_map(
     show_subspecies_lifers: bool = False,
     map_height_px: int = MAP_HEIGHT_PX_DEFAULT,
     visit_marker_scheme: MapMarkerColourScheme,
+    all_locations_framing: str | None = None,
+    all_locations_focus_country: str = "",
+    all_locations_location_country: dict[Hashable, str] | None = None,
+    all_locations_preserved_center_zoom: tuple[tuple[float, float], int] | None = None,
 ) -> MapOverlayResult:
     """Build the Folium map for all-species, one-species, or lifer-locations overlay.
 
@@ -161,4 +166,8 @@ def build_species_overlay_map(
         map_height_px=map_height_px,
         visit_marker_scheme=visit_marker_scheme,
         map_view_mode=mode,
+        all_locations_framing=all_locations_framing or ALL_LOCATIONS_FRAMING_FIT_ALL,
+        all_locations_focus_country=all_locations_focus_country,
+        all_locations_location_country=all_locations_location_country,
+        all_locations_preserved_center_zoom=all_locations_preserved_center_zoom,
     )

--- a/explorer/core/map_controller.py
+++ b/explorer/core/map_controller.py
@@ -30,7 +30,7 @@ from explorer.core.map_overlay_types import (
     SpeciesUrlFn,
     VALID_MAP_VIEWS,
 )
-from explorer.core.all_locations_viewport import ALL_LOCATIONS_FRAMING_FIT_ALL
+from explorer.core.all_locations_viewport import ALL_LOCATIONS_SCOPE_FOCUSED
 from explorer.core.map_overlay_visit_map import build_visit_overlay_map
 from explorer.core.species_logic import base_species_for_lifer
 
@@ -164,6 +164,6 @@ def build_species_overlay_map(
         map_height_px=map_height_px,
         visit_marker_scheme=visit_marker_scheme,
         map_view_mode=mode,
-        all_locations_scope=all_locations_scope or ALL_LOCATIONS_FRAMING_FIT_ALL,
+        all_locations_scope=all_locations_scope or ALL_LOCATIONS_SCOPE_FOCUSED,
         all_locations_location_country=all_locations_location_country,
     )

--- a/explorer/core/map_overlay_visit_map.py
+++ b/explorer/core/map_overlay_visit_map.py
@@ -19,6 +19,7 @@ from explorer.app.streamlit.defaults import (
     MAP_DEBUG_SHOW_ZOOM_LEVEL,
     MAP_DEFAULT_LOCATION_CLUSTER_DISABLE_AT_ZOOM,
     MAP_DEFAULT_LOCATION_CLUSTER_MAX_RADIUS_PX,
+    MAP_DEFAULT_LOCATION_CLUSTER_REMOVE_OUTSIDE_VISIBLE_BOUNDS,
     MAP_DEFAULT_LOCATION_CLUSTER_SPIDERFY_ON_MAX_ZOOM,
     MAP_MARKER_CLUSTER_BORDER_OPACITY_DEFAULT,
     MAP_MARKER_CLUSTER_BORDER_WIDTH_PX_DEFAULT,
@@ -410,6 +411,7 @@ def build_visit_overlay_map(
                 options={
                     "maxClusterRadius": MAP_DEFAULT_LOCATION_CLUSTER_MAX_RADIUS_PX,
                     "disableClusteringAtZoom": MAP_DEFAULT_LOCATION_CLUSTER_DISABLE_AT_ZOOM,
+                    "removeOutsideVisibleBounds": MAP_DEFAULT_LOCATION_CLUSTER_REMOVE_OUTSIDE_VISIBLE_BOUNDS,
                     "spiderfyOnMaxZoom": MAP_DEFAULT_LOCATION_CLUSTER_SPIDERFY_ON_MAX_ZOOM,
                     "zoomToBoundsOnClick": True,
                 },

--- a/explorer/core/map_overlay_visit_map.py
+++ b/explorer/core/map_overlay_visit_map.py
@@ -15,6 +15,9 @@ from explorer.app.streamlit.defaults import (
     MAP_ALL_LOCATIONS_CENTRE_OF_GRAVITY_ZOOM,
     MAP_ALL_LOCATIONS_FIT_BOUNDS_MAX_ZOOM,
     MAP_ALL_LOCATIONS_FIT_BOUNDS_PADDING_PX,
+    MAP_ALL_LOCATIONS_FOCUSED_MIN_OBSERVATIONS_PER_COUNTRY,
+    MAP_ALL_LOCATIONS_FOCUSED_QUANTILE_HIGH,
+    MAP_ALL_LOCATIONS_FOCUSED_QUANTILE_LOW,
     MAP_ALL_LOCATIONS_SINGLE_POINT_ZOOM,
     MAP_DEBUG_SHOW_ZOOM_LEVEL,
     MAP_DEFAULT_LOCATION_CLUSTER_DISABLE_AT_ZOOM,
@@ -33,8 +36,11 @@ from explorer.app.streamlit.defaults import (
 from explorer.core.all_locations_viewport import (
     ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
     ALL_LOCATIONS_FRAMING_FIT_ALL,
+    ALL_LOCATIONS_SCOPE_FOCUSED,
+    coordinate_pairs_focused_viewport,
     coordinate_pairs_for_viewport,
     mean_center_from_pairs,
+    observation_row_counts_by_country_key,
 )
 from explorer.core.map_marker_colour_resolve import (
     is_valid_hex_colour,
@@ -299,7 +305,7 @@ def build_visit_overlay_map(
     map_height_px: int,
     visit_marker_scheme: MapMarkerColourScheme,
     map_view_mode: str = "all",
-    all_locations_scope: str = ALL_LOCATIONS_FRAMING_FIT_ALL,
+    all_locations_scope: str = ALL_LOCATIONS_SCOPE_FOCUSED,
     all_locations_location_country: dict[Hashable, str] | None = None,
 ) -> MapOverlayResult:
     """Build all-locations or species-filtered overlay (not lifer-locations mode)."""
@@ -329,7 +335,7 @@ def build_visit_overlay_map(
     all_loc_pairs: list[list[float]] = []
     if not selected_species and _mv == "all":
         loc_c = all_locations_location_country or {}
-        scope = (all_locations_scope or ALL_LOCATIONS_FRAMING_FIT_ALL).strip()
+        scope = (all_locations_scope or ALL_LOCATIONS_SCOPE_FOCUSED).strip()
         if scope == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY:
             all_loc_pairs = coordinate_pairs_for_viewport(
                 effective_location_data,
@@ -340,6 +346,21 @@ def build_visit_overlay_map(
             if mc:
                 map_center = [mc[0], mc[1]]
             create_zoom = MAP_ALL_LOCATIONS_CENTRE_OF_GRAVITY_ZOOM
+        elif scope == ALL_LOCATIONS_SCOPE_FOCUSED:
+            _min_c = int(MAP_ALL_LOCATIONS_FOCUSED_MIN_OBSERVATIONS_PER_COUNTRY)
+            _obs_by_c = (
+                observation_row_counts_by_country_key(df)
+                if _min_c > 0
+                else {}
+            )
+            all_loc_pairs = coordinate_pairs_focused_viewport(
+                effective_location_data,
+                location_id_to_country=loc_c,
+                observation_counts_by_country=_obs_by_c,
+                quantile_low=MAP_ALL_LOCATIONS_FOCUSED_QUANTILE_LOW,
+                quantile_high=MAP_ALL_LOCATIONS_FOCUSED_QUANTILE_HIGH,
+                min_observations_full_country=_min_c,
+            )
         else:
             fc = "" if scope == ALL_LOCATIONS_FRAMING_FIT_ALL else scope
             all_loc_pairs = coordinate_pairs_for_viewport(
@@ -444,7 +465,7 @@ def build_visit_overlay_map(
         if marker_cluster is not None:
             marker_cluster.add_to(species_map)
 
-        scope_fit = (all_locations_scope or ALL_LOCATIONS_FRAMING_FIT_ALL).strip()
+        scope_fit = (all_locations_scope or ALL_LOCATIONS_SCOPE_FOCUSED).strip()
         should_fit = scope_fit != ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY and bool(all_loc_pairs)
         if should_fit and all_loc_pairs:
             pad = int(MAP_ALL_LOCATIONS_FIT_BOUNDS_PADDING_PX)

--- a/explorer/core/map_overlay_visit_map.py
+++ b/explorer/core/map_overlay_visit_map.py
@@ -12,6 +12,10 @@ from branca.element import Element
 from folium.plugins import MarkerCluster
 
 from explorer.app.streamlit.defaults import (
+    MAP_ALL_LOCATIONS_CENTRE_OF_GRAVITY_ZOOM,
+    MAP_ALL_LOCATIONS_FIT_BOUNDS_MAX_ZOOM,
+    MAP_ALL_LOCATIONS_FIT_BOUNDS_PADDING_PX,
+    MAP_ALL_LOCATIONS_SINGLE_POINT_ZOOM,
     MAP_DEBUG_SHOW_ZOOM_LEVEL,
     MAP_DEFAULT_LOCATION_CLUSTER_DISABLE_AT_ZOOM,
     MAP_DEFAULT_LOCATION_CLUSTER_MAX_RADIUS_PX,
@@ -24,6 +28,13 @@ from explorer.app.streamlit.defaults import (
     MapMarkerColourScheme,
     clamp_map_marker_circle_fill_opacity,
     clamp_map_marker_circle_radius_px,
+)
+from explorer.core.all_locations_viewport import (
+    ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
+    ALL_LOCATIONS_FRAMING_FIT_ALL,
+    ALL_LOCATIONS_FRAMING_LAST_VIEWED,
+    coordinate_pairs_for_viewport,
+    mean_center_from_pairs,
 )
 from explorer.core.map_marker_colour_resolve import (
     is_valid_hex_colour,
@@ -51,6 +62,11 @@ from explorer.presentation.map_renderer import (
 from explorer.presentation.map_ui_constants import MAP_POPUP_MAX_WIDTH_PX
 from explorer.core.species_logic import filter_species
 from explorer.core.stats import safe_count
+
+
+def _epsilon_bounds_around_point(lat: float, lon: float, delta: float = 0.02) -> list[list[float]]:
+    """Tiny bounding box so Leaflet ``fitBounds`` has non-zero extent for a single pin."""
+    return [[lat - delta, lon - delta], [lat + delta, lon + delta]]
 
 
 def _all_locations_marker_params_from_scheme(sch: MapMarkerColourScheme) -> tuple[str, str, int, int, float]:
@@ -283,6 +299,10 @@ def build_visit_overlay_map(
     map_height_px: int,
     visit_marker_scheme: MapMarkerColourScheme,
     map_view_mode: str = "all",
+    all_locations_framing: str = ALL_LOCATIONS_FRAMING_FIT_ALL,
+    all_locations_focus_country: str = "",
+    all_locations_location_country: dict[Hashable, str] | None = None,
+    all_locations_preserved_center_zoom: tuple[tuple[float, float], int] | None = None,
 ) -> MapOverlayResult:
     """Build all-locations or species-filtered overlay (not lifer-locations mode)."""
     if selected_species:
@@ -306,10 +326,37 @@ def build_visit_overlay_map(
             effective_location_data["Longitude"].mean(),
         ]
 
+    _mv = (map_view_mode or "all").strip().lower()
+    create_zoom: int | None = None
+    all_loc_pairs: list[list[float]] = []
+    if not selected_species and _mv == "all":
+        loc_c = all_locations_location_country or {}
+        fc = (all_locations_focus_country or "").strip()
+        all_loc_pairs = coordinate_pairs_for_viewport(
+            effective_location_data,
+            location_id_to_country=loc_c,
+            focus_country=fc,
+        )
+        if fc and not all_loc_pairs:
+            all_loc_pairs = coordinate_pairs_for_viewport(
+                effective_location_data,
+                location_id_to_country=loc_c,
+                focus_country="",
+            )
+        fn_al = (all_locations_framing or ALL_LOCATIONS_FRAMING_FIT_ALL).strip().lower()
+        if fn_al == ALL_LOCATIONS_FRAMING_LAST_VIEWED and all_locations_preserved_center_zoom:
+            latlon, zsnap = all_locations_preserved_center_zoom
+            map_center = [float(latlon[0]), float(latlon[1])]
+            create_zoom = int(zsnap)
+        elif fn_al == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY:
+            mc = mean_center_from_pairs(all_loc_pairs)
+            if mc:
+                map_center = [mc[0], mc[1]]
+            create_zoom = MAP_ALL_LOCATIONS_CENTRE_OF_GRAVITY_ZOOM
+
     popup_ascending = popup_sort_order == "ascending"
     date_filter_status_line = date_filter_status or None
 
-    _mv = (map_view_mode or "all").strip().lower()
     if not selected_species and (hide_non_matching_locations or _mv == "species"):
         if effective_location_data.empty:
             lat, lon = -25.0, 134.0
@@ -331,7 +378,12 @@ def build_visit_overlay_map(
         species_map.get_root().html.add_child(Element(scroll_popup_script))
         return MapOverlayResult(species_map, None)
 
-    species_map = create_map(map_center, map_style, height_px=map_height_px)
+    species_map = create_map(
+        map_center,
+        map_style,
+        height_px=map_height_px,
+        zoom_start=create_zoom,
+    )
     inject_map_overlay_theme(species_map)
     add_zoom_level_debug_overlay(species_map, enabled=MAP_DEBUG_SHOW_ZOOM_LEVEL)
 
@@ -390,6 +442,26 @@ def build_visit_overlay_map(
 
         if marker_cluster is not None:
             marker_cluster.add_to(species_map)
+
+        fnv = (all_locations_framing or ALL_LOCATIONS_FRAMING_FIT_ALL).strip().lower()
+        preserve_snapshot = all_locations_preserved_center_zoom is not None
+        should_fit = fnv in (
+            ALL_LOCATIONS_FRAMING_FIT_ALL,
+            ALL_LOCATIONS_FRAMING_LAST_VIEWED,
+        ) and not (fnv == ALL_LOCATIONS_FRAMING_LAST_VIEWED and preserve_snapshot)
+        if should_fit and all_loc_pairs:
+            pad = int(MAP_ALL_LOCATIONS_FIT_BOUNDS_PADDING_PX)
+            max_z = int(MAP_ALL_LOCATIONS_FIT_BOUNDS_MAX_ZOOM)
+            if len(all_loc_pairs) == 1:
+                la, lo = float(all_loc_pairs[0][0]), float(all_loc_pairs[0][1])
+                b = _epsilon_bounds_around_point(la, lo)
+                species_map.fit_bounds(
+                    b,
+                    padding=(pad, pad),
+                    max_zoom=int(MAP_ALL_LOCATIONS_SINGLE_POINT_ZOOM),
+                )
+            else:
+                species_map.fit_bounds(all_loc_pairs, padding=(pad, pad), max_zoom=max_z)
 
     else:
         if selected_species not in filtered_by_loc_cache:

--- a/explorer/core/map_overlay_visit_map.py
+++ b/explorer/core/map_overlay_visit_map.py
@@ -32,7 +32,6 @@ from explorer.app.streamlit.defaults import (
 from explorer.core.all_locations_viewport import (
     ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
     ALL_LOCATIONS_FRAMING_FIT_ALL,
-    ALL_LOCATIONS_FRAMING_LAST_VIEWED,
     coordinate_pairs_for_viewport,
     mean_center_from_pairs,
 )
@@ -299,10 +298,8 @@ def build_visit_overlay_map(
     map_height_px: int,
     visit_marker_scheme: MapMarkerColourScheme,
     map_view_mode: str = "all",
-    all_locations_framing: str = ALL_LOCATIONS_FRAMING_FIT_ALL,
-    all_locations_focus_country: str = "",
+    all_locations_scope: str = ALL_LOCATIONS_FRAMING_FIT_ALL,
     all_locations_location_country: dict[Hashable, str] | None = None,
-    all_locations_preserved_center_zoom: tuple[tuple[float, float], int] | None = None,
 ) -> MapOverlayResult:
     """Build all-locations or species-filtered overlay (not lifer-locations mode)."""
     if selected_species:
@@ -331,28 +328,30 @@ def build_visit_overlay_map(
     all_loc_pairs: list[list[float]] = []
     if not selected_species and _mv == "all":
         loc_c = all_locations_location_country or {}
-        fc = (all_locations_focus_country or "").strip()
-        all_loc_pairs = coordinate_pairs_for_viewport(
-            effective_location_data,
-            location_id_to_country=loc_c,
-            focus_country=fc,
-        )
-        if fc and not all_loc_pairs:
+        scope = (all_locations_scope or ALL_LOCATIONS_FRAMING_FIT_ALL).strip()
+        if scope == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY:
             all_loc_pairs = coordinate_pairs_for_viewport(
                 effective_location_data,
                 location_id_to_country=loc_c,
                 focus_country="",
             )
-        fn_al = (all_locations_framing or ALL_LOCATIONS_FRAMING_FIT_ALL).strip().lower()
-        if fn_al == ALL_LOCATIONS_FRAMING_LAST_VIEWED and all_locations_preserved_center_zoom:
-            latlon, zsnap = all_locations_preserved_center_zoom
-            map_center = [float(latlon[0]), float(latlon[1])]
-            create_zoom = int(zsnap)
-        elif fn_al == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY:
             mc = mean_center_from_pairs(all_loc_pairs)
             if mc:
                 map_center = [mc[0], mc[1]]
             create_zoom = MAP_ALL_LOCATIONS_CENTRE_OF_GRAVITY_ZOOM
+        else:
+            fc = "" if scope == ALL_LOCATIONS_FRAMING_FIT_ALL else scope
+            all_loc_pairs = coordinate_pairs_for_viewport(
+                effective_location_data,
+                location_id_to_country=loc_c,
+                focus_country=fc,
+            )
+            if fc and not all_loc_pairs:
+                all_loc_pairs = coordinate_pairs_for_viewport(
+                    effective_location_data,
+                    location_id_to_country=loc_c,
+                    focus_country="",
+                )
 
     popup_ascending = popup_sort_order == "ascending"
     date_filter_status_line = date_filter_status or None
@@ -443,12 +442,8 @@ def build_visit_overlay_map(
         if marker_cluster is not None:
             marker_cluster.add_to(species_map)
 
-        fnv = (all_locations_framing or ALL_LOCATIONS_FRAMING_FIT_ALL).strip().lower()
-        preserve_snapshot = all_locations_preserved_center_zoom is not None
-        should_fit = fnv in (
-            ALL_LOCATIONS_FRAMING_FIT_ALL,
-            ALL_LOCATIONS_FRAMING_LAST_VIEWED,
-        ) and not (fnv == ALL_LOCATIONS_FRAMING_LAST_VIEWED and preserve_snapshot)
+        scope_fit = (all_locations_scope or ALL_LOCATIONS_FRAMING_FIT_ALL).strip()
+        should_fit = scope_fit != ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY and bool(all_loc_pairs)
         if should_fit and all_loc_pairs:
             pad = int(MAP_ALL_LOCATIONS_FIT_BOUNDS_PADDING_PX)
             max_z = int(MAP_ALL_LOCATIONS_FIT_BOUNDS_MAX_ZOOM)

--- a/explorer/core/region_display.py
+++ b/explorer/core/region_display.py
@@ -38,3 +38,23 @@ def state_for_display(country_code, state_code):
     code = f"{country_s}-{state_s}"
     sub = pycountry.subdivisions.get(code=code)
     return sub.name if sub else state_s
+
+
+def map_focus_key_for_display(key) -> str:
+    """Label for the All locations **Focus** dropdown.
+
+    Internal keys come from :func:`~explorer.core.stats.checklist_country_keys` (ISO alpha-2,
+    full ``Country`` cell text, or ``_R:…`` state-only markers). ISO codes are expanded to
+    common country names via pycountry when available; everything else is shown as-is.
+    """
+    if key is None or (isinstance(key, float) and pd.isna(key)):
+        return ""
+    s = str(key).strip()
+    if not s:
+        return ""
+    if s.startswith("_R:"):
+        tail = s[3:].strip()
+        return tail if tail else s
+    if len(s) == 2 and s.isalpha():
+        return country_for_display(s)
+    return s

--- a/explorer/presentation/design_map_preview.py
+++ b/explorer/presentation/design_map_preview.py
@@ -21,6 +21,7 @@ from folium.plugins import MarkerCluster
 from explorer.app.streamlit.defaults import (
     MAP_DEFAULT_LOCATION_CLUSTER_DISABLE_AT_ZOOM,
     MAP_DEFAULT_LOCATION_CLUSTER_MAX_RADIUS_PX,
+    MAP_DEFAULT_LOCATION_CLUSTER_REMOVE_OUTSIDE_VISIBLE_BOUNDS,
     MAP_DEFAULT_LOCATION_CLUSTER_SPIDERFY_ON_MAX_ZOOM,
     MAP_MARKER_CIRCLE_RADIUS_PX_FALLBACK,
     MAP_POPUP_MAX_WIDTH_PX,
@@ -405,6 +406,7 @@ def _add_seq_cluster_marker_demo(
         options={
             "maxClusterRadius": MAP_DEFAULT_LOCATION_CLUSTER_MAX_RADIUS_PX,
             "disableClusteringAtZoom": MAP_DEFAULT_LOCATION_CLUSTER_DISABLE_AT_ZOOM,
+            "removeOutsideVisibleBounds": MAP_DEFAULT_LOCATION_CLUSTER_REMOVE_OUTSIDE_VISIBLE_BOUNDS,
             "spiderfyOnMaxZoom": MAP_DEFAULT_LOCATION_CLUSTER_SPIDERFY_ON_MAX_ZOOM,
             "zoomToBoundsOnClick": True,
         },

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -1085,6 +1085,7 @@ def create_map(
     map_style="default",
     *,
     height_px: int | float | None = None,
+    zoom_start: int | None = None,
 ):
     """Create a folium Map centred on *map_center* with the given tile style.
 
@@ -1094,12 +1095,14 @@ def create_map(
     *height_px*: pixel height for the map pane. Folium defaults to ``100%``, which
     depends on parent layout; inside ``streamlit-folium`` that can collapse to a thin
     strip. Pass the same value as the Streamlit **Map height** slider when embedding.
+
+    *zoom_start*: optional initial zoom level (defaults to ``5`` when omitted).
     """
     # Default initial zoom for first render. Lower = more zoomed out.
-    zoom_start = 5
+    z = 5 if zoom_start is None else int(zoom_start)
     h = float(height_px if height_px is not None else MAP_HEIGHT_PX_DEFAULT)
     h = max(float(MAP_HEIGHT_PX_MIN), min(float(MAP_HEIGHT_PX_MAX), h))
-    common = {"location": map_center, "zoom_start": zoom_start, "height": h, "width": "100%"}
+    common = {"location": map_center, "zoom_start": z, "height": h, "width": "100%"}
     if map_style == "google":
         return folium.Map(
             tiles="https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",

--- a/tests/explorer/test_all_locations_viewport.py
+++ b/tests/explorer/test_all_locations_viewport.py
@@ -6,8 +6,11 @@ from explorer.core.all_locations_viewport import (
     ALL_LOCATIONS_FOCUS_ALL,
     ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
     ALL_LOCATIONS_FRAMING_FIT_ALL,
+    ALL_LOCATIONS_SCOPE_FOCUSED,
     all_locations_scope_option_values,
+    coordinate_pairs_focused_viewport,
     coordinate_pairs_for_viewport,
+    observation_row_counts_by_country_key,
     filter_location_rows_by_focus_country,
     location_id_to_country_map,
     mean_center_from_pairs,
@@ -101,6 +104,34 @@ def test_mean_center_from_pairs():
     assert mean_center_from_pairs([]) is None
 
 
+def test_observation_row_counts_by_country_key():
+    df = pd.DataFrame(
+        {
+            "Country": ["US", "US", "NZ"],
+            "Location ID": ["a", "b", "c"],
+        }
+    )
+    assert observation_row_counts_by_country_key(df) == {"US": 2, "NZ": 1}
+
+
+def test_coordinate_pairs_focused_viewport_includes_high_observation_country():
+    """Quantile trim drops a geographic outlier; country threshold adds that pin back."""
+    rows = [[f"L{i}", i * 0.001, i * 0.001] for i in range(100)] + [["L100", 89.0, 179.0]]
+    eff = pd.DataFrame(rows, columns=["Location ID", "Latitude", "Longitude"])
+    loc_c = {f"L{i}": "NZ" for i in range(100)} | {"L100": "US"}
+    obs = {"NZ": 5, "US": 25}
+    out = coordinate_pairs_focused_viewport(
+        eff,
+        location_id_to_country=loc_c,
+        observation_counts_by_country=obs,
+        quantile_low=0.01,
+        quantile_high=0.99,
+        min_observations_full_country=20,
+    )
+    assert len(out) == 100
+    assert any(abs(float(lat) - 89.0) < 0.01 for lat, _ in out)
+
+
 def test_all_locations_scope_option_values_order():
     df = pd.DataFrame(
         {
@@ -110,5 +141,6 @@ def test_all_locations_scope_option_values_order():
     )
     opts = all_locations_scope_option_values(df)
     assert opts[0] == ALL_LOCATIONS_FRAMING_FIT_ALL
-    assert opts[1] == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY
-    assert set(opts[2:]) == {"NZ", "US"}
+    assert opts[1] == ALL_LOCATIONS_SCOPE_FOCUSED
+    assert opts[2] == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY
+    assert set(opts[3:]) == {"NZ", "US"}

--- a/tests/explorer/test_all_locations_viewport.py
+++ b/tests/explorer/test_all_locations_viewport.py
@@ -1,0 +1,98 @@
+"""Tests for :mod:`explorer.core.all_locations_viewport`."""
+
+import pandas as pd
+
+from explorer.core.all_locations_viewport import (
+    ALL_LOCATIONS_FOCUS_ALL,
+    coordinate_pairs_for_viewport,
+    filter_location_rows_by_focus_country,
+    location_id_to_country_map,
+    mean_center_from_pairs,
+    sorted_country_labels_from_work,
+)
+
+
+def test_location_id_to_country_map_first_non_null():
+    df = pd.DataFrame(
+        {
+            "Location ID": ["A", "A", "B"],
+            "Country": ["NZ", None, "Australia"],
+        }
+    )
+    m = location_id_to_country_map(df)
+    assert m["A"] == "NZ"
+    assert m["B"] == "Australia"
+
+
+def test_location_id_to_country_map_from_state_province_when_no_country_col():
+    """eBird exports often include State/Province but not Country (aligns with Country tab keys)."""
+    df = pd.DataFrame(
+        {
+            "Location ID": ["L1", "L2"],
+            "State/Province": ["AU-NSW", "US-CA"],
+        }
+    )
+    m = location_id_to_country_map(df)
+    assert m["L1"] == "AU"
+    assert m["L2"] == "US"
+
+
+def test_location_id_to_country_map_missing_column():
+    df = pd.DataFrame({"Location ID": ["A"]})
+    assert location_id_to_country_map(df) == {}
+
+
+def test_sorted_country_labels_from_work():
+    df = pd.DataFrame(
+        {
+            "Location ID": ["x", "y"],
+            "Country": ["Brazil", "argentina"],
+        }
+    )
+    assert sorted_country_labels_from_work(df) == ["argentina", "Brazil"]
+
+
+def test_filter_focus_empty_means_all_rows():
+    loc = pd.DataFrame(
+        {
+            "Location ID": ["1", "2"],
+            "Latitude": [0.0, 1.0],
+            "Longitude": [0.0, 1.0],
+        }
+    )
+    m = {"1": "X", "2": "Y"}
+    out = filter_location_rows_by_focus_country(
+        loc, location_id_to_country=m, focus_country=ALL_LOCATIONS_FOCUS_ALL
+    )
+    assert len(out) == 2
+
+
+def test_coordinate_pairs_for_viewport_focus():
+    loc = pd.DataFrame(
+        {
+            "Location ID": ["1", "2"],
+            "Latitude": [10.0, 20.0],
+            "Longitude": [-50.0, -40.0],
+        }
+    )
+    m = {"1": "US", "2": "CA"}
+    pairs = coordinate_pairs_for_viewport(
+        loc, location_id_to_country=m, focus_country="CA"
+    )
+    assert pairs == [[20.0, -40.0]]
+
+
+def test_coordinate_pairs_for_viewport_no_country_map():
+    loc = pd.DataFrame(
+        {
+            "Location ID": ["1"],
+            "Latitude": [1.0],
+            "Longitude": [2.0],
+        }
+    )
+    assert coordinate_pairs_for_viewport(loc, location_id_to_country={}, focus_country="US") == []
+
+
+def test_mean_center_from_pairs():
+    assert mean_center_from_pairs([[0.0, 0.0], [2.0, 4.0]]) == (1.0, 2.0)
+    assert mean_center_from_pairs([]) is None

--- a/tests/explorer/test_all_locations_viewport.py
+++ b/tests/explorer/test_all_locations_viewport.py
@@ -4,6 +4,9 @@ import pandas as pd
 
 from explorer.core.all_locations_viewport import (
     ALL_LOCATIONS_FOCUS_ALL,
+    ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY,
+    ALL_LOCATIONS_FRAMING_FIT_ALL,
+    all_locations_scope_option_values,
     coordinate_pairs_for_viewport,
     filter_location_rows_by_focus_country,
     location_id_to_country_map,
@@ -96,3 +99,16 @@ def test_coordinate_pairs_for_viewport_no_country_map():
 def test_mean_center_from_pairs():
     assert mean_center_from_pairs([[0.0, 0.0], [2.0, 4.0]]) == (1.0, 2.0)
     assert mean_center_from_pairs([]) is None
+
+
+def test_all_locations_scope_option_values_order():
+    df = pd.DataFrame(
+        {
+            "Location ID": ["a", "b"],
+            "Country": ["US", "NZ"],
+        }
+    )
+    opts = all_locations_scope_option_values(df)
+    assert opts[0] == ALL_LOCATIONS_FRAMING_FIT_ALL
+    assert opts[1] == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY
+    assert set(opts[2:]) == {"NZ", "US"}

--- a/tests/explorer/test_region_display.py
+++ b/tests/explorer/test_region_display.py
@@ -3,7 +3,11 @@
 import pandas as pd
 import pytest
 
-from explorer.core.region_display import country_for_display, state_for_display
+from explorer.core.region_display import (
+    country_for_display,
+    map_focus_key_for_display,
+    state_for_display,
+)
 
 
 def test_country_for_display_empty_and_none():
@@ -58,3 +62,20 @@ def test_state_for_display_no_country_returns_state_code():
     pytest.importorskip("pycountry")
     assert state_for_display("", "NSW") == "NSW"
     assert state_for_display(None, "NSW") == "NSW"
+
+
+def test_map_focus_key_for_display_iso_uses_pycountry():
+    """Two-letter ISO keys show common country names (All locations Focus)."""
+    pytest.importorskip("pycountry")
+    assert map_focus_key_for_display("US") == "United States"
+    assert map_focus_key_for_display("AU") == "Australia"
+
+
+def test_map_focus_key_for_display_full_name_passthrough():
+    """Keys that are already full ``Country`` cell text are unchanged."""
+    assert map_focus_key_for_display("New Zealand") == "New Zealand"
+
+
+def test_map_focus_key_for_display_r_prefix():
+    """State-only ``_R:…`` keys show the tail for readability."""
+    assert map_focus_key_for_display("_R:California") == "California"


### PR DESCRIPTION
## Summary
Reworks the all-locations map area flow so Focused becomes the default viewport and country selection remains explicit and predictable.

## Changes
- Add a single `Map area` control order: All locations, Focused, My activity centre, then countries.
- Set Focused as the default scope across controller/UI/session fallbacks.
- Implement Focused viewport trimming via tunable quantiles and add a tunable country inclusion threshold (`>= N` observation rows).
- Country selections use full country fit logic (not focused trimming).
- Add a Focused helper caption in the sidebar and update related tests.
- Include a small bug-report template typo fix.

## Testing
- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q`

## Issues
Fixes #166  
Refs #105  
Implemented in #126

Made with [Cursor](https://cursor.com)