### PR TITLE
Add Go to GPS sidebar control and temporary map pin

### DIFF
--- a/explorer/app/streamlit/app_caches.py
+++ b/explorer/app/streamlit/app_caches.py
@@ -127,6 +127,7 @@ def static_map_cache_key(
     species_selected_sci: str = "",
     species_selected_common: str = "",
     hide_non_matching_locations: bool = False,
+    go_to_gps_pin: tuple[float, float] | None = None,
 ) -> tuple:
     """Stable key for Folium map reuse (session holds one cached map; same key → skip rebuild).
 
@@ -140,6 +141,12 @@ def static_map_cache_key(
     tax = (taxonomy_locale or "").strip()
     sci = (species_selected_sci or "").strip()
     common = (species_selected_common or "").strip()
+    gps_sig = ""
+    if go_to_gps_pin is not None and len(go_to_gps_pin) == 2:
+        try:
+            gps_sig = f"{float(go_to_gps_pin[0]):.6f},{float(go_to_gps_pin[1]):.6f}"
+        except (TypeError, ValueError):
+            gps_sig = ""
     return (
         map_view_mode,
         date_filter_banner,
@@ -151,4 +158,5 @@ def static_map_cache_key(
         sci,
         common,
         bool(hide_non_matching_locations),
+        gps_sig,
     )

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -212,6 +212,10 @@ SESSION_SPECIES_SEARCH_LAST_MAIN_RUN_KEY = "_streamlit_species_search_last_main_
 FOLIUM_STATIC_MAP_CACHE_KEY = "_folium_static_all_lifer_cache"
 # Bumped when toggling Map view All locations <-> Species locations so streamlit-folium remounts cleanly.
 FOLIUM_MAP_MOUNT_NONCE_KEY = "_folium_map_mount_nonce"
+# Go to GPS — session-only temporary marker (refs #199); never persisted to YAML.
+SESSION_GO_TO_GPS_PIN_KEY = "_session_go_to_gps_pin"
+STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY = "_streamlit_go_to_gps_draft_lat_txt"
+STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY = "_streamlit_go_to_gps_draft_lon_txt"
 SETTINGS_CONFIG_PATH_KEY = "_streamlit_settings_yaml_path"
 SETTINGS_CONFIG_SOURCE_KEY = "_streamlit_settings_source_label"
 SETTINGS_LOADED_FROM_KEY = "_streamlit_settings_loaded_from_path"

--- a/explorer/app/streamlit/app_go_to_gps_ui.py
+++ b/explorer/app/streamlit/app_go_to_gps_ui.py
@@ -1,0 +1,178 @@
+"""Sidebar “Go to GPS” expander for All locations / Species locations maps (refs #199)."""
+
+from __future__ import annotations
+
+import math
+
+import streamlit as st
+
+from explorer.app.streamlit.app_constants import (
+    SESSION_GO_TO_GPS_PIN_KEY,
+    STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY,
+    STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY,
+)
+
+# Pending draft updates must run before ``text_input`` widgets mount (Streamlit session_state rule).
+_GO_TO_GPS_PENDING_DRAFT_UPDATE_KEY = "_go_to_gps_pending_draft_update"
+
+
+def format_coord_for_display(v: float) -> str:
+    """Stable decimal-degrees text without noisy trailing zeros."""
+    s = f"{v:.10f}".rstrip("0").rstrip(".")
+    return s if s else "0"
+
+
+def parse_lat_lon_pair(text: str) -> tuple[float, float] | None:
+    """Parse ``lat, lon`` paste (Google-style comma-separated decimal degrees)."""
+    raw = (text or "").strip()
+    if "," not in raw:
+        return None
+    parts = [p.strip() for p in raw.split(",", 1)]
+    if len(parts) != 2:
+        return None
+    try:
+        a = float(parts[0])
+        b = float(parts[1])
+    except ValueError:
+        return None
+    if not math.isfinite(a) or not math.isfinite(b):
+        return None
+    # Standard order from Google / eBird: latitude first, then longitude.
+    la, lo = a, b
+    if -90.0 <= la <= 90.0 and -180.0 <= lo <= 180.0:
+        return (la, lo)
+    return None
+
+
+def parse_single_coord(text: str) -> float | None:
+    """Parse one decimal number (strip stray commas from pasted fragments)."""
+    raw = (text or "").strip()
+    if not raw:
+        return None
+    raw = raw.replace(",", "")
+    try:
+        x = float(raw)
+    except ValueError:
+        return None
+    return x if math.isfinite(x) else None
+
+
+def go_to_gps_pin_from_session() -> tuple[float, float] | None:
+    """Validated ``(lat, lon)`` for map build, or ``None``."""
+    v = st.session_state.get(SESSION_GO_TO_GPS_PIN_KEY)
+    if v is None:
+        return None
+    if not isinstance(v, (tuple, list)) or len(v) != 2:
+        return None
+    try:
+        la, lo = float(v[0]), float(v[1])
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(la) or not math.isfinite(lo):
+        return None
+    if not (-90.0 <= la <= 90.0 and -180.0 <= lo <= 180.0):
+        return None
+    return (la, lo)
+
+
+def _try_split_pasted_lat_lon() -> None:
+    """If either field contains a ``lat, lon`` paste, split into both fields (refs #199)."""
+    lat_s = str(st.session_state.get(STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY, "")).strip()
+    lon_s = str(st.session_state.get(STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY, "")).strip()
+    for raw in (lat_s, lon_s):
+        pair = parse_lat_lon_pair(raw)
+        if pair:
+            la, lo = pair
+            st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY] = format_coord_for_display(la)
+            st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY] = format_coord_for_display(lo)
+            break
+
+
+def _sync_draft_text_from_pin() -> None:
+    """Seed coordinate text fields from the active pin when draft keys are uninitialized."""
+    _pin = st.session_state.get(SESSION_GO_TO_GPS_PIN_KEY)
+    _missing = (
+        STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY not in st.session_state
+        or STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY not in st.session_state
+    )
+    if not _missing:
+        return
+    if _pin and len(_pin) == 2:
+        try:
+            la, lo = float(_pin[0]), float(_pin[1])
+            st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY] = format_coord_for_display(la)
+            st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY] = format_coord_for_display(lo)
+        except (TypeError, ValueError):
+            st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY] = ""
+            st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY] = ""
+    else:
+        st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY] = ""
+        st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY] = ""
+
+
+def render_go_to_gps_sidebar_expander() -> None:
+    """Collapsible lat/long fields + form actions; bumps Folium cache when pin is set or cleared."""
+    from explorer.app.streamlit.app_map_working_ui import invalidate_folium_map_embed_cache
+
+    _pending = st.session_state.pop(_GO_TO_GPS_PENDING_DRAFT_UPDATE_KEY, None)
+    if _pending == "clear":
+        st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY] = ""
+        st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY] = ""
+    elif isinstance(_pending, tuple) and len(_pending) == 2:
+        try:
+            la = float(_pending[0])
+            lo = float(_pending[1])
+        except (TypeError, ValueError):
+            pass
+        else:
+            if math.isfinite(la) and math.isfinite(lo):
+                st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY] = format_coord_for_display(la)
+                st.session_state[STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY] = format_coord_for_display(lo)
+
+    _sync_draft_text_from_pin()
+
+    with st.expander("Go to GPS", expanded=False):
+        st.text_input(
+            "Latitude",
+            key=STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY,
+            on_change=_try_split_pasted_lat_lon,
+            placeholder="Decimal degrees, or paste lat, lon",
+        )
+        st.text_input(
+            "Longitude",
+            key=STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY,
+            on_change=_try_split_pasted_lat_lon,
+            placeholder="Decimal degrees, or paste lat, lon",
+        )
+        with st.form("go_to_gps_sidebar_form"):
+            go = st.form_submit_button("Go to location")
+            clear = st.form_submit_button("Clear marker")
+
+        if go:
+            lat_raw = str(st.session_state.get(STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY, "")).strip()
+            lon_raw = str(st.session_state.get(STREAMLIT_GO_TO_GPS_DRAFT_LON_TEXT_KEY, "")).strip()
+            pair = parse_lat_lon_pair(lat_raw) or parse_lat_lon_pair(lon_raw)
+            if pair:
+                la, lo = pair
+            else:
+                la = parse_single_coord(lat_raw)
+                lo = parse_single_coord(lon_raw)
+            if (
+                la is not None
+                and lo is not None
+                and -90.0 <= la <= 90.0
+                and -180.0 <= lo <= 180.0
+            ):
+                st.session_state[SESSION_GO_TO_GPS_PIN_KEY] = (la, lo)
+                invalidate_folium_map_embed_cache()
+            else:
+                st.error(
+                    "Could not use those coordinates. Enter decimal degrees for latitude and "
+                    'longitude, or paste a pair such as "-35.26897, 149.08054".'
+                )
+
+        if clear:
+            st.session_state.pop(SESSION_GO_TO_GPS_PIN_KEY, None)
+            st.session_state[_GO_TO_GPS_PENDING_DRAFT_UPDATE_KEY] = "clear"
+            invalidate_folium_map_embed_cache()
+            st.rerun()

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -46,6 +46,7 @@ from explorer.app.streamlit.app_constants import (
     SETTINGS_CONFIG_SOURCE_KEY,
     DEFAULT_TAXONOMY_LOCALE,
 )
