### PR TITLE
fix(explorer): restore streamlit-folium map embed (#190)

### DIFF
--- a/explorer/app/streamlit/app.py
+++ b/explorer/app/streamlit/app.py
@@ -34,8 +34,9 @@ Streamlit does not expose the browser language to Python.
 match Country / Yearly (refs #70).
 
 **Prep vs Map load:** One **sidebar** ``st.spinner`` in a **dedicated bottom slot** wraps checklist prep, tab syncs,
-Folium **build**, serialized HTML in the Map tab (iframe ``srcdoc`` + export), then clears the bird-emoji strip
-(refs #124) so the explorer spinner tracks the built-in Streamlit spinner. Iframe min-height CSS reduces
+Folium **build**, serialized HTML cached for export plus **streamlit-folium** embed in the Map tab,
+then clears the bird-emoji strip (refs #124) so the explorer spinner tracks the built-in Streamlit spinner.
+Iframe min-height CSS reduces
 letterboxing. Partial
 ``@st.fragment`` reruns do not use this spinner. Implementation: :mod:`explorer.app.streamlit.app_prep_map_ui`
 (refs #130).

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -3,11 +3,11 @@
 The map tab is nested inside the sidebar ``st.spinner`` so loading indicators stay aligned with
 Streamlit’s spinner. Partial ``@st.fragment`` reruns do not use this path.
 
-A single :func:`~explorer.app.streamlit.map_working.folium_map_to_html_bytes` call (on a
-**deep-copied** map) feeds both **Export map HTML** and the live iframe via
-:func:`~explorer.app.streamlit.map_working.embed_folium_html_bytes_iframe` — one render per miss,
-cached ``html_bytes`` on hit. Session :data:`FOLIUM_STATIC_MAP_CACHE_KEY` still stores an
-unrendered Folium :class:`folium.Map` for the LRU.
+**Export map HTML** uses :func:`~explorer.app.streamlit.map_working.folium_map_to_html_bytes` on a
+**deep-copied** map (``branca`` mutates on render), with ``html_bytes`` cached on hit. The live map
+uses **streamlit-folium** ``st_folium`` (``use_container_width=True``) so Leaflet markers, popups,
+and overlay sizing match behaviour on ``main``. Session :data:`FOLIUM_STATIC_MAP_CACHE_KEY` still
+stores an unrendered Folium :class:`folium.Map` for the LRU.
 """
 
 from __future__ import annotations
@@ -58,7 +58,7 @@ from explorer.app.streamlit.checklist_stats_streamlit_html import (
 )
 from explorer.app.streamlit.country_stats_streamlit_html import sync_country_tab_session_inputs
 from explorer.app.streamlit.maintenance_streamlit_html import sync_maintenance_tab_session_inputs
-from explorer.app.streamlit.map_working import embed_folium_html_bytes_iframe, folium_map_to_html_bytes
+from explorer.app.streamlit.map_working import folium_map_to_html_bytes
 from explorer.app.streamlit.rankings_streamlit_html import (
     build_rankings_tab_bundle,
     sync_rankings_tab_session_inputs,
@@ -571,14 +571,25 @@ def render_prep_spinner_and_map_tab(
                     if map_hint_text:
                         st.info(map_hint_text)
                     inject_map_folium_iframe_min_height_css(map_height)
-                    _map_bytes = bytes(st.session_state[EXPLORER_MAP_HTML_BYTES_KEY])
-                    with st.container(key=folium_st_key):
-                        with perf_span("prep.map_iframe_embed"):
-                            embed_folium_html_bytes_iframe(
-                                _map_bytes,
-                                height=map_height,
-                                scrolling=True,
-                            )
+                    try:
+                        from streamlit_folium import st_folium
+                    except ImportError:
+                        st.error(
+                            "Missing **streamlit-folium** (needed to embed the Folium map). "
+                            "Locally: `pip install -r requirements.txt`. "
+                            "**Streamlit Community Cloud:** set app **Python requirements** to "
+                            "`requirements.txt` at the repo root."
+                        )
+                        st.stop()
+                    with perf_span("prep.map_iframe_embed"):
+                        st_folium(
+                            result_map,
+                            use_container_width=True,
+                            height=int(map_height),
+                            key=folium_st_key,
+                            returned_objects=[],
+                            return_on_hover=False,
+                        )
 
         _spinner_emoji_placeholder.empty()
         _has_map_export = bool(st.session_state.get(EXPLORER_MAP_HTML_BYTES_KEY))


### PR DESCRIPTION
## Summary

Restores the live Map tab embed to **streamlit-folium** (`st_folium`) with `use_container_width=True`, matching `main`-era behaviour so banner, legend, and Leaflet popups/layout stay correct after the #179-era “serialized HTML iframe” refactor on `beta-next`.

Keeps **`folium_map_to_html_bytes` on `copy.deepcopy(map)`**, **`html_bytes` LRU caching**, **`FOLIUM_STATIC_MAP_CACHE_KEY` Folium LRU**, and **`perf_*` instrumentation** unchanged.

Adds a **marker-only empty commit** (issue bookkeeping): **Refs [#179](https://github.com/jimchurches/myebirdstuff/issues/179)**; follow-ups for optional perf tuning stay on that thread.

See also **[#179 discussion comment](https://github.com/jimchurches/myebirdstuff/issues/179#issuecomment-4339696490)** (Apr 2026) for regression/agent context.

## Changes

- `explorer/app/streamlit/app_prep_map_ui.py`: live map → `st_folium`; export path unchanged  
- `explorer/app/streamlit/app.py`: docstring alignment  

## Testing

- `python3 -m ruff check explorer/`  
- `python3 -m pytest tests/ -q` (537 passed, 2 skipped)

## Issues

Fixes #190  

Refs #179  
