### PR TITLE
Fix map LRU cache cleared on view-mode change (#214)

### DIFF
--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -446,9 +446,10 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         st.session_state[SESSION_PREV_EFFECTIVE_BASEMAP_KEY] = map_style
         invalidate_folium_map_embed_cache()
 
+    # Bump mount nonce when the view mode changes so the Folium iframe remounts with the new map.
+    # Do not clear FOLIUM_STATIC_MAP_CACHE_KEY / EXPLORER_MAP_HTML_BYTES_KEY here: the LRU cache key
+    # already includes map_view_mode (#214); clearing defeated reuse across All ↔ Lifer ↔ Species.
     if _prev_mv is not None and _prev_mv != map_view_mode:
-        st.session_state.pop(FOLIUM_STATIC_MAP_CACHE_KEY, None)
-        st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
         st.session_state[FOLIUM_MAP_MOUNT_NONCE_KEY] = int(
             st.session_state.get(FOLIUM_MAP_MOUNT_NONCE_KEY, 0)
         ) + 1

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -182,7 +182,21 @@ def render_prep_spinner_and_map_tab(
             with perf_span("prep.data_signature"):
                 prov_plain = provenance or ""
                 sig = data_signature_for_caches(df_full, prov_plain)
-                if st.session_state.get(EBIRD_DATA_SIG_KEY) != sig:
+                _prev_sig = st.session_state.get(EBIRD_DATA_SIG_KEY)
+                if _prev_sig != sig:
+                    perf_record_point(
+                        "prep.data_sig_change",
+                        extra={
+                            "prev_present": _prev_sig is not None,
+                            "prev_sig": list(_prev_sig) if isinstance(_prev_sig, tuple) else _prev_sig,
+                            "new_sig": list(sig) if isinstance(sig, tuple) else sig,
+                            "map_cache_entries_before_nuke": (
+                                len(st.session_state[FOLIUM_STATIC_MAP_CACHE_KEY])
+                                if isinstance(st.session_state.get(FOLIUM_STATIC_MAP_CACHE_KEY), OrderedDict)
+                                else 0
+                            ),
+                        },
+                    )
                     st.session_state[EBIRD_DATA_SIG_KEY] = sig
                     st.session_state[POPUP_HTML_CACHE_KEY] = {}
                     st.session_state[FILTERED_BY_LOC_CACHE_KEY] = OrderedDict()
@@ -476,6 +490,29 @@ def render_prep_spinner_and_map_tab(
                         hide_non_matching_locations=bool(hide_nm),
                         go_to_gps_pin=_go_pin,
                     )
+                    _cache_at_lookup = st.session_state.get(FOLIUM_STATIC_MAP_CACHE_KEY)
+                    perf_record_point(
+                        "prep.map_cache_key_components",
+                        extra={
+                            "mode": map_view_mode,
+                            "k_map_view_mode": _ck[0],
+                            "k_date_filter_banner": _ck[1],
+                            "k_map_style": _ck[2],
+                            "k_render_opts_sig": list(_ck[3]),
+                            "k_n": _ck[4],
+                            "k_sid0": _ck[5],
+                            "k_tax": _ck[6],
+                            "k_sci": _ck[7],
+                            "k_common": _ck[8],
+                            "k_hide_nm": _ck[9],
+                            "k_gps_sig": _ck[10],
+                            "cache_entries_at_lookup": (
+                                len(_cache_at_lookup)
+                                if isinstance(_cache_at_lookup, OrderedDict)
+                                else (1 if isinstance(_cache_at_lookup, dict) else 0)
+                            ),
+                        },
+                    )
                     _cached = _map_cache_lookup(_ck)
                     if isinstance(_cached, dict) and _cached.get("map") is not None:
                         perf_record_point("prep.map_cache_hit", extra={"mode": map_view_mode})
@@ -494,6 +531,19 @@ def render_prep_spinner_and_map_tab(
                                     "key": _ck,
                                     "map": result_map,
                                     "warning": result_warning,
+                                },
+                            )
+                            _cache_after = st.session_state.get(FOLIUM_STATIC_MAP_CACHE_KEY)
+                            perf_record_point(
+                                "prep.map_cache_store",
+                                extra={
+                                    "mode": map_view_mode,
+                                    "site": "after_build_species_overlay_map",
+                                    "cache_entries_after_store": (
+                                        len(_cache_after)
+                                        if isinstance(_cache_after, OrderedDict)
+                                        else 0
+                                    ),
                                 },
                             )
 

--- a/tests/explorer/test_map_perf_e2e.py
+++ b/tests/explorer/test_map_perf_e2e.py
@@ -83,6 +83,14 @@ def test_map_perf_fixture_journey_emits_prep_stages_within_loose_ceiling(
     missing = must - stages_seen
     assert not missing, f"missing expected stages {missing!r} in {sorted(stages_seen)!r}"
 
+    # #214: All → Lifer → All must hit the Folium prep cache at least once on return (before the fix,
+    # ``app_map_working_ui`` cleared the LRU on every view-mode change, so this count stayed 0).
+    cache_hits = [e for e in events if e.get("stage") == "prep.map_cache_hit"]
+    assert len(cache_hits) >= 1, (
+        "expected at least one prep.map_cache_hit in JSONL for All→Lifer→All "
+        f"(got {len(cache_hits)}); stages seen: {sorted(stages_seen)!r}"
+    )
+
     highs = max_elapsed_ms_by_stage(events)
     failures: list[str] = []
     for stage, cap in ceilings.items():

--- a/tests/explorer/test_map_render_cache.py
+++ b/tests/explorer/test_map_render_cache.py
@@ -1,0 +1,72 @@
+"""Session Folium map LRU cache (#214).
+
+Before #214, switching map view mode cleared the entire cache in ``app_map_working_ui``, so
+``prep.map_cache_hit`` never fired when returning to a previously visited mode. These tests lock in
+the intended LRU behaviour: distinct ``static_map_cache_key`` tuples (e.g. ``all`` vs ``lifers``)
+can coexist in ``FOLIUM_STATIC_MAP_CACHE_KEY``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+pytest.importorskip("streamlit", reason="map cache helpers use Streamlit session state")
+
+from explorer.app.streamlit.app_caches import static_map_cache_key
+from explorer.app.streamlit.app_constants import FOLIUM_STATIC_MAP_CACHE_KEY
+from explorer.app.streamlit.app_prep_map_ui import _map_cache_lookup, _map_cache_store
+
+
+@pytest.fixture
+def fake_session_state(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Patch ``st.session_state`` used by ``app_prep_map_ui`` cache helpers."""
+    session: dict = {}
+    monkeypatch.setattr(
+        "explorer.app.streamlit.app_prep_map_ui.st",
+        SimpleNamespace(session_state=session),
+    )
+    return session
+
+
+def test_map_render_cache_two_view_modes_remain_addressable(fake_session_state: dict) -> None:
+    df = pd.DataFrame({"Submission ID": ["s1"]})
+    render_opts: tuple = ()
+    key_all = static_map_cache_key(
+        df,
+        "all",
+        "",
+        "default",
+        render_opts,
+        taxonomy_locale="en_AU",
+    )
+    key_lifers = static_map_cache_key(
+        df,
+        "lifers",
+        "",
+        "default",
+        render_opts,
+        taxonomy_locale="en_AU",
+    )
+    map_all = object()
+    map_lifers = object()
+    _map_cache_store(key_all, {"key": key_all, "map": map_all, "warning": None})
+    _map_cache_store(key_lifers, {"key": key_lifers, "map": map_lifers, "warning": None})
+
+    got_all = _map_cache_lookup(key_all)
+    got_lifers = _map_cache_lookup(key_lifers)
+    assert got_all is not None and got_all.get("map") is map_all
+    assert got_lifers is not None and got_lifers.get("map") is map_lifers
+
+
+def test_map_render_cache_legacy_single_entry_payload_upgraded(fake_session_state: dict) -> None:
+    """Backward-compatible path: one dict-shaped entry is folded into the OrderedDict."""
+    df = pd.DataFrame({"Submission ID": ["s2"]})
+    key = static_map_cache_key(df, "all", "", "default", (), taxonomy_locale="en_AU")
+    legacy = {"key": key, "map": object(), "warning": None}
+    fake_session_state[FOLIUM_STATIC_MAP_CACHE_KEY] = legacy
+
+    got = _map_cache_lookup(key)
+    assert got is not None and got.get("key") == key


### PR DESCRIPTION
## Summary

The Folium map session LRU was cleared on every **map view mode** change (All ↔ Lifer ↔ Species ↔ Family), even though `static_map_cache_key` already includes `map_view_mode`. That defeated cache reuse when returning to a previously visited mode. This change only bumps the Folium **mount nonce** on view-mode change so the iframe remounts, while keeping distinct LRU entries alive.

Instrumentation from the [#205](https://github.com/jimchurches/myebirdstuff/issues/205) W4 investigation is included behind `EXPLORER_PERF=1` (`prep.data_sig_change`, `prep.map_cache_key_components`, `prep.map_cache_store`) to spot regressions.

## Changes

- **`app_map_working_ui.py`:** Stop popping `FOLIUM_STATIC_MAP_CACHE_KEY` / `EXPLORER_MAP_HTML_BYTES_KEY` when `map_view_mode` changes; keep mount nonce bump.
- **`app_prep_map_ui.py`:** Add optional perf record points for data-signature-driven cache nukes, cache key components at lookup, and entry count after store.
- **`test_map_render_cache.py`:** Unit tests that two view-mode keys coexist in the LRU (and legacy single-entry upgrade).
- **`test_map_perf_e2e.py`:** Assert ≥ one `prep.map_cache_hit` in JSONL after All → Lifer → All Playwright journey.

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (547 passed, 4 skipped)
- Manual: All → Lifer → All; with `EXPLORER_PERF=1`, confirm `prep.map_cache_hit` when returning to All.

## Issues

- Fixes [#214](https://github.com/jimchurches/myebirdstuff/issues/214)
- Refs [#205](https://github.com/jimchurches/myebirdstuff/issues/205)

Made with [Cursor](https://cursor.com)