### PR TITLE
Improve All locations map banner content and hierarchy

### DIFF
--- a/.cursor/commands/create-dev-branch.md
+++ b/.cursor/commands/create-dev-branch.md
@@ -1,0 +1,136 @@
+# Create development branch (myebirdstuff)
+
+You are creating a new local development branch for **myebirdstuff**, following this repo’s branching model.
+
+## Branching model (important)
+
+- `main` = stable / current beta (live)
+- `beta-next` = integration branch for the upcoming release
+- New feature/fix work should branch from **`beta-next`** unless the user explicitly names another base (e.g. a hotfix from `main`)
+
+This matches **Commit work**, **Open PR**, and **Merge PR** in this repo.
+
+---
+
+## Step 1 — Confirm inputs
+
+From the user (or infer only when obvious, e.g. from an open issue in context):
+
+1. **GitHub issue number** (optional)
+2. **Short description** — slug-style: lowercase words separated by hyphens
+3. **Base branch** (optional) — default **`beta-next`**
+
+If there is no issue number, omit it from the branch name (do not invent a number).
+
+---
+
+## Step 2 — Determine branch name
+
+**With issue number** (preferred when an issue exists):
+
+```text
+<issue-number>-<short-description>
+```
+
+Examples:
+
+- `123-map-focus-improvements`
+- `245-fix-banner-title`
+- `167-enhancement-improve-all-locations-map-banner-content` (optional type word after the number is fine)
+
+**Without issue number:**
+
+```text
+<short-description>
+```
+
+Example:
+
+- `refactor-colour-schemes`
+
+**Rules**
+
+- Lowercase only; hyphens (`-`) only; no spaces or shell‑unsafe characters
+- Keep it concise but meaningful (roughly **≤ 60 characters** total is a good target)
+- Avoid a slug that is **only digits**, so it is not mistaken for an issue id
+
+There is **no** separate “confirm the branch name” step: once inputs and preconditions pass, create the branch with the name you derived.
+
+---
+
+## Step 3 — Preconditions (do not skip)
+
+1. **Working tree** must be clean (`git status`). If not, stop and ask whether to **commit**, **stash**, or **abort** — do not switch branches with uncommitted work unless the user explicitly chooses that path.
+
+2. **Branch name must not already exist** locally or on `origin`:
+   - Local: `git show-ref --verify --quiet refs/heads/<branch-name>` — if exit code `0`, the branch exists; stop and ask
+   - Remote: `git ls-remote --heads origin <branch-name>` — if non‑empty, stop and ask (use a different name or delete only if the user explicitly requests and it is safe)
+
+3. **Execute from the repository root** (where `.git` lives). Use **`git switch`** (not legacy `git checkout` for branch changes).
+
+---
+
+## Step 4 — Update base and create branch
+
+Use the chosen base (default **`beta-next`**). Replace `beta-next` below if the user overrode the base.
+
+```bash
+git fetch origin
+git switch <base-branch>
+git pull origin <base-branch>
+git switch -c <branch-name>
+```
+
+Notes:
+
+- **`git fetch origin`** first avoids creating a branch from a stale local `beta-next`.
+- **`git pull origin <base-branch>`** is explicit and works even if upstream tracking is misconfigured.
+
+---
+
+## Step 5 — Optional: push and set upstream
+
+Only if the user wants the branch on GitHub immediately (or your workflow expects an early push):
+
+```bash
+git push -u origin <branch-name>
+```
+
+Do **not** force‑push when creating a new branch. If push is rejected because the name exists on the remote, stop and reconcile with the user.
+
+---
+
+## Step 6 — Output summary
+
+Report clearly:
+
+- **Branch name** created
+- **Base branch** and tip (e.g. short `git rev-parse --short HEAD` after pull)
+- **Current branch** after `git switch -c` (must be the new branch)
+
+Example:
+
+> Created and switched to `123-map-focus-improvements` from `beta-next` at `abc1234`. Remote not pushed yet.
+
+---
+
+## Do not
+
+- Create the new branch from **`main`** unless the user explicitly asked for that base
+- Proceed with a **dirty** working tree without confirmation
+- **Invent** issue numbers
+- **Overwrite** an existing branch (`-C`, `-f`, force push) unless the user explicitly instructs and risks are understood
+
+---
+
+## For Cursor / agent execution
+
+- Run the git commands yourself from the repo root; use **`git_write`** and **`network`** (for `fetch` / `pull` / `push`) when the environment requires it.
+- If any step fails, stop, show the command output, and ask how to proceed.
+
+---
+
+## Why this command exists
+
+- Keeps new work aligned with **`beta-next`** so PRs do not replay unrelated `main` history or miss integration commits.
+- Enforces predictable branch names for issue linking and review.