+from explorer.app.streamlit.app_go_to_gps_ui import render_go_to_gps_sidebar_expander
 from explorer.app.streamlit.app_map_ui import (
     ensure_streamlit_map_basemap_height_keys,
     ensure_streamlit_map_marker_colour_scheme_keys,
@@ -285,6 +286,7 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                     "Centres the map on the middle of the places you've birded. "
                     "You may need to zoom out to see more locations."
                 )
+            render_go_to_gps_sidebar_expander()
 
     hide_non_matching_locations = False
     species_pick_common: str | None = None
@@ -341,6 +343,7 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 for _para in (p.strip() for p in SPECIES_SEARCH_CAPTION.split("\n\n")):
                     if _para:
                         st.caption(_para)
+            render_go_to_gps_sidebar_expander()
 
         species_pick_common = st.session_state.get(SESSION_SPECIES_PICK_KEY)
         if species_pick_common:

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -6,9 +6,9 @@ payloads before fragments run. Partial ``@st.fragment`` reruns do not use this p
 
 **Export map HTML** uses :func:`~explorer.app.streamlit.map_working.folium_map_to_html_bytes` on a
 **deep-copied** map (``branca`` mutates on render), with ``html_bytes`` cached on hit. The live map
-uses **streamlit-folium** ``st_folium`` (``use_container_width=True``) so Leaflet markers, popups,
-and overlay sizing match behaviour on ``main``. Session :data:`FOLIUM_STATIC_MAP_CACHE_KEY` still
-stores an unrendered Folium :class:`folium.Map` for the LRU.
+uses **streamlit-folium** ``st_folium`` with a **deep copy** of the cached map so embed rendering
+cannot strip layers from the session cache (same mutation hazard as HTML export). Session
+:data:`FOLIUM_STATIC_MAP_CACHE_KEY` still stores an unrendered Folium :class:`folium.Map` for the LRU.
 """
 
 from __future__ import annotations
@@ -46,6 +46,7 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_MAP_DATE_FILTER_KEY,
     STREAMLIT_RANKINGS_TOP_N_KEY,
 )
+from explorer.app.streamlit.app_go_to_gps_ui import go_to_gps_pin_from_session
 from explorer.app.streamlit.app_map_ui import (
     inject_map_folium_iframe_min_height_css,
     inject_sidebar_outline_download_button_css,
@@ -382,6 +383,7 @@ def render_prep_spinner_and_map_tab(
                         map_view_mode == "species" and bool(hide_non_matching_locations)
                     )
                     capture_all_locations_view = map_view_mode == "all" and not overlay_sci
+                    _go_pin = go_to_gps_pin_from_session()
                     _visit_sch = active_map_marker_colour_scheme(int(family_colour_scheme))
                     _map_kw = {
                         **ctx,
@@ -415,6 +417,7 @@ def render_prep_spinner_and_map_tab(
                         "species_blank_default_center": tuple(blank_viewport_recipe.get("center", [MAP_SPECIES_DEFAULT_CENTER_LAT, MAP_SPECIES_DEFAULT_CENTER_LON])),
                         "species_blank_default_zoom": int(blank_viewport_recipe.get("zoom", MAP_SPECIES_DEFAULT_ZOOM)),
                         "species_blank_viewport_recipe": blank_viewport_recipe,
+                        "go_to_gps_pin": _go_pin,
                     }
                     if capture_all_locations_view:
                         _valid = {
@@ -471,6 +474,7 @@ def render_prep_spinner_and_map_tab(
                         species_selected_sci=overlay_sci if _species_selected else "",
                         species_selected_common=overlay_common if _species_selected else "",
                         hide_non_matching_locations=bool(hide_nm),
+                        go_to_gps_pin=_go_pin,
                     )
                     _cached = _map_cache_lookup(_ck)
                     if isinstance(_cached, dict) and _cached.get("map") is not None:
@@ -544,8 +548,10 @@ def render_prep_spinner_and_map_tab(
                         )
                         st.stop()
                     with perf_span("prep.map_iframe_embed"):
+                        # Deep copy: ``st_folium`` / Folium render paths mutate in memory; mutating the
+                        # cached ``folium.Map`` causes intermittent empty maps on subsequent cache hits.
                         st_folium(
-                            result_map,
+                            copy.deepcopy(result_map),
                             use_container_width=True,
                             height=int(map_height),
                             key=folium_st_key,

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -84,6 +84,8 @@ MAP_SPECIES_DEFAULT_ZOOM = 5
 MAP_SPECIES_FIT_BOUNDS_PADDING_PX = 48
 MAP_SPECIES_FIT_BOUNDS_MAX_ZOOM = 7
 MAP_SPECIES_SINGLE_POINT_ZOOM = 8
+# Go to GPS temporary pin: fitBounds max zoom (session-only marker; refs #199).
+MAP_GO_TO_GPS_MAX_ZOOM = 10
 
 # Lifer-locations map: initial fit_bounds (not colour-scheme settings). Framing uses base-species
 # lifer pins only; subspecies-only pins do not affect bounds (refs #105).

--- a/explorer/core/map_controller.py
+++ b/explorer/core/map_controller.py
@@ -78,6 +78,7 @@ def build_species_overlay_map(
     species_blank_default_center: tuple[float, float] | None = None,
     species_blank_default_zoom: int | None = None,
     species_blank_viewport_recipe: dict[str, Any] | None = None,
+    go_to_gps_pin: tuple[float, float] | None = None,
 ) -> MapOverlayResult:
     """Build the Folium map for all-species, one-species, or lifer-locations overlay.
 
