### PR TITLE
ui: Improve focused view map help text

### DIFF
--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -279,7 +279,7 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             if _scope_sel == ALL_LOCATIONS_SCOPE_FOCUSED:
                 st.caption(
                     "Focused view shows your main birding regions. "
-                    "Smaller or infrequent locations may be hidden."
+                    "Other locations may be outside the current view; zoom or pan to find them."
                 )
             elif _scope_sel == ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY:
                 st.caption(


### PR DESCRIPTION
## Summary

Update the Map focus **Focused** caption so it no longer implies locations are hidden, and nudge users to zoom or pan. Final copy uses a semicolon before the guidance phrase.

## Changes

- Replace focused-view `st.caption` in `explorer/app/streamlit/app_map_working_ui.py` with: *Focused view shows your main birding regions. Other locations may be outside the current view; zoom or pan to find them.*

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (545 passed, 4 skipped)

Fixes #207
