### PR TITLE
Adopt signal-first testing strategy and add optional Streamlit map E2E example

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint-ruff:
     name: Lint (Ruff)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Python CI
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -9,6 +12,12 @@ on:
     branches: [main, beta-next]
   pull_request:
     branches: [main, beta-next]
+  workflow_dispatch:
+    inputs:
+      run_e2e:
+        description: "Run optional Streamlit Playwright E2E example tests"
+        required: false
+        default: "false"
 
 jobs:
   repository-hygiene:
@@ -28,6 +37,16 @@ jobs:
             echo "$tracked"
             exit 1
           fi
+
+  secret-scan:
+    name: Secret scan (gitleaks)
+    needs: repository-hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
 
   lint-ruff:
     name: Lint (Ruff)
@@ -88,7 +107,7 @@ jobs:
           pip-audit -r requirements.txt -r requirements-gps-script.txt --cache-dir .pip-audit-cache
 
   unit-tests:
-    name: Unit tests (pytest & coverage)
+    name: Unit tests (pytest + baseline coverage guardrail)
     needs: repository-hygiene
     runs-on: ubuntu-latest
     steps:
@@ -109,8 +128,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-gps-script.txt
 
-      - name: Run pytest with coverage (fail under 65%)
+      - name: Run pytest with coverage baseline (fail under 65%)
         run: |
+          # Signal-first policy: this threshold is a floor to catch major blind spots,
+          # not a target to optimize at the expense of low-value tests.
           pytest tests/ -v \
             --cov=explorer \
             --cov-report=term-missing \
@@ -122,3 +143,32 @@ jobs:
 
       - name: Run GPS checklist script offline test
         run: python scripts/eBirdChecklistNameFromGPS.py --testfile tests/fixtures/gps_checklistName_testing.json
+
+  e2e-map-example:
+    name: Optional E2E (Streamlit + Playwright example)
+    if: github.event_name == 'workflow_dispatch' && inputs.run_e2e == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-gps-script.txt
+
+      - name: Install Python dependencies + Playwright
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-gps-script.txt
+          pip install playwright
+
+      - name: Install Playwright browser
+        run: python -m playwright install chromium
+
+      - name: Run optional e2e marker tests
+        run: pytest tests/explorer/test_streamlit_map_e2e.py -m e2e -v

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ _ruff_local/
 # pytest-cov / coverage.py
 .coverage
 htmlcov/
