### PR TITLE
fix: merge en_US taxonomy with regional locale for eBird species links

### DIFF
--- a/explorer/core/taxonomy.py
+++ b/explorer/core/taxonomy.py
@@ -7,6 +7,12 @@ Offline or API failure: lookup returns None; callers continue without links.
 
 Locale: pass locale to load_taxonomy() so common names match your eBird export
 (e.g. "en_AU" for Australian English: Grey Teal, Willie Wagtail, Common Starling).
+
+For any locale **other than** ``en_US``, we also merge in the ``en_US`` common names for the
+same species codes. eBird uses different English names in different regions (e.g. *en_AU*
+``Grey Ternlet`` vs *en_US* ``Gray Noddy``, or *en_AU* ``Black Petrel`` vs *en_US*
+``Parkinson's Petrel``). Checklist rows may use either wording; merging avoids missing links.
+
 API reference: https://documenter.getpostman.com/view/664302/S1ENwy59
 """
 
@@ -21,6 +27,38 @@ _TAXONOMY_BASE = "https://api.ebird.org/v2/ref/taxonomy/ebird"
 _common_to_code: dict[str, str] | None = None
 
 
+def _taxonomy_csv_to_lookup(raw: str) -> dict[str, str] | None:
+    """Parse taxonomy CSV body into common_name -> species_code for category ``species`` only."""
+    reader = csv.DictReader(io.StringIO(raw))
+    if not reader.fieldnames:
+        return None
+    field_lower = {f.strip().lower(): f for f in reader.fieldnames}
+    common_key = field_lower.get("common_name") or field_lower.get("common name")
+    code_key = field_lower.get("species_code") or field_lower.get("species code")
+    category_key = field_lower.get("category")
+    if not common_key or not code_key or not category_key:
+        return None
+    lookup: dict[str, str] = {}
+    for row in reader:
+        cat = (row.get(category_key) or "").strip().lower()
+        if cat != "species":
+            continue
+        common = (row.get(common_key) or "").strip()
+        code = (row.get(code_key) or "").strip()
+        if common and code:
+            lookup[common] = code
+    return lookup
+
+
+def _fetch_taxonomy_csv(url: str) -> str | None:
+    try:
+        req = Request(url, headers={"Accept": "text/csv"})
+        with urlopen(req, timeout=30) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except (URLError, OSError, TimeoutError):
+        return None
+
+
 def load_taxonomy(locale: str | None = None) -> bool:
     """Fetch eBird taxonomy and build common name -> species_code lookup (species only).
 
@@ -32,41 +70,33 @@ def load_taxonomy(locale: str | None = None) -> bool:
         locale: Optional locale code so common names match your eBird export.
             Examples: "en_AU" (Australian), "en_GB" (British), "" or None for API default (en_US).
             See eBird API 2.0 reference for supported codes.
+            Non-``en_US`` locales load that CSV and merge **en_US** names so alternate regional
+            labels for the same species code still resolve (see module docstring).
 
     Returns:
         True if taxonomy loaded and cache is populated, False otherwise.
     """
     global _common_to_code
     _common_to_code = None
-    url = _TAXONOMY_BASE
-    if locale and str(locale).strip():
-        url = f"{_TAXONOMY_BASE}?{urlencode({'locale': locale.strip()})}"
-    try:
-        req = Request(url, headers={"Accept": "text/csv"})
-        with urlopen(req, timeout=30) as resp:
-            raw = resp.read().decode("utf-8", errors="replace")
-    except (URLError, OSError, TimeoutError):
+    loc_clean = str(locale).strip() if locale else ""
+    primary_url = _TAXONOMY_BASE
+    if loc_clean:
+        primary_url = f"{_TAXONOMY_BASE}?{urlencode({'locale': loc_clean})}"
+    raw_primary = _fetch_taxonomy_csv(primary_url)
+    if raw_primary is None:
         return False
-    reader = csv.DictReader(io.StringIO(raw))
-    if not reader.fieldnames:
+    primary_lookup = _taxonomy_csv_to_lookup(raw_primary)
+    if primary_lookup is None:
         return False
-    # Normalize column names (API may use COMMON_NAME or common_name, etc.)
-    field_lower = {f.strip().lower(): f for f in reader.fieldnames}
-    common_key = field_lower.get("common_name") or field_lower.get("common name")
-    code_key = field_lower.get("species_code") or field_lower.get("species code")
-    category_key = field_lower.get("category")
-    if not common_key or not code_key or not category_key:
-        return False
-    lookup = {}
-    for row in reader:
-        cat = (row.get(category_key) or "").strip().lower()
-        if cat != "species":
-            continue
-        common = (row.get(common_key) or "").strip()
-        code = (row.get(code_key) or "").strip()
-        if common and code:
-            lookup[common] = code
-    _common_to_code = lookup
+    if loc_clean and loc_clean.lower() != "en_us":
+        us_url = f"{_TAXONOMY_BASE}?{urlencode({'locale': 'en_US'})}"
+        raw_us = _fetch_taxonomy_csv(us_url)
+        if raw_us:
+            us_lookup = _taxonomy_csv_to_lookup(raw_us)
+            if us_lookup:
+                _common_to_code = {**us_lookup, **primary_lookup}
+                return True
+    _common_to_code = primary_lookup
     return True
 
 

--- a/tests/explorer/test_taxonomy.py
+++ b/tests/explorer/test_taxonomy.py
@@ -50,7 +50,7 @@ def test_load_taxonomy_success_builds_lookup():
 
 
 def test_load_taxonomy_with_locale_requests_url_with_param():
-    """When locale is passed, the request URL includes locale query parameter."""
+    """When a non-en_US locale is passed, we fetch that locale and en_US, then merge."""
     csv_data = _make_csv([{"common_name": "Grey Teal", "species_code": "grtea", "category": "species"}])
     resp = MagicMock()
     resp.read.return_value = csv_data.encode("utf-8")
@@ -59,9 +59,25 @@ def test_load_taxonomy_with_locale_requests_url_with_param():
     cm.__exit__ = MagicMock(return_value=False)
     with patch("explorer.core.taxonomy.urlopen", return_value=cm) as m_urlopen:
         taxonomy.load_taxonomy(locale="en_AU")
-    call_args = m_urlopen.call_args[0][0]
-    assert "locale=en_AU" in call_args.full_url
+    assert m_urlopen.call_count == 2
+    urls = [c[0][0].full_url for c in m_urlopen.call_args_list]
+    assert any("locale=en_AU" in u for u in urls)
+    assert any("locale=en_US" in u for u in urls)
     assert taxonomy.get_species_url("Grey Teal") == "https://ebird.org/species/grtea"
+
+
+def test_load_taxonomy_en_us_fetches_once():
+    """en_US is the merge source; loading it directly only needs one request."""
+    csv_data = _make_csv([{"common_name": "Gray Teal", "species_code": "gretea1", "category": "species"}])
+    resp = MagicMock()
+    resp.read.return_value = csv_data.encode("utf-8")
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=resp)
+    cm.__exit__ = MagicMock(return_value=False)
+    with patch("explorer.core.taxonomy.urlopen", return_value=cm) as m_urlopen:
+        taxonomy.load_taxonomy(locale="en_US")
+    assert m_urlopen.call_count == 1
+    assert "locale=en_US" in m_urlopen.call_args[0][0].full_url
 
 
 def test_load_taxonomy_network_failure_returns_false():
@@ -90,21 +106,45 @@ def test_get_species_url_empty_name_returns_none():
         taxonomy._common_to_code = None
 
 
-def test_exact_match_required_after_locale_load():
-    """With locale set, API returns names that match export; exact match is sufficient."""
-    # Simulate API returning en_AU names (Grey Teal, Willie Wagtail, Common Starling)
+def test_merged_lookup_includes_en_us_alternate_spellings():
+    """After en_AU + en_US merge, both regional labels for the same code resolve (e.g. Gray vs Grey Teal)."""
     taxonomy._common_to_code = {
-        "Grey Teal": "grtea",
-        "Willie Wagtail": "wilwag",
+        "Grey Teal": "gretea1",
+        "Gray Teal": "gretea1",
+        "Willie Wagtail": "wilwag1",
         "Common Starling": "eursta",
     }
     try:
-        assert taxonomy.get_species_url("Grey Teal") == "https://ebird.org/species/grtea"
-        assert taxonomy.get_species_url("Willie Wagtail") == "https://ebird.org/species/wilwag"
+        assert taxonomy.get_species_url("Grey Teal") == "https://ebird.org/species/gretea1"
+        assert taxonomy.get_species_url("Gray Teal") == "https://ebird.org/species/gretea1"
+        assert taxonomy.get_species_url("Willie Wagtail") == "https://ebird.org/species/wilwag1"
         assert taxonomy.get_species_url("Common Starling") == "https://ebird.org/species/eursta"
-        assert taxonomy.get_species_url("Gray Teal") is None  # US spelling not in en_AU lookup
     finally:
         taxonomy._common_to_code = None
+
+
+def test_load_taxonomy_en_au_merges_en_us_alternate_names():
+    """regional + US names for the same species code both link (refs #201, e.g. Gray Noddy / Grey Ternlet)."""
+    au_csv = _make_csv(
+        [{"common_name": "Grey Ternlet", "species_code": "grynod1", "category": "species"}]
+    )
+    us_csv = _make_csv(
+        [{"common_name": "Gray Noddy", "species_code": "grynod1", "category": "species"}]
+    )
+    ctxs = []
+    for body in (au_csv, us_csv):
+        r = MagicMock()
+        r.read.return_value = body.encode("utf-8")
+        c = MagicMock()
+        c.__enter__ = MagicMock(return_value=r)
+        c.__exit__ = MagicMock(return_value=False)
+        ctxs.append(c)
+    with patch("explorer.core.taxonomy.urlopen", side_effect=ctxs) as m_urlopen:
+        ok = taxonomy.load_taxonomy(locale="en_AU")
+    assert ok is True
+    assert m_urlopen.call_count == 2
+    assert taxonomy.get_species_url("Gray Noddy") == "https://ebird.org/species/grynod1"
+    assert taxonomy.get_species_url("Grey Ternlet") == "https://ebird.org/species/grynod1"
 
 
 def test_get_species_and_lifelist_urls_single_lookup():


### PR DESCRIPTION
## Summary

Species links failed when checklist rows used a **different regional English label** than the taxonomy CSV for the selected locale (for example **Gray Noddy** vs **Grey Ternlet**, or **Parkinson's Petrel** vs **Black Petrel** for the same species code). Loading **`en_US`** alongside the user’s taxonomy locale and merging lookups fixes this without changing URL shape.

## Changes

- **`explorer/core/taxonomy.py`**: For locales other than `en_US`, fetch primary locale + `en_US`, merge `{**en_US, **primary}` so primary wins on duplicate strings but US-only aliases remain available.
- **`tests/explorer/test_taxonomy.py`**: Tests for two-fetch behaviour, merge aliases (Gray Noddy / Grey Ternlet), and `en_US` single-fetch.

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (540 passed, 4 skipped)

## Issues

Fixes #201
