### PR TITLE
fix: Placeholder paths in UI.Vision macros

### DIFF
--- a/UI.Vision/ebird_autolocation_update.json
+++ b/UI.Vision/ebird_autolocation_update.json
@@ -22,13 +22,13 @@
     },
     {
       "Command": "store",
-      "Target": "/Users/jameschurches/.pyenv/shims/python3",
+      "Target": "/Users/you/.pyenv/shims/python3",
       "Value": "pythonPath",
       "Description": "Store value macOS Python path into variable 'pythonPath'"
     },
     {
       "Command": "store",
-      "Target": "\"/Users/jameschurches/Library/Application Support/eBirdChecklistNameFromGPS/script/eBirdChecklistNameFromGPS.py\"",
+      "Target": "\"/Users/you/Library/Application Support/eBirdChecklistNameFromGPS/script/eBirdChecklistNameFromGPS.py\"",
       "Value": "scriptPath",
       "Description": "Store 'macOS' relevent script path into variable 'scriptPath'. Update as required"
     },
@@ -46,7 +46,7 @@
     },
     {
       "Command": "store",
-      "Target": "\"C:\\Users\\James\\Documents\\eBirdChecklistNameFromGPS\\eBirdChecklistNameFromGPS.py\"",
+      "Target": "\"C:\\Users\\you\\Documents\\eBirdChecklistNameFromGPS\\eBirdChecklistNameFromGPS.py\"",
       "Value": "scriptPath",
       "Description": "Store Windows releven script path into variable 'scriptPath'.  Update as required"
     },

--- a/UI.Vision/ebird_incidental_checklist_from_clipboard.json
+++ b/UI.Vision/ebird_incidental_checklist_from_clipboard.json
@@ -40,13 +40,13 @@
     },
     {
       "Command": "store",
-      "Target": "/Users/jameschurches/.pyenv/shims/python3",
+      "Target": "/Users/you/.pyenv/shims/python3",
       "Value": "pythonPath",
       "Description": "Store value macOS Python path into variable 'pythonPath'"
     },
     {
       "Command": "store",
-      "Target": "\"/Users/jameschurches/Library/Application Support/eBirdChecklistNameFromGPS/script/eBirdChecklistNameFromGPS.py\"",
+      "Target": "\"/Users/you/Library/Application Support/eBirdChecklistNameFromGPS/script/eBirdChecklistNameFromGPS.py\"",
       "Value": "scriptPath",
       "Description": "Store 'macOS' relevent script path into variable 'scriptPath'. Update as required"
     },
@@ -64,7 +64,7 @@
     },
     {
       "Command": "store",
-      "Target": "\"C:\\Users\\James\\Documents\\eBirdChecklistNameFromGPS\\eBirdChecklistNameFromGPS.py\"",
+      "Target": "\"C:\\Users\\you\\Documents\\eBirdChecklistNameFromGPS\\eBirdChecklistNameFromGPS.py\"",
       "Value": "scriptPath",
       "Description": "Store Windows releven script path into variable 'scriptPath'.  Update as required"
     },

--- a/docs/ui-vision/README.md
+++ b/docs/ui-vision/README.md
@@ -72,6 +72,8 @@ You will also need to update environment-specific settings, including:
 - the path to your Python installation (used by the GPS script)  
 - any OS-specific path handling (macOS vs Windows)  
 
+The JSON in the repo uses **placeholder paths** (`/Users/you/...` on macOS and `C:\Users\you\...` on Windows) for the `store` steps that set `pythonPath` and `scriptPath`. After you import a macro into UI.Vision, edit those values to match your machine (same idea as `config_template.yaml` using `/Users/you/`).
+
 The incidental checklist macro has more configurable options than the location naming macro.
 
 These settings are defined near the top of each macro and are intended to be easy to adjust.


### PR DESCRIPTION
## Summary

Removes machine-specific home paths from the exported UI.Vision JSON and documents that importers must set `pythonPath` and `scriptPath` locally. No git history rewrite.

## Changes

- macOS: use `/Users/you/...` placeholders (pyenv shim + Application Support script path).
- Windows: use `C:\\Users\\you\\Documents\\...` instead of a personal profile path.
- [docs/ui-vision/README.md](docs/ui-vision/README.md): note placeholder values and post-import edits.

## Testing

- `python3 -m json.tool` on both macro JSON files.

## Issues

Refs #110

Made with [Cursor](https://cursor.com)