### PR TITLE
CI: Restructure Python workflow for triggers, split jobs, and caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,22 @@
-name: Tests
+name: Python CI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
-    branches: ["**"]
+    branches: [main, beta-next]
   pull_request:
-    branches: [main]
+    branches: [main, beta-next]
 
 jobs:
-  test:
+  repository-hygiene:
+    name: Repository hygiene
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v6
+      - name: Check out repository
+        uses: actions/checkout@v6
 
       - name: Ensure gitignored config files are not tracked
         run: |
@@ -24,34 +29,96 @@ jobs:
             exit 1
           fi
 
+  lint-ruff:
+    name: Lint (Ruff)
+    needs: repository-hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-gps-script.txt
 
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-gps-script.txt
 
-      - name: Ruff (explorer package)
+      - name: Run Ruff on explorer/
         run: ruff check explorer/
 
-      - name: Audit Python dependencies (pip-audit)
+  dependency-audit:
+    name: Dependency audit (pip-audit)
+    needs: repository-hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-gps-script.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-gps-script.txt
+
+      - name: Cache pip-audit vulnerability DB
+        uses: actions/cache@v4
+        with:
+          path: .pip-audit-cache
+          key: pip-audit-${{ runner.os }}-${{ hashFiles('requirements.txt', 'requirements-gps-script.txt') }}
+
+      - name: Install pip-audit and scan requirements
         run: |
           python -m pip install --upgrade pip-audit
           pip-audit -r requirements.txt -r requirements-gps-script.txt --cache-dir .pip-audit-cache
 
-      - name: Run tests with coverage
+  unit-tests:
+    name: Unit tests (pytest & coverage)
+    needs: repository-hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-gps-script.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-gps-script.txt
+
+      - name: Run pytest with coverage (fail under 65%)
         run: |
           pytest tests/ -v \
             --cov=explorer \
             --cov-report=term-missing \
             --cov-fail-under=65
 
-      - name: Warn if Streamlit debug defaults (defaults.py) are enabled
+      - name: Check Streamlit debug defaults (defaults.py)
         if: success()
         run: python scripts/warn_streamlit_debug_defaults.py
 
-      - name: Run GPS script offline tests
+      - name: Run GPS checklist script offline test
         run: python scripts/eBirdChecklistNameFromGPS.py --testfile tests/fixtures/gps_checklistName_testing.json


### PR DESCRIPTION
## Summary

Aligns GitHub Actions with issue #182: avoid duplicate runs on pull requests, scope triggers to `main` and `beta-next`, and make checks easier to read and enforce in branch protection.

## Changes

- Rename workflow to **Python CI** and use clear job names (repository hygiene, lint, pip-audit, unit tests).
- **Triggers:** `push` only on `main` and `beta-next`; `pull_request` when the base is `main` or `beta-next` (covers feature → `beta-next` and release → `main`).
- **Concurrency:** cancel in-progress runs for the same ref or PR number on rapid pushes.
- **Caching:** pip cache via `setup-python`; separate cache for pip-audit DB.
- **Jobs:** split into parallel jobs after a fast repository hygiene gate (same steps/commands as before, reorganised).

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (493 passed) — run before commit; this PR only touches `.github/workflows/tests.yml`.

## Notes

- After merge, re-select **required status checks** from the GitHub dropdown (e.g. `Python CI / …`); do not type check names manually (#182).

## Issues

Refs #182

Made with [Cursor](https://cursor.com)