--- a/explorer/core/__init__.py
+++ b/explorer/core/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:  # pragma: no cover
         format_rankings_tab_html,
     )
     from explorer.presentation.map_renderer import (
-        build_all_species_banner_html,
+        build_all_locations_banner_html,
         build_legend_html,
         build_location_popup_html,
         build_species_banner_html,
@@ -129,9 +129,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "format_sighting_row": ("explorer.presentation.map_renderer", "format_sighting_row"),
     "popup_scroll_script": ("explorer.presentation.map_renderer", "popup_scroll_script"),
     "pin_legend_item": ("explorer.presentation.map_renderer", "pin_legend_item"),
-    "build_all_species_banner_html": (
+    "build_all_locations_banner_html": (
         "explorer.presentation.map_renderer",
-        "build_all_species_banner_html",
+        "build_all_locations_banner_html",
     ),
     "build_species_banner_html": ("explorer.presentation.map_renderer", "build_species_banner_html"),
     "build_legend_html": ("explorer.presentation.map_renderer", "build_legend_html"),
@@ -188,7 +188,7 @@ __all__ = [
     "format_sighting_row",
     "popup_scroll_script",
     "pin_legend_item",
-    "build_all_species_banner_html",
+    "build_all_locations_banner_html",
     "build_species_banner_html",
     "build_legend_html",
     "build_visit_info_html",

--- a/explorer/core/map_controller.py
+++ b/explorer/core/map_controller.py
@@ -45,7 +45,7 @@ def build_species_overlay_map(
     records_by_loc: Dict[Hashable, pd.DataFrame],
     effective_location_data: pd.DataFrame,
     effective_records_by_loc: Dict[Hashable, pd.DataFrame],
-    effective_totals: Tuple[int, int, int],
+    effective_totals: Tuple[int, int, int, int],
     effective_use_full: bool,
     lifer_lookup_df: pd.DataFrame,
     true_lifer_locations: Dict[str, Any],
@@ -99,6 +99,9 @@ def build_species_overlay_map(
     *hide_non_matching_locations*: in **Species locations** view with no species selected, when
     ``True`` an empty map is shown until a species is chosen. When ``False`` and the view is still
     **All locations**, the full map is shown; **Species** view with no selection is always empty (refs #147).
+
+    *effective_totals*: ``(n_locations, n_checklists, n_species, n_individuals)`` for the all-locations
+    banner (refs #167); from :func:`explorer.core.map_prep.prepare_all_locations_map_context`.
 
     *map_height_px*: pixel height for the Folium map pane (match Streamlit **Map height** slider).
 

--- a/explorer/core/map_overlay_visit_map.py
+++ b/explorer/core/map_overlay_visit_map.py
@@ -58,7 +58,7 @@ from explorer.core.map_overlay_theme import inject_map_overlay_theme
 from explorer.core.map_overlay_types import BaseSpeciesFn, MapOverlayResult, SpeciesUrlFn
 from explorer.presentation.map_renderer import (
     add_zoom_level_debug_overlay,
-    build_all_species_banner_html,
+    build_all_locations_banner_html,
     build_legend_html,
     build_location_popup_html,
     build_species_banner_html,
@@ -285,7 +285,7 @@ def build_visit_overlay_map(
     records_by_loc: Dict[Hashable, pd.DataFrame],
     effective_location_data: pd.DataFrame,
     effective_records_by_loc: Dict[Hashable, pd.DataFrame],
-    effective_totals: Tuple[int, int, int],
+    effective_totals: Tuple[int, int, int, int],
     effective_use_full: bool,
     lifer_lookup_df: pd.DataFrame,
     true_lifer_locations: Dict[str, Any],
@@ -450,9 +450,9 @@ def build_visit_overlay_map(
     add_zoom_level_debug_overlay(species_map, enabled=MAP_DEBUG_SHOW_ZOOM_LEVEL)
 
     if not selected_species:
-        tc, ts, ti = effective_totals
+        nl, tc, ts, ti = effective_totals
         species_map.get_root().html.add_child(
-            Element(build_all_species_banner_html(tc, ts, ti, date_filter_status_line))
+            Element(build_all_locations_banner_html(nl, tc, ts, ti, date_filter_status_line))
         )
         _fill, _edge, _radius_px, _stroke_w, _fill_op = _all_locations_marker_params_from_scheme(
             visit_marker_scheme

--- a/explorer/core/map_prep.py
+++ b/explorer/core/map_prep.py
@@ -65,6 +65,7 @@ def prepare_all_locations_map_context(
     total_checklists = int(work["Submission ID"].nunique())
     total_individuals = int(work["Count"].apply(safe_count).sum())
     total_species = int(countable_species_vectorized(work).dropna().nunique())
+    n_locations = int(location_data["Location ID"].nunique())
 
     prep = prepare_lifer_last_seen(full, base_species_fn=base_species_for_lifer)
 
@@ -74,7 +75,7 @@ def prepare_all_locations_map_context(
         "records_by_loc": records_by_loc,
         "effective_location_data": location_data,
         "effective_records_by_loc": records_by_loc,
-        "effective_totals": (total_checklists, total_species, total_individuals),
+        "effective_totals": (n_locations, total_checklists, total_species, total_individuals),
         "effective_use_full": False,
         "lifer_lookup_df": prep.lifer_lookup_df,
         "true_lifer_locations": prep.true_lifer_locations,

--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -330,6 +330,24 @@ def map_banner_and_legend_theme_stylesheet() -> str:
   font-weight: 400;
   margin: 0;
 }}
+/* All-locations map: match family-map banner hierarchy — title (green) + body-colour main line + muted smaller line (#167). */
+.pebird-map-banner__all-locations-primary {{
+  display: block;
+  font-size: inherit;
+  font-weight: 400;
+  color: {EXPLORER_UI_TEXT_COLOR};
+  margin: 0;
+  line-height: 1.35;
+}}
+/* Same rhythm as ``__family-selected-summary`` under family main stats (refs family map banner). */
+.pebird-map-banner__all-locations-details {{
+  display: block;
+  font-size: calc(1em - 2px);
+  font-weight: 400;
+  color: {EXPLORER_UI_MUTED};
+  margin-top: 6px;
+  line-height: 1.35;
+}}
 /* Species map only: secondary stats (first/last seen, high count) below the primary summary line (#162). */
 .pebird-map-banner__stats-secondary {{
   font-size: calc(1em - 3px);
@@ -686,16 +704,25 @@ def pin_legend_item(color, fill, label):
     )
 
 
-def build_all_species_banner_html(
-    total_checklists, total_species, total_individuals, date_filter_status=None
+def build_all_locations_banner_html(
+    n_locations,
+    total_checklists,
+    total_species,
+    total_individuals,
+    date_filter_status=None,
 ):
-    """Return the HTML overlay banner for the all-species map view.
+    """Return the HTML overlay banner for the **All locations** map (landing map).
+
+    Same hierarchy as the family-map banner: green ``__title``, main stats in body text, secondary
+    line muted and slightly smaller (refs #167).
 
     If date_filter_status is provided (e.g. "Date filter: Off" or "Date filter: 2026-01-01 to 2026-12-31"),
-    it is shown as a second line in the banner, smaller and lighter so it is less prominent.
+    it is shown below, smaller and lighter so it is less prominent.
     """
     sep = _banner_sep()
-    stats = (
+    loc_w = "locations" if n_locations != 1 else "location"
+    primary_line = f"{n_locations} {loc_w}"
+    details_line = (
         f'{total_checklists} checklist{"s" if total_checklists != 1 else ""}'
         f'{sep}{total_species} species'
         f'{sep}{total_individuals} individual{"s" if total_individuals != 1 else ""}'
@@ -703,8 +730,11 @@ def build_all_species_banner_html(
     date_block = _banner_muted_line(date_filter_status) if date_filter_status else ""
     return (
         f'<div class="pebird-map-banner" style="{_BANNER_POSITION}">'
-        f'<span class="pebird-map-banner__title">All species</span>'
-        f'<div class="pebird-map-banner__stats">{stats}</div>'
+        f'<span class="pebird-map-banner__title">All locations</span>'
+        f'<div class="pebird-map-banner__stats">'
+        f'<span class="pebird-map-banner__all-locations-primary">{primary_line}</span>'
+        f'<span class="pebird-map-banner__all-locations-details">{details_line}</span>'
+        f"</div>"
         f'{date_block}'
         f'</div>'
     )

--- a/tests/explorer/test_map_controller.py
+++ b/tests/explorer/test_map_controller.py
@@ -64,7 +64,7 @@ def _common_kwargs(df, *, visit_marker_scheme=None):
         records_by_loc=records_by_loc,
         effective_location_data=location_data,
         effective_records_by_loc=records_by_loc,
-        effective_totals=(df["Submission ID"].nunique(), 1, 3),
+        effective_totals=(df["Location ID"].nunique(), df["Submission ID"].nunique(), 1, 3),
         effective_use_full=False,
         lifer_lookup_df=prep.lifer_lookup_df,
         true_lifer_locations=prep.true_lifer_locations,
@@ -91,7 +91,7 @@ def test_no_sightings_returns_warning():
     assert "Xyz abcensis" in r.warning
 
 
-def test_all_species_builds_map_with_banner():
+def test_all_locations_builds_map_with_banner():
     df = _minimal_map_df()
     r = build_species_overlay_map(
         **_common_kwargs(df),
@@ -100,7 +100,8 @@ def test_all_species_builds_map_with_banner():
     assert r.warning is None
     assert r.map is not None
     html = r.map._repr_html_()
-    assert "All species" in html
+    assert "1 location" in html
+    assert "All locations" in html  # banner title + legend label
     assert "1 checklist" in html
     assert "Date filter" not in html
 

--- a/tests/explorer/test_map_renderer.py
+++ b/tests/explorer/test_map_renderer.py
@@ -8,7 +8,7 @@ from explorer.presentation.map_renderer import (
     build_species_map_location_popup_html,
     build_species_seen_sections_html,
     build_visit_info_html,
-    build_all_species_banner_html,
+    build_all_locations_banner_html,
     build_species_banner_html,
     build_legend_html,
     build_location_popup_html,
@@ -340,25 +340,29 @@ def test_pin_legend_item_is_single_span():
 
 
 # ---------------------------------------------------------------------------
-# build_all_species_banner_html
+# build_all_locations_banner_html
 # ---------------------------------------------------------------------------
 
-def test_build_all_species_banner_html_content():
-    html = build_all_species_banner_html(42, 100, 5000)
-    assert "All species" in html
-    assert "42 checklists" in html
+def test_build_all_locations_banner_html_content():
+    html = build_all_locations_banner_html(728, 7452, 100, 467_889)
+    assert 'class="pebird-map-banner__title">All locations</span>' in html
+    assert "728 locations" in html
+    assert "pebird-map-banner__all-locations-primary" in html
+    assert "pebird-map-banner__all-locations-details" in html
+    assert "7452 checklists" in html
     assert "100 species" in html
-    assert "5000 individuals" in html
+    assert "467889 individuals" in html
 
 
-def test_build_all_species_banner_html_singular():
-    html = build_all_species_banner_html(1, 1, 1)
+def test_build_all_locations_banner_html_singular():
+    html = build_all_locations_banner_html(1, 1, 1, 1)
+    assert "1 location" in html
     assert "1 checklist" in html
     assert "1 individual" in html
 
 
-def test_build_all_species_banner_html_is_div():
-    html = build_all_species_banner_html(10, 20, 30)
+def test_build_all_locations_banner_html_is_div():
+    html = build_all_locations_banner_html(10, 20, 30, 40)
     assert html.startswith("<div")
     assert html.endswith("</div>")
 


### PR DESCRIPTION
## Summary

Aligns the **All locations** Folium banner with the map’s purpose: correct heading, location count first in the data model, and a two-line stats layout that matches the **family map** banner hierarchy (green title, body-colour main line, muted secondary line).

## Changes

- **Banner:** `build_all_locations_banner_html` — title **All locations**; main line `N locations`; secondary line checklists · species · individuals; CSS aligned with family-map patterns (`EXPLORER_UI_TEXT_COLOR` / `EXPLORER_UI_MUTED`, spacing).
- **Data:** `prepare_all_locations_map_context` exposes `effective_totals` as `(n_locations, n_checklists, n_species, n_individuals)`; visit overlay and controller contract updated.
- **Exports:** Lazy barrel renames `build_all_species_banner_html` → `build_all_locations_banner_html`.
- **Docs (Cursor):** Adds `.cursor/commands/create-dev-branch.md` for the beta-next branching workflow (second commit on this branch).

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (458 passed)

## Notes

- PR targets **beta-next** per release workflow.
- Branch includes two commits: UI work for #167 plus the create-dev-branch command doc; split in a follow-up if you prefer only #167 in this PR.

## Issues

- Fixes #167
- Refs #126

Made with [Cursor](https://cursor.com)