### PR TITLE
Fix map popup scroll wheel falling through to map (#175)

### DIFF
--- a/explorer/presentation/map_renderer.py
+++ b/explorer/presentation/map_renderer.py
@@ -88,10 +88,12 @@ def map_popup_theme_stylesheet() -> str:
   /* Leaflet's close control sits top-right; long titles must not run under it. */
   padding-right: 2rem;
 }}
+/* Full width of the popup card so wheel events scroll visits instead of the map (#175). */
 .pebird-map-popup__scroll {{
-  width: fit-content;
-  max-width: 100%;
+  display: block;
+  width: 100%;
   min-width: 0;
+  max-width: 100%;
   box-sizing: border-box;
 }}
 .pebird-map-popup {{


### PR DESCRIPTION
## Summary

On the All locations map (and other long popups), scrolling worked only when the pointer was over visit **text**. Whitespace inside the popup still sent wheel events to Leaflet, so the map panned instead of the visit list scrolling (#175).

## Changes

- `map_popup_theme_stylesheet()` in `explorer/presentation/map_renderer.py`: `.pebird-map-popup__scroll` no longer uses `width: fit-content`; it is `display: block` with `width: 100%` so the scrollable layer spans the full popup card width (regression after shrink-wrap / #160-style layout).

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (473 passed)

## Issues

Fixes #175
Refs #160

Made with [Cursor](https://cursor.com)