### PR TITLE
Add hosted performance notice and refresh landing page experience

### DIFF
--- a/explorer/app/streamlit/app_landing_ui.py
+++ b/explorer/app/streamlit/app_landing_ui.py
@@ -147,8 +147,6 @@ def load_dataframe_after_landing(
         with st.container(key=EBIRD_LANDING_MAIN_CONTAINER_KEY):
             title_with_logo()
             inject_landing_typography_css()
-            if show_hosted_performance_notice():
-                st.info(hosted_performance_notice_markdown(), icon="ℹ️")
             st.markdown("Upload your `My eBird Data CSV` to open the map and tabs.")
             uploaded = st.file_uploader(
                 " ",
@@ -187,6 +185,8 @@ Tip: If species names look wrong, check `Settings -> Taxonomy` after loading.
                     "If you’re running Explorer locally, you can load data automatically from a configured file. "
                     f"See [Explorer docs]({explorer_readme_github_url()}) for details."
                 )
+                if show_hosted_performance_notice():
+                    st.info(hosted_performance_notice_markdown(), icon="ℹ️")
         sidebar_footer_links()
         if df_full is None:
             return None

--- a/explorer/app/streamlit/app_landing_ui.py
+++ b/explorer/app/streamlit/app_landing_ui.py
@@ -93,10 +93,11 @@ def hosted_performance_notice_markdown() -> str:
     """Landing note for hosted environments: set expectations and point to local setup docs."""
     docs_url = explorer_readme_github_url()
     return (
-        "Explorer is fully usable here, but free Streamlit hosting can be slow. "
-        "Running locally usually gives the best experience. "
-        f"See [Explorer docs]({docs_url}) for local setup. "
-        "If there is enough interest and support, hosting may move to a more capable platform later."
+        "**Running on free Streamlit hosting**\n\n"
+        "Explorer works here, but performance can be slow at times.\n\n"
+        "- Best experience: run locally  \n"
+        f"- Setup guide: [Explorer docs]({docs_url})  \n"
+        "- Future: may move to faster hosting with community support"
     )
 
 

--- a/explorer/app/streamlit/app_landing_ui.py
+++ b/explorer/app/streamlit/app_landing_ui.py
@@ -69,8 +69,17 @@ def title_with_logo() -> None:
 
 
 def _env_flag_true(key: str) -> bool:
-    """Boolean env flag parser (true/1/yes/on)."""
-    raw = str(os.environ.get(key, "")).strip().lower()
+    """Boolean flag parser from environment or Streamlit secrets (true/1/yes/on)."""
+    raw: str = ""
+    try:
+        # Streamlit Community Cloud commonly provides config via ``st.secrets``.
+        if key in st.secrets:
+            raw = str(st.secrets[key]).strip()
+    except Exception:
+        # Keep landing resilient if secrets backend is unavailable in local/dev runs.
+        raw = ""
+    if not raw:
+        raw = str(os.environ.get(key, "")).strip()
     return raw in {"1", "true", "yes", "on"}
 
 

--- a/explorer/app/streamlit/app_landing_ui.py
+++ b/explorer/app/streamlit/app_landing_ui.py
@@ -80,6 +80,7 @@ def _env_flag_true(key: str) -> bool:
         raw = ""
     if not raw:
         raw = str(os.environ.get(key, "")).strip()
+    raw = raw.lower()
     return raw in {"1", "true", "yes", "on"}
 
 

--- a/explorer/app/streamlit/app_landing_ui.py
+++ b/explorer/app/streamlit/app_landing_ui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import os
 from pathlib import Path
 from typing import Any
 
@@ -16,9 +17,11 @@ from explorer.app.streamlit.app_constants import (
 )
 from explorer.app.streamlit.app_data_loading import load_dataframe
 from explorer.app.streamlit.app_map_ui import sidebar_footer_links
+from explorer.app.streamlit.streamlit_ui_constants import explorer_readme_github_url
 from explorer.app.streamlit.streamlit_theme import inject_app_header_css
 
 _APP_LOGO_SVG = Path(REPO_ROOT) / "docs" / "explorer" / "assets" / "personal-ebird-explorer-logo.svg"
+_HOSTED_NOTICE_ENV_KEY = "STREAMLIT_SHOW_HOSTED_PERFORMANCE_NOTICE"
 
 APP_TAGLINE = "Your eBird data, made visible, navigable, and ready to explore"
 
@@ -65,6 +68,28 @@ def title_with_logo() -> None:
     inject_app_header_css()
 
 
+def _env_flag_true(key: str) -> bool:
+    """Boolean env flag parser (true/1/yes/on)."""
+    raw = str(os.environ.get(key, "")).strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def show_hosted_performance_notice() -> bool:
+    """Show hosted landing note only when explicitly enabled by environment."""
+    return _env_flag_true(_HOSTED_NOTICE_ENV_KEY)
+
+
+def hosted_performance_notice_markdown() -> str:
+    """Landing note for hosted environments: set expectations and point to local setup docs."""
+    docs_url = explorer_readme_github_url()
+    return (
+        "Explorer is fully usable here, but free Streamlit hosting can be slow. "
+        "Running locally usually gives the best experience. "
+        f"See [Explorer docs]({docs_url}) for local setup. "
+        "If there is enough interest and support, hosting may move to a more capable platform later."
+    )
+
+
 def load_dataframe_after_landing(
     upload_cache: Any,
 ) -> tuple[Any, Any, str, Any, str] | None:
@@ -83,6 +108,8 @@ def load_dataframe_after_landing(
     if df_full is None:
         with st.container(key=EBIRD_LANDING_MAIN_CONTAINER_KEY):
             title_with_logo()
+            if show_hosted_performance_notice():
+                st.info(hosted_performance_notice_markdown(), icon="ℹ️")
             st.markdown("Upload your **My eBird Data** CSV to open the map and tabs.")
             uploaded = st.file_uploader(
                 "eBird export (CSV)",

--- a/explorer/app/streamlit/app_landing_ui.py
+++ b/explorer/app/streamlit/app_landing_ui.py
@@ -68,6 +68,33 @@ def title_with_logo() -> None:
     inject_app_header_css()
 
 
+def inject_landing_typography_css() -> None:
+    """Keep landing-page typography aligned with the rest of the app."""
+    st.html(
+        """<style>
+.st-key-ebird_landing_main [data-testid="stMarkdownContainer"],
+.st-key-ebird_landing_main [data-testid="stMarkdownContainer"] * {
+  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.st-key-ebird_landing_main h1,
+.st-key-ebird_landing_main h2,
+.st-key-ebird_landing_main h3 {
+  line-height: 1.25;
+}
+.st-key-ebird_landing_main [data-testid="stMarkdownContainer"] code,
+.st-key-ebird_landing_main [data-testid="stCaptionContainer"] code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.92em;
+  font-weight: 500;
+  color: #1f6f54;
+  background: rgba(31, 111, 84, 0.10);
+  padding: 0.08em 0.34em;
+  border-radius: 0.22rem;
+}
+</style>"""
+    )
+
+
 def _env_flag_true(key: str) -> bool:
     """Boolean flag parser from environment or Streamlit secrets (true/1/yes/on)."""
     raw: str = ""
@@ -119,13 +146,15 @@ def load_dataframe_after_landing(
     if df_full is None:
         with st.container(key=EBIRD_LANDING_MAIN_CONTAINER_KEY):
             title_with_logo()
+            inject_landing_typography_css()
             if show_hosted_performance_notice():
                 st.info(hosted_performance_notice_markdown(), icon="ℹ️")
-            st.markdown("Upload your **My eBird Data** CSV to open the map and tabs.")
+            st.markdown("Upload your `My eBird Data CSV` to open the map and tabs.")
             uploaded = st.file_uploader(
-                "eBird export (CSV)",
+                " ",
                 type=["csv"],
                 key=EBIRD_LANDING_CSV_UPLOADER_KEY,
+                label_visibility="collapsed",
                 help="Official eBird full data export (CSV).",
             )
             if uploaded is not None:
@@ -139,21 +168,24 @@ def load_dataframe_after_landing(
             if df_full is None:
                 st.markdown(
                     """
-**From eBird**
+Upload your eBird data to get started.
 
-1. Sign in: [Download My Data](https://ebird.org/downloadMyData)
-2. Under **My eBird Observations**, use **Request My Observations**.
-3. A link to your data will be sent to your email address (often a few minutes; sometimes longer).
-4. Open the email, download the **.zip** and unzip it.
-5. Upload the CSV here (in English the file name should be **MyEBirdData.csv**).
+### Get your eBird data
+
+1. Go to eBird -> [`Download My Data`](https://ebird.org/downloadMyData)
+2. Under `My eBird Observations`, select `Request My Observations`
+3. Wait for the email (usually a few minutes)
+4. Download and unzip the file
+5. Upload the CSV here (file name usually `MyEBirdData.csv`)
+
+Tip: If species names look wrong, check `Settings -> Taxonomy` after loading.
                     """
                 )
                 st.caption(
-                    "Species links default to **en_AU**; change locale under **Settings → Taxonomy** after load. "
-                    "Data still loads if names don’t match.\n\n"
-                    "This page is skipped when a CSV is already found on disk (local config path). "
-                    "Support for local files works when Streamlit is running locally; see the code repo for more information. "
-                    "Proper instructions will appear here in future releases."
+                    "Species names come from the configured taxonomy; you can configure the taxonomy options "
+                    "on the `Settings` tab once the full application has loaded. The default is `en_AU`.\n\n"
+                    "If you’re running Explorer locally, you can load data automatically from a configured file. "
+                    f"See [Explorer docs]({explorer_readme_github_url()}) for details."
                 )
         sidebar_footer_links()
         if df_full is None:

--- a/explorer/app/streamlit/app_landing_ui.py
+++ b/explorer/app/streamlit/app_landing_ui.py
@@ -81,6 +81,12 @@ def inject_landing_typography_css() -> None:
 .st-key-ebird_landing_main h3 {
   line-height: 1.25;
 }
+.st-key-ebird_landing_main .pebird-landing-pitch {
+  font-size: 1.02rem;
+  line-height: 1.48;
+  color: #1a2e22;
+  margin: 0.35rem 0 0.7rem 0;
+}
 .st-key-ebird_landing_main [data-testid="stMarkdownContainer"] code,
 .st-key-ebird_landing_main [data-testid="stCaptionContainer"] code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -90,6 +96,41 @@ def inject_landing_typography_css() -> None:
   background: rgba(31, 111, 84, 0.10);
   padding: 0.08em 0.34em;
   border-radius: 0.22rem;
+}
+/* Keep upload and hosted-info panels readable on wide screens. */
+.st-key-ebird_landing_main [data-testid="stFileUploader"],
+.st-key-ebird_landing_main [data-testid="stAlert"] {
+  max-width: min(100%, 60rem);
+}
+.st-key-ebird_landing_main .pebird-landing-instructions {
+  max-width: min(100%, 60rem);
+  font-size: 0.94rem;
+  line-height: 1.45;
+  color: rgba(26, 46, 34, 0.88);
+}
+.st-key-ebird_landing_main .pebird-landing-instructions h3 {
+  font-size: 1.02rem;
+  font-weight: 600;
+  margin: 0.55rem 0 0.2rem 0;
+  color: #1a2e22;
+}
+.st-key-ebird_landing_main .pebird-landing-instructions ol {
+  margin-top: 0.25rem;
+  margin-bottom: 0.45rem;
+  padding-left: 0;
+  list-style-position: inside;
+}
+.st-key-ebird_landing_main .pebird-landing-instructions li {
+  margin: 0.16rem 0;
+}
+.st-key-ebird_landing_main .pebird-landing-instructions h4 {
+  font-size: 1.02rem;
+  font-weight: 600;
+  margin: 0.55rem 0 0.2rem 0;
+  color: #1a2e22;
+}
+.st-key-ebird_landing_main .pebird-landing-instructions p {
+  margin: 0.1rem 0 0.45rem 0;
 }
 </style>"""
     )
@@ -120,8 +161,8 @@ def hosted_performance_notice_markdown() -> str:
     """Landing note for hosted environments: set expectations and point to local setup docs."""
     docs_url = explorer_readme_github_url()
     return (
-        "**Running on free Streamlit hosting**\n\n"
-        "Explorer works here, but performance can be slow at times.\n\n"
+        "Explorer works here, but performance can be slow at times on this free hosted platform "
+        "(Streamlit Community Cloud).\n\n"
         "- Best experience: run locally  \n"
         f"- Setup guide: [Explorer docs]({docs_url})  \n"
         "- Future: may move to faster hosting with community support"
@@ -147,7 +188,18 @@ def load_dataframe_after_landing(
         with st.container(key=EBIRD_LANDING_MAIN_CONTAINER_KEY):
             title_with_logo()
             inject_landing_typography_css()
-            st.markdown("Upload your `My eBird Data CSV` to open the map and tabs.")
+            st.markdown(
+                '<p class="pebird-landing-pitch">'
+                "Load your eBird data to explore your locations, species, and records across maps, "
+                "tables, and rich summaries."
+                "</p>",
+                unsafe_allow_html=True,
+            )
+            if show_hosted_performance_notice():
+                st.markdown("<div style='height:0.35rem;'></div>", unsafe_allow_html=True)
+                st.info(hosted_performance_notice_markdown(), icon="ℹ️")
+                st.markdown("<div style='height:0.35rem;'></div>", unsafe_allow_html=True)
+            st.markdown("Upload your eBird data to begin.")
             uploaded = st.file_uploader(
                 " ",
                 type=["csv"],
@@ -165,28 +217,34 @@ def load_dataframe_after_landing(
 
             if df_full is None:
                 st.markdown(
+                    f"""
+<div class="pebird-landing-instructions">
+<h3>Get your eBird data</h3>
+<ol>
+<li>Go to eBird -> <a href="https://ebird.org/downloadMyData" target="_blank" rel="noopener noreferrer"><code>Download My Data</code></a></li>
+<li>Under <code>My eBird Observations</code>, select <code>Request My Observations</code></li>
+<li>Wait for the email (usually a few minutes)</li>
+<li>Download and unzip the file</li>
+<li>Upload the CSV here (file name usually <code>MyEBirdData.csv</code>)</li>
+</ol>
+
+<h4>Taxononmy</h4>
+<p>
+Species names come from the configured taxonomy; you can configure the taxonomy options on the
+<code>Settings</code> tab once the full application has loaded. The default is <code>en_AU</code>.
+</p>
+
+<h4>Configuration file</h4>
+<p>
+If you’re running Explorer locally, you can load data automatically from a configured file.
+See <a href="{explorer_readme_github_url()}"
+target="_blank" rel="noopener noreferrer">Explorer docs</a> for details.
+</p>
+</div>
                     """
-Upload your eBird data to get started.
-
-### Get your eBird data
-
-1. Go to eBird -> [`Download My Data`](https://ebird.org/downloadMyData)
-2. Under `My eBird Observations`, select `Request My Observations`
-3. Wait for the email (usually a few minutes)
-4. Download and unzip the file
-5. Upload the CSV here (file name usually `MyEBirdData.csv`)
-
-Tip: If species names look wrong, check `Settings -> Taxonomy` after loading.
-                    """
+                    ,
+                    unsafe_allow_html=True,
                 )
-                st.caption(
-                    "Species names come from the configured taxonomy; you can configure the taxonomy options "
-                    "on the `Settings` tab once the full application has loaded. The default is `en_AU`.\n\n"
-                    "If you’re running Explorer locally, you can load data automatically from a configured file. "
-                    f"See [Explorer docs]({explorer_readme_github_url()}) for details."
-                )
-                if show_hosted_performance_notice():
-                    st.info(hosted_performance_notice_markdown(), icon="ℹ️")
         sidebar_footer_links()
         if df_full is None:
             return None


### PR DESCRIPTION
## Summary

Implements the requested hosted-performance notice for landing (**#177**) and includes a focused landing-page polish pass done in the same branch to improve readability and first-run onboarding.

## Changes

- Add hosted notice block on landing, gated by `STREAMLIT_SHOW_HOSTED_PERFORMANCE_NOTICE`.
- Support flag resolution from both `st.secrets` and environment variables (case-insensitive parsing).
- Keep docs link branch-aware via `explorer_readme_github_url()`.
- Rework landing copy hierarchy:
  - top “pitch” sentence,
  - cleaner eBird acquisition steps,
  - separate taxonomy/configuration guidance sections.
- Refine styling/layout:
  - scoped typography styles,
  - inline highlight chips for key terms,
  - constrained uploader/info panel widths,
  - tuned spacing around hosted notice and list alignment.

## Notes

- **Issue scope note:** #177 originally requested the hosted blue notice block. While implementing that, this branch also applies a broader landing-page cleanup/improvement pass for clarity and visual consistency.

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (473 passed)

## Issues

Resolves #177

Made with [Cursor](https://cursor.com)