### PR TITLE
Add sidebar help caption for My activity centre map focus

### DIFF
--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -270,10 +270,16 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 ),
                 key=STREAMLIT_ALL_LOCATIONS_SCOPE_KEY,
             )
-            if st.session_state.get(STREAMLIT_ALL_LOCATIONS_SCOPE_KEY) == ALL_LOCATIONS_SCOPE_FOCUSED:
+            _scope_sel = st.session_state.get(STREAMLIT_ALL_LOCATIONS_SCOPE_KEY)
+            if _scope_sel == ALL_LOCATIONS_SCOPE_FOCUSED:
                 st.caption(
                     "Focused view shows your main birding regions. "
                     "Smaller or infrequent locations may be hidden."
+                )
+            elif _scope_sel == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY:
+                st.caption(
+                    "Centres the map on the middle of the places you've birded. "
+                    "You may need to zoom out to see more locations."
                 )
 
     hide_non_matching_locations = False


### PR DESCRIPTION
## Summary

Adds a short **caption under Map focus** when **My activity centre** is selected (All locations map), matching the existing help for **Focused** so users understand centre-of-gravity framing and fixed zoom.

## Changes

- `app_map_working_ui.py`: caption text for `ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY`; refactored scope read into `_scope_sel` for `if` / `elif` captions.

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (458 passed)
- Manual: All locations → Map focus → My activity centre shows the new caption.

## Issues

- Refs #168

Made with [Cursor](https://cursor.com)