@@ -175,4 +176,5 @@ def build_species_overlay_map(
         species_blank_default_center=species_blank_default_center,
         species_blank_default_zoom=species_blank_default_zoom,
         species_blank_viewport_recipe=species_blank_viewport_recipe,
+        go_to_gps_pin=go_to_gps_pin,
     )

--- a/explorer/core/map_overlay_visit_map.py
+++ b/explorer/core/map_overlay_visit_map.py
@@ -19,6 +19,7 @@ from explorer.app.streamlit.defaults import (
     MAP_ALL_LOCATIONS_FOCUSED_QUANTILE_HIGH,
     MAP_ALL_LOCATIONS_FOCUSED_QUANTILE_LOW,
     MAP_ALL_LOCATIONS_SINGLE_POINT_ZOOM,
+    MAP_GO_TO_GPS_MAX_ZOOM,
     MAP_DEBUG_SHOW_ZOOM_LEVEL,
     MAP_DEFAULT_LOCATION_CLUSTER_DISABLE_AT_ZOOM,
     MAP_DEFAULT_LOCATION_CLUSTER_MAX_RADIUS_PX,
@@ -79,6 +80,27 @@ from explorer.core.stats import safe_count
 def _epsilon_bounds_around_point(lat: float, lon: float, delta: float = 0.02) -> list[list[float]]:
     """Tiny bounding box so Leaflet ``fitBounds`` has non-zero extent for a single pin."""
     return [[lat - delta, lon - delta], [lat + delta, lon + delta]]
+
+
+def _apply_go_to_gps_pin_view(map_obj: folium.Map, pin: tuple[float, float]) -> None:
+    """Centre map on a temporary red pin (Google-style glyph; refs #199 comments)."""
+    lat = float(pin[0])
+    lon = float(pin[1])
+    folium.Marker(
+        location=[lat, lon],
+        popup=folium.Popup(
+            "<div style='font-size:13px'><strong>Temporary GPS marker</strong></div>",
+            max_width=MAP_POPUP_MAX_WIDTH_PX,
+        ),
+        icon=folium.Icon(color="red", icon="map-marker", prefix="fa"),
+    ).add_to(map_obj)
+    pad = int(MAP_SPECIES_FIT_BOUNDS_PADDING_PX)
+    b = _epsilon_bounds_around_point(lat, lon)
+    map_obj.fit_bounds(
+        b,
+        padding=(pad, pad),
+        max_zoom=int(MAP_GO_TO_GPS_MAX_ZOOM),
+    )
 
 
 def _all_locations_marker_params_from_scheme(sch: MapMarkerColourScheme) -> tuple[str, str, int, int, float]:
@@ -316,6 +338,7 @@ def build_visit_overlay_map(
     species_blank_default_center: tuple[float, float] | None = None,
     species_blank_default_zoom: int | None = None,
     species_blank_viewport_recipe: dict[str, Any] | None = None,
+    go_to_gps_pin: tuple[float, float] | None = None,
 ) -> MapOverlayResult:
     """Build all-locations or species-filtered overlay (not lifer-locations mode)."""
     if selected_species:
@@ -438,6 +461,8 @@ def build_visit_overlay_map(
             popup_scroll_hint, popup_sort_order == "ascending"
         )
         species_map.get_root().html.add_child(Element(scroll_popup_script))
+        if go_to_gps_pin:
+            _apply_go_to_gps_pin_view(species_map, go_to_gps_pin)
         return MapOverlayResult(species_map, None)
 
     species_map = create_map(
@@ -508,7 +533,9 @@ def build_visit_overlay_map(
 
         scope_fit = (all_locations_scope or ALL_LOCATIONS_SCOPE_FOCUSED).strip()
         should_fit = scope_fit != ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY and bool(all_loc_pairs)
-        if should_fit and all_loc_pairs:
+        if go_to_gps_pin:
+            _apply_go_to_gps_pin_view(species_map, go_to_gps_pin)
+        elif should_fit and all_loc_pairs:
             pad = int(MAP_ALL_LOCATIONS_FIT_BOUNDS_PADDING_PX)
             max_z = int(MAP_ALL_LOCATIONS_FIT_BOUNDS_MAX_ZOOM)
             if len(all_loc_pairs) == 1:
@@ -706,7 +733,9 @@ def build_visit_overlay_map(
             if pd.isna(la) or pd.isna(lo):
                 continue
             species_pairs.append([la, lo])
-        if species_pairs:
+        if go_to_gps_pin:
+            _apply_go_to_gps_pin_view(species_map, go_to_gps_pin)
+        elif species_pairs:
             pad = int(MAP_SPECIES_FIT_BOUNDS_PADDING_PX)
             if len(species_pairs) == 1:
                 la, lo = float(species_pairs[0][0]), float(species_pairs[0][1])

--- a/tests/explorer/test_go_to_gps_parse.py
+++ b/tests/explorer/test_go_to_gps_parse.py
@@ -1,0 +1,40 @@
+"""Tests for Go to GPS coordinate parsing (refs #199)."""
+
+from __future__ import annotations
+
+import pytest
+
+from explorer.app.streamlit.app_go_to_gps_ui import (
+    format_coord_for_display,
+    parse_lat_lon_pair,
+    parse_single_coord,
+)
+
+
+def test_parse_google_style_pair_from_issue_comment() -> None:
+    raw = "-35.268965820020014, 149.08053613146686"
+    pair = parse_lat_lon_pair(raw)
+    assert pair is not None
+    la, lo = pair
+    assert la == pytest.approx(-35.268965820020014)
+    assert lo == pytest.approx(149.08053613146686)
+
+
+def test_parse_lat_lon_pair_rejects_invalid_ranges() -> None:
+    assert parse_lat_lon_pair("91, 0") is None
+    assert parse_lat_lon_pair("0, 181") is None
+
+
+def test_parse_lat_lon_pair_requires_comma() -> None:
+    assert parse_lat_lon_pair("-35.27 149.08") is None
+
+
+def test_parse_single_coord_strips_commas() -> None:
+    assert parse_single_coord("-35.26897") == pytest.approx(-35.26897)
+    assert parse_single_coord("149.08054,") == pytest.approx(149.08054)
+
+
+def test_format_coord_trims_trailing_zeros() -> None:
+    assert format_coord_for_display(-35.5) == "-35.5"
+    assert "0000000000" not in format_coord_for_display(-35.26896582)
+

--- a/tests/explorer/test_streamlit_ui_helpers.py
+++ b/tests/explorer/test_streamlit_ui_helpers.py
@@ -304,6 +304,18 @@ def test_static_map_cache_key_includes_species_overlay() -> None:
     assert with_species != hide_on
     assert empty_awaiting_species != no_species
 
+    base_all = static_map_cache_key(df, "all", "", "default", ro, taxonomy_locale="en_AU")
+    all_with_gps = static_map_cache_key(
+        df,
+        "all",
+        "",
+        "default",
+        ro,
+        taxonomy_locale="en_AU",
+        go_to_gps_pin=(-33.0, 151.0),
+    )
+    assert base_all != all_with_gps
+
 
 # --- app_data_loading / app_map_ui / streamlit_theme (refs #98; UI-surface regressions) ---
 


### PR DESCRIPTION
## Summary

Adds a session-only **Go to GPS** control on the **All locations** and **Species locations** maps so users can paste or enter decimal latitude/longitude, centre the map on that point, and show a distinct temporary red pin for comparison with checklist markers—without persisting anything or calling external services ([GitHub #199](https://github.com/jimchurches/myebirdstuff/issues/199)).

## Changes

- **UI:** Sidebar expander with latitude/longitude text inputs, **Go to location** and **Clear marker** (form submit); comma-separated **lat, lon** paste splits into both fields via `on_change`.
- **Map:** `go_to_gps_pin` threaded through visit overlay; temporary **red Font Awesome map-marker** pin; viewport centres on GPS when active, otherwise existing framing behaviour.
- **Caching:** `static_map_cache_key` includes GPS coordinates; **`st_folium(copy.deepcopy(result_map))`** so Folium embed does not mutate the cached map (fixes intermittent blank maps).
- **Tests:** Parsing helpers (`parse_lat_lon_pair`, etc.) and cache-key regression test.

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` → 545 passed, 4 skipped

Manual: Map tab → All locations / Species locations → Go to GPS expander → enter coords or paste `lat, lon` → Go → map centres + pin; Clear removes pin and restores default framing.

## Notes

- No YAML/settings persistence for GPS state.
- DMS format (e.g. degrees/minutes/seconds) deferred for a possible future request.

## Issues

Fixes #199