+.pytest_cache/
+.mypy_cache/
+.hypothesis/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ If something crosses a line, report it to the maintainers (e.g. via GitHub issue
 ## How to contribute
 
 1. **Issues** — For bugs, describe what you expected, what happened, and how to reproduce (OS, Python version, and steps). For features or larger changes, opening an issue first helps align on scope.
-2. **Pull requests** — Fork the repo, create a branch from the target default branch (e.g. `main`), and open a PR when the change is ready for review.
+2. **Pull requests** — Fork the repo, create a branch from the target default branch (normally `beta-next`; use `main` only for explicit hotfixes), and open a PR when the change is ready for review.
 3. **Commits & PRs** — Prefer small, reviewable changes. In the PR description, explain **what** changed and **why** (and note any trade-offs). Link related issues when applicable.
 
 ---
@@ -36,6 +36,11 @@ If something crosses a line, report it to the maintainers (e.g. via GitHub issue
   Optional coverage (matches CI’s package scope):  
   `pytest tests/ -v --cov=explorer --cov-report=term-missing`  
   More detail: [docs/development.md — Testing workflow](docs/development.md#testing-workflow).
+  Test strategy for this repo is **signal over percentage**:
+  - Add focused tests for pure logic, hot paths, and regression-prone behavior.
+  - Prefer small table-driven tests when touching fragile transformations (for example family grouping logic).
+  - Avoid broad UI wiring/HTML snapshot tests that mostly increase coverage without catching meaningful breakage.
+  - Treat coverage as a baseline safety guardrail, not the optimization target.
 - **Lint:**  
   `ruff check explorer/`  
   (same as CI; `ruff` is in `requirements.txt`, rules in `ruff.toml` — currently Pyflakes + pycodestyle, with line-length and import-order left for a later pass).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,9 +15,7 @@ Please include enough detail to reproduce or understand the issue. We will treat
 
 Continuous integration runs **`pip-audit`** against the repository’s requirement files as defined in [.github/workflows/tests.yml](.github/workflows/tests.yml) (exact `-r` list may change as dependencies evolve).
 
-**Allowlisted advisory:** **`CVE-2026-4539`** is passed to `pip-audit` with `--ignore-vuln` because, at the time this was added, **no fixed package version was available** and the audit would otherwise fail the job with no remediation path. CI is still configured to **fail on any other** reported vulnerability.
-
-This allowlist is a **transparency** note about the pipeline, not a substitute for fixing the underlying issue when upstream publishes a fix. Revisit the ignore when dependencies or the advisory status changes.
+Current policy is to run `pip-audit` without an allowlist in CI and fail on reported vulnerabilities so remediation decisions stay explicit in pull requests.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -206,24 +206,42 @@ streamlit run explorer/app/streamlit/design_map_app.py
 
 # Testing
 
-## Running tests
+## Testing workflow
 
 ```
 pytest tests/ -v
 ```
 
-Optional coverage:
+Optional coverage (same package scope used by CI):
 
 ```
-pytest tests/ -v --cov=explorer
+pytest tests/ -v --cov=explorer --cov-report=term-missing
 ```
 
----
+### Signal-over-coverage policy
 
-## Scope
+- Use automated tests where they catch real regressions:
+  - pure logic and data transforms,
+  - hot paths used across tabs/maps,
+  - bug fixes and edge-case handling.
+- Prefer focused, table-driven tests for fragile logic (for example family/taxonomy grouping logic when touched).
+- Avoid broad Streamlit wiring or HTML-heavy snapshot tests when they mostly inflate coverage without meaningful failure signal.
+- Keep CI coverage gates as baseline protection only; do not chase percentage increases for their own sake.
 
-- Unit tests for core modules
-- Integration fixture available
+### Current scope
+
+- Unit tests for `explorer/core` and presentation helpers under `tests/explorer/`.
+- Integration fixture coverage for realistic eBird exports (see `tests/fixtures/ebird_integration_fixture_notes.md`).
+- Focused guardrail tests for CI/runtime behavior (for example debug defaults and selected script checks).
+
+### Optional higher-cost testing
+
+- Browser E2E automation for Streamlit is optional and should be added only if manual smoke repeatedly misses impactful UI regressions.
+- For git-dependent behavior in `explorer/core/repo_git.py`, add/expand tests when there is an incident-driven need; avoid brittle over-mocking for low-value paths.
+- Minimal Playwright example tests live in `tests/explorer/test_streamlit_map_e2e.py` (map banner/legend/focus smoke checks). Local setup:
+  - `pip install playwright`
+  - `python -m playwright install chromium`
+  - `pytest tests/explorer/test_streamlit_map_e2e.py -v`
 
 ---
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 pythonpath = .
 addopts = --import-mode=importlib
+markers =
+    e2e: browser end-to-end tests (optional/manual by default)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,38 @@
+# Tests
+
+Quick guide for running test layers in this repo.
+
+## Default test run (recommended day-to-day)
+
+Run the normal unit/integration suite:
+
+```bash
+pytest tests/ -v
+```
+
+This is the same core path used in CI (plus coverage there).
+
+## Optional browser E2E examples
+
+Browser E2E tests are intentionally opt-in and marked with `@pytest.mark.e2e`.
+
+Run only E2E tests:
+
+```bash
+pytest -m e2e -v
+```
+
+Run only the Streamlit map example module:
+
+```bash
+pytest tests/explorer/test_streamlit_map_e2e.py -m e2e -v
+```
+
+### Playwright setup (local)
+
+```bash
+pip install playwright
+python -m playwright install chromium
+```
+
+If Playwright is not installed, E2E modules skip by design.

--- a/tests/explorer/test_species_family.py
+++ b/tests/explorer/test_species_family.py
@@ -1,0 +1,124 @@
+"""Focused tests for explorer.core.species_family."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from explorer.core import species_family
+from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
+
+
+@pytest.fixture(autouse=True)
+def _clear_species_family_cache():
+    """Clear memoized family map cache between tests."""
+    species_family._base_species_family_items_cached.cache_clear()
+    yield
+    species_family._base_species_family_items_cached.cache_clear()
+
+
+def _mock_urlopen_payload(payload: str) -> MagicMock:
+    resp = MagicMock()
+    resp.read.return_value = payload.encode("utf-8")
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=resp)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+def test_load_taxonomy_species_rows_filters_and_parses_species_rows():
+    csv_data = """CATEGORY,SCIENTIFIC_NAME,COMMON_NAME,SPECIES_CODE,TAXON_ORDER
+species,Corvus corax,Common Raven,comrav,100.5
+species,Anas gracilis,Grey Teal,grtea,200
+spuh,Corvus sp.,Crow sp.,corsp,300
+species,Missing Order Bird,No Order,misord,
+species,No Common, ,nocomm,400
+"""
+    with patch(
+        "explorer.core.species_family.urlopen",
+        return_value=_mock_urlopen_payload(csv_data),
+    ) as m_urlopen:
+        out = species_family.load_taxonomy_species_rows("en_AU")
+
+    req = m_urlopen.call_args[0][0]
+    assert "locale=en_AU" in req.full_url
+    assert list(out["common_name"]) == ["Common Raven", "Grey Teal"]
+    assert list(out["base_species"]) == ["corvus corax", "anas gracilis"]
+    assert list(out["taxon_order"]) == [100.5, 200.0]
+
+
+def test_load_taxonomy_groups_parses_bounds_and_skips_invalid_entries():
+    payload = json.dumps(
+        [
+            {
+                "groupName": "Ducks",
+                "groupOrder": 2,
+                "taxonOrderBounds": [[10, 20], ["x", 30], [31], [40, 50]],
+            },
+            {"groupName": "Ravens", "groupOrder": 3, "taxonOrderBounds": []},
+        ]
+    )
+    with patch(
+        "explorer.core.species_family.urlopen",
+        return_value=_mock_urlopen_payload(payload),
+    ) as m_urlopen:
+        out = species_family.load_taxonomy_groups("en_AU")
+
+    req = m_urlopen.call_args[0][0]
+    assert "locale=en_AU" in req.full_url
+    assert out[0]["group_name"] == "Ducks"
+    assert out[0]["bounds"] == [(10.0, 20.0), (40.0, 50.0)]
+    assert out[1]["bounds"] == []
+
+
+@pytest.mark.parametrize(
+    ("taxon_order", "expected"),
+    [
+        (10.0, ("Ducks", 5)),
+        (20.0, ("Ducks", 5)),
+        (50.5, ("Raptors", 7)),
+        (9.9, ("Unmapped", 999999)),
+    ],
+)
+def test_assign_group_for_taxon_order_boundaries_and_unmapped(taxon_order, expected):
+    groups = [
+        {"group_name": "Ducks", "group_order": 5, "bounds": [(10.0, 20.0)]},
+        {"group_name": "Raptors", "group_order": 7, "bounds": [(50.0, 60.0)]},
+    ]
+    assert species_family.assign_group_for_taxon_order(taxon_order, groups) == expected
+
+
+def test_build_base_species_to_family_map_uses_default_locale_and_returns_mapping():
+    tax = pd.DataFrame(
+        [
+            {"base_species": "corvus corax", "taxon_order": 11.0},
+            {"base_species": "anas gracilis", "taxon_order": 51.0},
+        ]
+    )
+    groups = [
+        {"group_name": "Corvids", "group_order": 1, "bounds": [(10.0, 20.0)]},
+        {"group_name": "Ducks", "group_order": 2, "bounds": [(50.0, 60.0)]},
+    ]
+    with patch(
+        "explorer.core.species_family.load_taxonomy_species_rows",
+        return_value=tax,
+    ) as m_tax, patch(
+        "explorer.core.species_family.load_taxonomy_groups",
+        return_value=groups,
+    ) as m_groups:
+        out = species_family.build_base_species_to_family_map("")
+
+    m_tax.assert_called_once_with(TAXONOMY_LOCALE_DEFAULT)
+    m_groups.assert_called_once_with(TAXONOMY_LOCALE_DEFAULT)
+    assert out == {"anas gracilis": "Ducks", "corvus corax": "Corvids"}
+
+
+def test_build_base_species_to_family_map_returns_empty_on_loader_error():
+    with patch(
+        "explorer.core.species_family.load_taxonomy_species_rows",
+        side_effect=RuntimeError("offline"),
+    ):
+        assert species_family.build_base_species_to_family_map("en_AU") == {}

--- a/tests/explorer/test_streamlit_map_e2e.py
+++ b/tests/explorer/test_streamlit_map_e2e.py
@@ -1,0 +1,216 @@
+"""Minimal browser E2E smoke tests for Streamlit map defaults.
+
+These tests are intentionally small and educational:
+- launch the real Streamlit app in a subprocess,
+- point it at a fixture CSV via temporary config/config.yaml,
+- assert high-value map UI contracts in a real browser.
+
+If Playwright is not installed locally, this module is skipped.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import pytest
+
+playwright = pytest.importorskip("playwright.sync_api")
+pytestmark = pytest.mark.e2e
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_ENTRYPOINT = REPO_ROOT / "explorer" / "app" / "streamlit" / "app.py"
+FIXTURE_CSV = REPO_ROOT / "tests" / "fixtures" / "ebird_integration_fixture.csv"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_http_ready(url: str, timeout_s: float = 45.0) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            with urlopen(url, timeout=2) as resp:  # nosec B310 - local ephemeral test server
+                if 200 <= int(resp.status) < 500:
+                    return
+        except (URLError, TimeoutError, ConnectionError):
+            pass
+        time.sleep(0.25)
+    raise TimeoutError(f"Streamlit app did not become ready: {url}")
+
+
+def _wait_for_map_srcdoc(page, timeout_ms: int = 45000) -> str:
+    """Return the map iframe ``srcdoc`` HTML once banner markup appears.
+
+    Streamlit renders ``components.html`` content in an iframe with ``srcdoc``.
+    Reading that attribute is more stable than traversing nested frames.
+    """
+    deadline = time.time() + (timeout_ms / 1000)
+    last_iframe_debug: list[str] = []
+    while time.time() < deadline:
+        try:
+            iframe_handles = page.locator("iframe").element_handles()
+            if iframe_handles:
+                debug_rows: list[str] = []
+                for h in iframe_handles:
+                    src = h.get_attribute("src") or ""
+                    srcdoc = h.get_attribute("srcdoc") or ""
+                    title = h.get_attribute("title") or ""
+                    debug_rows.append(
+                        "title="
+                        f"{title[:40]!r} src={src[:80]!r} "
+                        f"srcdoc_len={len(srcdoc)} has_banner={'pebird-map-banner' in srcdoc}"
+                    )
+                    if "pebird-map-banner" in srcdoc:
+                        return srcdoc
+                    try:
+                        frame = h.content_frame()
+                        if frame is not None:
+                            html = frame.content()
+                            if "pebird-map-banner" in html:
+                                return html
+                    except Exception:
+                        # Frame may still be mounting; keep polling.
+                        pass
+                last_iframe_debug = debug_rows
+        except Exception:
+            pass
+        page.wait_for_timeout(150)
+    debug_text = " | ".join(last_iframe_debug) if last_iframe_debug else "no iframes detected"
+    page_html = page.content()
+    has_export_btn = "Export map HTML" in page_html
+    raise AssertionError(
+        "Map iframe with banner was not found in time "
+        f"({debug_text}); export_button_visible={has_export_btn}"
+    )
+
+
+@contextlib.contextmanager
+def _launch_chromium_or_skip():
+    """Launch Chromium for E2E, or skip when browser binaries are unavailable."""
+    with playwright.sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as exc:
+            msg = str(exc)
+            if "Executable doesn't exist" in msg:
+                pytest.skip("Playwright browser binaries unavailable; run `python -m playwright install chromium`.")
+            raise
+        try:
+            yield browser
+        finally:
+            browser.close()
+
+
+@pytest.fixture
+def streamlit_app_url(tmp_path: Path):
+    """Run Streamlit against a temporary, config-backed dataset."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    dataset_path = data_dir / "MyEBirdData.csv"
+    shutil.copyfile(FIXTURE_CSV, dataset_path)
+
+    config_dir = REPO_ROOT / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_yaml = config_dir / "config.yaml"
+    config_secret_yaml = config_dir / "config_secret.yaml"
+    original_cfg = config_yaml.read_text(encoding="utf-8") if config_yaml.exists() else None
+    original_secret_cfg = (
+        config_secret_yaml.read_text(encoding="utf-8")
+        if config_secret_yaml.exists()
+        else None
+    )
+    config_payload = f"data_folder: {data_dir.as_posix()}\n"
+    # ``config_secret.yaml`` has higher precedence than ``config.yaml`` for data resolution.
+    # Write both so local machine configs cannot interfere with deterministic E2E fixtures.
+    config_yaml.write_text(config_payload, encoding="utf-8")
+    config_secret_yaml.write_text(config_payload, encoding="utf-8")
+
+    port = _free_port()
+    url = f"http://127.0.0.1:{port}"
+    env = os.environ.copy()
+    env.setdefault("PYTHONUNBUFFERED", "1")
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "streamlit",
+            "run",
+            str(APP_ENTRYPOINT),
+            "--server.headless=true",
+            f"--server.port={port}",
+            "--browser.gatherUsageStats=false",
+        ],
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        _wait_for_http_ready(url)
+        yield url
+    finally:
+        with contextlib.suppress(Exception):
+            proc.terminate()
+            proc.wait(timeout=8)
+        with contextlib.suppress(Exception):
+            if proc.poll() is None:
+                proc.kill()
+        if original_cfg is None:
+            with contextlib.suppress(FileNotFoundError):
+                config_yaml.unlink()
+        else:
+            config_yaml.write_text(original_cfg, encoding="utf-8")
+        if original_secret_cfg is None:
+            with contextlib.suppress(FileNotFoundError):
+                config_secret_yaml.unlink()
+        else:
+            config_secret_yaml.write_text(original_secret_cfg, encoding="utf-8")
+
+
+def test_map_default_view_with_config_shows_all_locations_banner(streamlit_app_url: str):
+    with _launch_chromium_or_skip() as browser:
+        page = browser.new_page()
+        page.goto(streamlit_app_url, wait_until="domcontentloaded")
+        page.get_by_text("Personal eBird Explorer").wait_for(timeout=20000)
+
+        sidebar = page.locator('[data-testid="stSidebar"]')
+        expect = playwright.expect
+        expect(sidebar.get_by_text("Map view")).to_be_visible()
+        expect(sidebar.get_by_text("All locations")).to_be_visible()
+
+        srcdoc = _wait_for_map_srcdoc(page)
+        assert "pebird-map-banner" in srcdoc
+        assert "pebird-map-banner__title\">All locations</span>" in srcdoc
+
+
+def test_all_locations_map_shows_legend_and_focused_default(streamlit_app_url: str):
+    with _launch_chromium_or_skip() as browser:
+        page = browser.new_page()
+        page.goto(streamlit_app_url, wait_until="domcontentloaded")
+        page.get_by_text("Personal eBird Explorer").wait_for(timeout=20000)
+
+        sidebar = page.locator('[data-testid="stSidebar"]')
+        expect = playwright.expect
+        expect(sidebar.get_by_text("Map focus")).to_be_visible()
+        expect(
+            sidebar.get_by_text("Focused view shows your main birding regions.")
+        ).to_be_visible()
+
+        srcdoc = _wait_for_map_srcdoc(page)
+        assert "pebird-map-legend" in srcdoc
+


### PR DESCRIPTION
## Summary
Implements #180 by adopting a signal-first testing posture and documenting that CI coverage is a baseline guardrail, not the optimization target.

## Changes
- Updated testing guidance in `CONTRIBUTING.md` and `docs/development.md`.
- Clarified coverage-gate intent in `.github/workflows/tests.yml`.
- Added focused `species_family` unit tests (`tests/explorer/test_species_family.py`).
- Added optional Playwright map E2E example (`tests/explorer/test_streamlit_map_e2e.py`) with:
  - `e2e` pytest marker registration (`pytest.ini`),
  - quick usage docs (`tests/README.md`),
  - optional manual CI entrypoint (`workflow_dispatch` / `run_e2e`).
- Hardened E2E fixture determinism for local config precedence (`config_secret.yaml` over `config.yaml`) and graceful skip when browser binaries are unavailable.
- Minor hygiene/doc alignment updates (`.gitignore`, `SECURITY.md`).

## Testing
- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q`
- `pytest tests/explorer/test_streamlit_map_e2e.py -m e2e -v` (local)

## Notes
- E2E remains optional and educational for now; default CI stays fast.

Refs #180