### PR TITLE
feat(#205): map perf instrumentation (I1/I2/I4/I5) for beta-next

### DIFF
--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -520,8 +520,17 @@ def render_prep_spinner_and_map_tab(
                         result_warning = _cached.get("warning")
                     else:
                         perf_record_point("prep.map_cache_miss", extra={"mode": map_view_mode})
-                        with perf_span("prep.build_species_overlay_map"):
-                            result = build_species_overlay_map(**_map_kw)
+                        # #205 batch 4 I1/I2: collect popup-build vs marker-count split inside
+                        # the same perf event. ``perf_span`` stamps ``extra`` by reference at
+                        # finalize time, so mutations inside :func:`build_species_overlay_map`
+                        # land on the emitted record.
+                        _build_metrics: dict[str, Any] = {"mode": map_view_mode}
+                        with perf_span(
+                            "prep.build_species_overlay_map", extra=_build_metrics
+                        ):
+                            result = build_species_overlay_map(
+                                metrics_sink=_build_metrics, **_map_kw
+                            )
                             result_map = result.map
                             result_warning = result.warning
                         if result_map is not None:

--- a/explorer/core/map_controller.py
+++ b/explorer/core/map_controller.py
@@ -79,6 +79,7 @@ def build_species_overlay_map(
     species_blank_default_zoom: int | None = None,
     species_blank_viewport_recipe: dict[str, Any] | None = None,
     go_to_gps_pin: tuple[float, float] | None = None,
+    metrics_sink: Optional[Dict[str, Any]] = None,
 ) -> MapOverlayResult:
     """Build the Folium map for all-species, one-species, or lifer-locations overlay.
 
@@ -110,6 +111,20 @@ def build_species_overlay_map(
     (resolved via :mod:`explorer.core.map_marker_colour_resolve`) for **All locations**, **Species
     locations**, and **Lifer locations** pins (colours, radii, stroke weight, fill opacities, cluster
     tiers).
+
+    *metrics_sink*: optional mutable dict for the host (Streamlit / tests) to collect rebuild-cost
+    instrumentation (#205 batch 4: I1 popup-build timing/count + I2 marker count). When provided,
+    the active overlay function populates these keys before returning:
+
+    - ``view_path`` (``"all_locations"`` / ``"species"`` / ``"lifer"``)
+    - ``marker_count`` (CircleMarker calls added in this build)
+    - ``popup_build_count`` (popups built and stored in *popup_html_cache* this call)
+    - ``popup_cache_hit_count`` (popups served from *popup_html_cache* this call)
+    - ``popup_build_total_ms`` (wall time spent inside popup-HTML construction)
+
+    Host-side wiring: pass the same dict to ``perf_span("prep.build_species_overlay_map",
+    extra=metrics)`` and to this function; the span emits a single enriched event per rebuild.
+    Default ``None`` is a no-op — overlays don't import any perf module from ``explorer/app/``.
     """
     tax_loc_key = (taxonomy_locale or "").strip()
     mode = (map_view_mode or "all").strip().lower()
@@ -133,6 +148,7 @@ def build_species_overlay_map(
             effective_use_full=effective_use_full,
             base_species_fn=base_species_fn,
             visit_marker_scheme=visit_marker_scheme,
+            metrics_sink=metrics_sink,
         )
 
     # Species overlay is driven by a non-empty *selected_species* (same as legacy behaviour), not only
@@ -177,4 +193,5 @@ def build_species_overlay_map(
         species_blank_default_zoom=species_blank_default_zoom,
         species_blank_viewport_recipe=species_blank_viewport_recipe,
         go_to_gps_pin=go_to_gps_pin,
+        metrics_sink=metrics_sink,
     )

--- a/explorer/core/map_overlay_lifer_map.py
+++ b/explorer/core/map_overlay_lifer_map.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, MutableMapping, Optional, Tuple
+import time
+from typing import Any, Dict, MutableMapping, Optional, Tuple
 
 import folium
 import pandas as pd
@@ -53,8 +54,14 @@ def build_lifer_overlay_map(
     effective_use_full: bool,
     base_species_fn: BaseSpeciesFn,
     visit_marker_scheme: MapMarkerColourScheme,
+    metrics_sink: Optional[Dict[str, Any]] = None,
 ) -> MapOverlayResult:
-    """Assemble the lifer-locations Folium map or return a user-facing *warning*."""
+    """Assemble the lifer-locations Folium map or return a user-facing *warning*.
+
+    See :func:`explorer.core.map_controller.build_species_overlay_map` for *metrics_sink*
+    semantics (#205 batch 4 I1/I2). Populated keys: ``view_path``, ``marker_count``,
+    ``popup_build_count``, ``popup_cache_hit_count``, ``popup_build_total_ms``.
+    """
     if full_location_data is None or full_location_data.empty:
         return MapOverlayResult(
             None,
@@ -145,10 +152,18 @@ def build_lifer_overlay_map(
             legend_items.append((se, sp, "Subspecies"))
         species_map.get_root().html.add_child(Element(build_legend_html(legend_items)))
 
+    # I1/I2 counters (#205 batch 4); zero-cost when ``metrics_sink is None`` other than the
+    # per-cache-miss ``time.perf_counter`` pair.
+    _m_count = 0
+    _p_built = 0
+    _p_hit = 0
+    _p_build_ms = 0.0
     for _, row in loc_rows.iterrows():
         lid = row["Location ID"]
         popup_key = (lid, "__lifer_map__", effective_use_full, tax_loc_key, bool(show_subspecies_lifers))
         if popup_key not in popup_html_cache:
+            _p_built += 1
+            _t_p0 = time.perf_counter()
             entries = loc_to_species.get(lid, [])
             base_entries = [e for e in entries if e.get("is_base_lifer")]
             popup_entries = entries if show_subspecies_lifers else base_entries
@@ -167,6 +182,9 @@ def build_lifer_overlay_map(
                 lifer_heading_html="",
                 location_heading_margin_px=2,
             )
+            _p_build_ms += (time.perf_counter() - _t_p0) * 1000.0
+        else:
+            _p_hit += 1
         popup_html = popup_html_cache[popup_key]
         if not show_subspecies_lifers:
             popup = folium.Popup(popup_html, max_width=MAP_POPUP_MAX_WIDTH_PX)
@@ -180,6 +198,7 @@ def build_lifer_overlay_map(
                 fill_opacity=fo_lif,
                 popup=popup,
             ).add_to(species_map)
+            _m_count += 1
         else:
             latlng = [row["Latitude"], row["Longitude"]]
             loc_kind = loc_kind_by_id.get(lid, "lifer")
@@ -195,6 +214,7 @@ def build_lifer_overlay_map(
                     fill_opacity=fo_spec,
                     popup=popup,
                 ).add_to(species_map)
+                _m_count += 1
             else:
                 popup = folium.Popup(popup_html, max_width=MAP_POPUP_MAX_WIDTH_PX)
                 folium.CircleMarker(
@@ -207,6 +227,14 @@ def build_lifer_overlay_map(
                     fill_opacity=fo_lif,
                     popup=popup,
                 ).add_to(species_map)
+                _m_count += 1
+
+    if metrics_sink is not None:
+        metrics_sink["view_path"] = "lifer"
+        metrics_sink["marker_count"] = _m_count
+        metrics_sink["popup_build_count"] = _p_built
+        metrics_sink["popup_cache_hit_count"] = _p_hit
+        metrics_sink["popup_build_total_ms"] = round(_p_build_ms, 3)
 
     # Initial viewport follows base lifer extent only; subspecies toggle does not change these bounds.
     if framing_pairs:

--- a/explorer/core/map_overlay_visit_map.py
+++ b/explorer/core/map_overlay_visit_map.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from collections import OrderedDict
 from typing import Any, Dict, Hashable, Literal, MutableMapping, Optional, Tuple, cast
 
@@ -339,8 +340,14 @@ def build_visit_overlay_map(
     species_blank_default_zoom: int | None = None,
     species_blank_viewport_recipe: dict[str, Any] | None = None,
     go_to_gps_pin: tuple[float, float] | None = None,
+    metrics_sink: Optional[Dict[str, Any]] = None,
 ) -> MapOverlayResult:
-    """Build all-locations or species-filtered overlay (not lifer-locations mode)."""
+    """Build all-locations or species-filtered overlay (not lifer-locations mode).
+
+    See :func:`explorer.core.map_controller.build_species_overlay_map` for *metrics_sink*
+    semantics (#205 batch 4 I1/I2). Populated keys: ``view_path``, ``marker_count``,
+    ``popup_build_count``, ``popup_cache_hit_count``, ``popup_build_total_ms``.
+    """
     if selected_species:
         filtered = filter_species(df, selected_species)
         if filtered.empty:
@@ -505,9 +512,18 @@ def build_visit_overlay_map(
             )
         pin_parent: folium.Map | MarkerCluster = marker_cluster if marker_cluster is not None else species_map
 
+        # I1/I2 counters (#205 batch 4); zero-cost when ``metrics_sink is None`` other than the
+        # per-cache-miss ``time.perf_counter`` pair, which is ~100 ns total per popup build.
+        _m_count = 0
+        _p_built = 0
+        _p_hit = 0
+        _p_build_ms = 0.0
         for _, row in effective_location_data.iterrows():
+            _m_count += 1
             popup_key = (row["Location ID"], "", effective_use_full, tax_loc_key)
             if popup_key not in popup_html_cache:
+                _p_built += 1
+                _t_p0 = time.perf_counter()
                 base_records = effective_records_by_loc.get(row["Location ID"], pd.DataFrame())
                 visit_records = base_records.drop_duplicates(subset=["Submission ID"]).sort_values(
                     "datetime", ascending=popup_ascending
@@ -516,6 +532,9 @@ def build_visit_overlay_map(
                 popup_html_cache[popup_key] = build_location_popup_html(
                     row["Location"], row["Location ID"], visit_info
                 )
+                _p_build_ms += (time.perf_counter() - _t_p0) * 1000.0
+            else:
+                _p_hit += 1
             popup_html = popup_html_cache[popup_key]
             folium.CircleMarker(
                 location=[row["Latitude"], row["Longitude"]],
@@ -530,6 +549,13 @@ def build_visit_overlay_map(
 
         if marker_cluster is not None:
             marker_cluster.add_to(species_map)
+
+        if metrics_sink is not None:
+            metrics_sink["view_path"] = "all_locations"
+            metrics_sink["marker_count"] = _m_count
+            metrics_sink["popup_build_count"] = _p_built
+            metrics_sink["popup_cache_hit_count"] = _p_hit
+            metrics_sink["popup_build_total_ms"] = round(_p_build_ms, 3)
 
         scope_fit = (all_locations_scope or ALL_LOCATIONS_SCOPE_FOCUSED).strip()
         should_fit = scope_fit != ALL_LOCATIONS_FRAMING_CENTRE_OF_GRAVITY and bool(all_loc_pairs)
@@ -666,6 +692,11 @@ def build_visit_overlay_map(
             legend_items.append((e, f, label))
         species_map.get_root().html.add_child(Element(build_legend_html(legend_items)))
 
+        # I1/I2 counters (#205 batch 4); same shape as the all-locations loop above.
+        _m_count = 0
+        _p_built = 0
+        _p_hit = 0
+        _p_build_ms = 0.0
         for _, row in location_data_local.iterrows():
             loc_id = row["Location ID"]
 
@@ -674,6 +705,8 @@ def build_visit_overlay_map(
 
             popup_key = (loc_id, selected_species, tax_loc_key)
             if popup_key not in popup_html_cache:
+                _p_built += 1
+                _t_p0 = time.perf_counter()
                 base_records = records_by_loc.get(loc_id, pd.DataFrame())
                 visit_records = base_records.drop_duplicates(subset=["Submission ID"]).sort_values(
                     "datetime", ascending=popup_ascending
@@ -696,6 +729,9 @@ def build_visit_overlay_map(
                     popup_html_cache[popup_key] = build_location_popup_html(
                         row["Location"], loc_id, visit_info, ""
                     )
+                _p_build_ms += (time.perf_counter() - _t_p0) * 1000.0
+            else:
+                _p_hit += 1
             popup_html = popup_html_cache[popup_key]
             popup_content = folium.Popup(popup_html, max_width=MAP_POPUP_MAX_WIDTH_PX)
 
@@ -722,6 +758,14 @@ def build_visit_overlay_map(
                 fill_opacity=fill_opacity,
                 popup=popup_content,
             ).add_to(species_map)
+            _m_count += 1
+
+        if metrics_sink is not None:
+            metrics_sink["view_path"] = "species"
+            metrics_sink["marker_count"] = _m_count
+            metrics_sink["popup_build_count"] = _p_built
+            metrics_sink["popup_cache_hit_count"] = _p_hit
+            metrics_sink["popup_build_total_ms"] = round(_p_build_ms, 3)
 
         # Follow the selected species extent only; background/context pins may be off-screen.
         species_pairs: list[list[float]] = []

--- a/scripts/aggregate_perf_jsonl.py
+++ b/scripts/aggregate_perf_jsonl.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Aggregate Explorer perf JSONL archives into per-(group, stage) tables (#205 batch 4 I5).
+
+Reads one or more ``EXPLORER_PERF_LOG_FILE`` archives (and/or ``e2e.first_paint`` records from
+:func:`tests.explorer.e2e_support.append_e2e_first_paint_record`), groups files by a
+filename-regex capture, and prints a table with per-stage event count, median, p95, and max
+``elapsed_ms`` per group — plus optional per-stage aggregates over numeric ``extra.*`` fields.
+
+Origin: ad-hoc ``/tmp/aggregate_w1_ab.py`` used during the W1 A/B for #205 batch 3. Graduating
+into a reusable tool so future batches don't re-write the same arithmetic.
+
+Examples
+--------
+Reproduce the W1 A/B summary::
+
+    python scripts/aggregate_perf_jsonl.py \\
+        benchmarks/map_perf/snapshots/issue-205-batch-3 \\
+        --glob 'w1-*.jsonl' \\
+        --group-regex 'w1-(?P<dataset>[^-]+)-fragment_(?P<mode>[^-]+)' \\
+        --stage prep.map_iframe_embed \\
+        --stage prep.build_species_overlay_map
+
+Batch 4 baseline with the new I1/I2/I4 fields::
+
+    python scripts/aggregate_perf_jsonl.py \\
+        benchmarks/map_perf/snapshots/issue-205-batch-4 \\
+        --group-regex 'baseline-(?P<dataset>[^-]+)-r(?P<run>\\d+)' \\
+        --stage prep.build_species_overlay_map \\
+        --stage e2e.first_paint \\
+        --extra-key marker_count \\
+        --extra-key popup_build_count \\
+        --extra-key popup_cache_hit_count \\
+        --extra-key popup_build_total_ms
+
+Output is plain text by default (suitable for posting to GitHub comments) or JSON when
+``--format json`` is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from statistics import median
+from typing import Any, Iterable
+
+
+def parse_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file and return parsed objects (skipping malformed / non-object lines)."""
+    out: list[dict[str, Any]] = []
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def percentile(values: list[float], q: float) -> float:
+    """Return the *q* percentile of *values* using the nearest-rank method (``q`` in 0..100)."""
+    if not values:
+        return float("nan")
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    k = max(0, min(len(s) - 1, int(round((q / 100.0) * (len(s) - 1)))))
+    return s[k]
+
+
+def group_label_for_filename(name: str, group_regex: re.Pattern[str] | None) -> str:
+    """Return the regex-derived group label for *name*, or *name* itself when no regex matches."""
+    if group_regex is None:
+        return name
+    m = group_regex.search(name)
+    if not m:
+        return name
+    captures = m.groupdict()
+    if not captures:
+        return m.group(0)
+    return "/".join(f"{k}={v}" for k, v in captures.items() if v is not None)
+
+
+def aggregate(
+    files: Iterable[Path],
+    *,
+    group_regex: re.Pattern[str] | None,
+    stages: set[str] | None,
+    extra_keys: list[str],
+) -> dict[str, Any]:
+    """Compute per-(group, stage) statistics from *files*.
+
+    Returns a dict::
+
+        {
+            "groups": {
+                "<group_label>": {
+                    "n_files": int,
+                    "files": [str, ...],
+                    "stages": {
+                        "<stage>": {
+                            "n_runs": int,                # files in this group
+                            "total_events": int,          # sum of events across files
+                            "events_per_run": [int, ...], # per-file event count
+                            "median_events_per_run": float,
+                            "elapsed_ms": {
+                                "median": float,
+                                "p95": float,
+                                "max": float,
+                                "n_samples": int,
+                            },
+                            "extras": {
+                                "<extra_key>": {
+                                    "median": float,
+                                    "p95": float,
+                                    "max": float,
+                                    "n_samples": int,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+    groups: dict[str, dict[Path, list[dict[str, Any]]]] = defaultdict(dict)
+    for f in files:
+        label = group_label_for_filename(f.name, group_regex)
+        groups[label][f] = parse_jsonl(f)
+
+    out_groups: dict[str, Any] = {}
+    for label, file_map in groups.items():
+        files_in_group = list(file_map.keys())
+        all_stages_in_group = {
+            ev.get("stage")
+            for events in file_map.values()
+            for ev in events
+            if isinstance(ev.get("stage"), str)
+        }
+        stages_to_emit = (
+            sorted(all_stages_in_group & stages) if stages else sorted(all_stages_in_group)
+        )
+
+        stage_blob: dict[str, Any] = {}
+        for stage in stages_to_emit:
+            events_per_run: list[int] = []
+            elapsed_samples: list[float] = []
+            extra_samples: dict[str, list[float]] = {k: [] for k in extra_keys}
+            for events in file_map.values():
+                matches = [e for e in events if e.get("stage") == stage]
+                events_per_run.append(len(matches))
+                for e in matches:
+                    ms = e.get("elapsed_ms")
+                    if isinstance(ms, (int, float)):
+                        elapsed_samples.append(float(ms))
+                    extra = e.get("extra") if isinstance(e.get("extra"), dict) else {}
+                    for k in extra_keys:
+                        # ``extra`` events for E2E first-paint records put fields at the top
+                        # level rather than nested under ``extra``; check both.
+                        v = extra.get(k) if isinstance(extra, dict) else None
+                        if v is None:
+                            v = e.get(k)
+                        if isinstance(v, (int, float)):
+                            extra_samples[k].append(float(v))
+            stage_blob[stage] = {
+                "n_runs": len(files_in_group),
+                "total_events": sum(events_per_run),
+                "events_per_run": events_per_run,
+                "median_events_per_run": (
+                    float(median(events_per_run)) if events_per_run else 0.0
+                ),
+                "elapsed_ms": {
+                    "median": percentile(elapsed_samples, 50.0),
+                    "p95": percentile(elapsed_samples, 95.0),
+                    "max": max(elapsed_samples) if elapsed_samples else float("nan"),
+                    "n_samples": len(elapsed_samples),
+                },
+                "extras": {
+                    k: {
+                        "median": percentile(extra_samples[k], 50.0),
+                        "p95": percentile(extra_samples[k], 95.0),
+                        "max": max(extra_samples[k]) if extra_samples[k] else float("nan"),
+                        "n_samples": len(extra_samples[k]),
+                    }
+                    for k in extra_keys
+                },
+            }
+        out_groups[label] = {
+            "n_files": len(files_in_group),
+            "files": sorted(str(f) for f in files_in_group),
+            "stages": stage_blob,
+        }
+    return {"groups": out_groups}
+
+
+def _fmt(v: float, width: int = 9) -> str:
+    if v != v:  # NaN
+        return "—".rjust(width)
+    return f"{v:>{width}.1f}"
+
+
+def render_text(result: dict[str, Any], extra_keys: list[str]) -> str:
+    """Render the aggregate result as a flat text table (one row per (group, stage))."""
+    lines: list[str] = []
+    base_cols = [
+        "group",
+        "stage",
+        "n_runs",
+        "total_events",
+        "med_evt/run",
+        "med_ms",
+        "p95_ms",
+        "max_ms",
+    ]
+    extra_cols: list[str] = []
+    for k in extra_keys:
+        extra_cols += [f"{k}.med", f"{k}.max"]
+    header_cols = base_cols + extra_cols
+    lines.append(" ".join(f"{c:>14s}" if i >= 2 else f"{c:<28s}" for i, c in enumerate(header_cols)))
+    lines.append("-" * (len(lines[-1])))
+
+    for group_label in sorted(result["groups"].keys()):
+        g = result["groups"][group_label]
+        for stage in sorted(g["stages"].keys()):
+            s = g["stages"][stage]
+            row = [
+                f"{group_label:<28s}",
+                f"{stage:<28s}",
+                f"{s['n_runs']:>14d}",
+                f"{s['total_events']:>14d}",
+                f"{s['median_events_per_run']:>14.1f}",
+                _fmt(s["elapsed_ms"]["median"], 14),
+                _fmt(s["elapsed_ms"]["p95"], 14),
+                _fmt(s["elapsed_ms"]["max"], 14),
+            ]
+            for k in extra_keys:
+                ev = s["extras"][k]
+                row += [_fmt(ev["median"], 14), _fmt(ev["max"], 14)]
+            lines.append(" ".join(row))
+    return "\n".join(lines) + "\n"
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="aggregate_perf_jsonl",
+        description="Aggregate Explorer perf JSONL archives into per-(group, stage) tables.",
+    )
+    p.add_argument(
+        "input_dir",
+        type=Path,
+        help="Directory containing JSONL files (matched against --glob).",
+    )
+    p.add_argument(
+        "--glob",
+        default="*.jsonl",
+        help="Glob pattern (relative to input_dir) for files to aggregate. Default: *.jsonl",
+    )
+    p.add_argument(
+        "--group-regex",
+        default=None,
+        help=(
+            "Optional regex applied to each file name; named captures become the group label. "
+            "Example: 'w1-(?P<dataset>[^-]+)-fragment_(?P<mode>[^-]+)'."
+        ),
+    )
+    p.add_argument(
+        "--stage",
+        action="append",
+        default=[],
+        dest="stages",
+        help="Stage to include (repeatable). Default: include every stage observed.",
+    )
+    p.add_argument(
+        "--extra-key",
+        action="append",
+        default=[],
+        dest="extra_keys",
+        help=(
+            "Numeric key to aggregate from each event's ``extra`` dict (or top-level for "
+            "synthesised E2E records). Repeatable."
+        ),
+    )
+    p.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(argv)
+
+    if not args.input_dir.is_dir():
+        print(f"error: input_dir is not a directory: {args.input_dir}", file=sys.stderr)
+        return 2
+
+    group_regex = re.compile(args.group_regex) if args.group_regex else None
+    files = sorted(args.input_dir.glob(args.glob))
+    if not files:
+        print(f"warning: no files matched {args.glob!r} under {args.input_dir}", file=sys.stderr)
+
+    stages_filter = set(args.stages) if args.stages else None
+    result = aggregate(
+        files,
+        group_regex=group_regex,
+        stages=stages_filter,
+        extra_keys=list(args.extra_keys),
+    )
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        print(render_text(result, list(args.extra_keys)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/explorer/e2e_support.py
+++ b/tests/explorer/e2e_support.py
@@ -127,6 +127,64 @@ def sidebar_map_view_select(page: Any) -> Any:
     return sidebar.locator('[data-testid="stSelectbox"]').first
 
 
+def measure_first_paint_ms(
+    page: Any,
+    url: str,
+    *,
+    must_contain: Sequence[str] | None = None,
+    timeout_ms: int | None = None,
+) -> dict[str, float]:
+    """Time ``page.goto`` → first appearance of ``pebird-map-banner`` in any frame.
+
+    Returns ``{"goto_ms", "banner_ms"}``. ``goto_ms`` is navigation-complete wall time
+    (``page.goto(... wait_until="domcontentloaded")`` return); ``banner_ms`` is the
+    user-experienced first-paint, end-to-end (subprocess pipeline: data load → prep →
+    map build → Streamlit render → iframe DOM paint). This is I4 for #205 batch 4.
+
+    *must_contain* (optional) lets callers refine "banner observed" to a specific
+    banner (e.g. ``All locations`` vs ``Lifer locations``); default just waits for
+    *any* ``pebird-map-banner``.
+    """
+    import time
+
+    t0 = time.monotonic()
+    page.goto(url, wait_until="domcontentloaded")
+    t_goto = time.monotonic()
+    wait_for_pebird_map_markup(
+        page,
+        must_contain=list(must_contain or []),
+        timeout_ms=timeout_ms,
+    )
+    t_banner = time.monotonic()
+    return {
+        "goto_ms": round((t_goto - t0) * 1000.0, 1),
+        "banner_ms": round((t_banner - t0) * 1000.0, 1),
+    }
+
+
+def append_e2e_first_paint_record(log_file: Path, payload: dict[str, Any]) -> None:
+    """Append one ``stage="e2e.first_paint"`` JSONL record to *log_file*.
+
+    Uses the same JSONL shape as ``EXPLORER_PERF_LOG_FILE`` events so the aggregator
+    (:mod:`scripts.aggregate_perf_jsonl`) can join app-side perf events with E2E-side
+    first-paint timings. Run-side identifier (``main_run_id``) is unknown from the
+    Playwright process, so callers should embed dataset / mode labels in *payload*.
+    Synthetic event uses ``run_kind="e2e"`` and ``fragment=None``.
+    """
+    import json
+    from datetime import datetime, timezone
+
+    rec: dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "stage": "e2e.first_paint",
+        "run_kind": "e2e",
+        "fragment": None,
+    }
+    rec.update(payload)
+    with open(log_file, "a", encoding="utf-8") as fp:
+        fp.write(json.dumps(rec, default=str) + "\n")
+
+
 def choose_map_view_mode(page: Any, label: str) -> None:
     """Pick a sidebar **Map view** option (*All locations*, *Lifer locations*, …)."""
     sidebar_map_view_select(page).click()

--- a/tests/explorer/test_aggregate_perf_jsonl.py
+++ b/tests/explorer/test_aggregate_perf_jsonl.py
@@ -1,0 +1,187 @@
+"""Tests for :mod:`scripts.aggregate_perf_jsonl` (#205 batch 4 I5)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = REPO_ROOT / "scripts" / "aggregate_perf_jsonl.py"
+
+
+def _load_module() -> Any:
+    """Import ``scripts/aggregate_perf_jsonl.py`` as a module (path isn't on PYTHONPATH)."""
+    spec = importlib.util.spec_from_file_location("aggregate_perf_jsonl", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["aggregate_perf_jsonl"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_parse_jsonl_skips_malformed_and_non_object_lines(tmp_path: Path) -> None:
+    """``parse_jsonl`` must tolerate stray log preludes / blank lines without raising."""
+    mod = _load_module()
+    f = tmp_path / "noisy.jsonl"
+    f.write_text(
+        "INFO some prelude\n"
+        '{"stage": "prep.x", "elapsed_ms": 1.5}\n'
+        "\n"
+        "not a json line\n"
+        '{"stage": "prep.y", "elapsed_ms": 2.0}\n',
+        encoding="utf-8",
+    )
+    out = mod.parse_jsonl(f)
+    assert [e["stage"] for e in out] == ["prep.x", "prep.y"]
+
+
+def test_percentile_handles_singletons_and_uses_nearest_rank() -> None:
+    """``percentile`` is the nearest-rank style used by the original /tmp aggregator."""
+    mod = _load_module()
+    assert mod.percentile([], 50.0) != mod.percentile([], 50.0)  # NaN
+    assert mod.percentile([42.0], 50.0) == 42.0
+    assert mod.percentile([1.0, 2.0, 3.0, 4.0, 5.0], 50.0) == 3.0
+    assert mod.percentile([1.0, 2.0, 3.0, 4.0, 5.0], 95.0) == 5.0
+
+
+def test_group_label_uses_named_captures() -> None:
+    mod = _load_module()
+    rx = re.compile(r"baseline-(?P<dataset>[^-]+)-r(?P<run>\d+)")
+    assert (
+        mod.group_label_for_filename("baseline-fixture-r2.jsonl", rx)
+        == "dataset=fixture/run=2"
+    )
+    # No match -> filename itself is the group label.
+    assert (
+        mod.group_label_for_filename("unmatched-name.jsonl", rx) == "unmatched-name.jsonl"
+    )
+    # No regex -> filename itself.
+    assert mod.group_label_for_filename("a.jsonl", None) == "a.jsonl"
+
+
+def test_aggregate_counts_events_and_summarises_elapsed_ms(tmp_path: Path) -> None:
+    mod = _load_module()
+    f1 = tmp_path / "baseline-fixture-r1.jsonl"
+    f2 = tmp_path / "baseline-fixture-r2.jsonl"
+    _write_jsonl(
+        f1,
+        [
+            {"stage": "prep.build_species_overlay_map", "elapsed_ms": 100.0},
+            {"stage": "prep.build_species_overlay_map", "elapsed_ms": 110.0},
+        ],
+    )
+    _write_jsonl(
+        f2,
+        [
+            {"stage": "prep.build_species_overlay_map", "elapsed_ms": 200.0},
+        ],
+    )
+    rx = re.compile(r"baseline-(?P<dataset>[^-]+)-r(?P<run>\d+)")
+    result = mod.aggregate(
+        [f1, f2],
+        group_regex=rx,
+        stages={"prep.build_species_overlay_map"},
+        extra_keys=[],
+    )
+    # Different runs -> different group labels (run-keyed).
+    assert set(result["groups"].keys()) == {
+        "dataset=fixture/run=1",
+        "dataset=fixture/run=2",
+    }
+    g1 = result["groups"]["dataset=fixture/run=1"]["stages"][
+        "prep.build_species_overlay_map"
+    ]
+    assert g1["n_runs"] == 1
+    assert g1["total_events"] == 2
+    assert g1["events_per_run"] == [2]
+    # Nearest-rank median on even-sample input picks the lower middle (same convention as
+    # the original /tmp/aggregate_w1_ab.py; ``round(0.5)`` is banker's-rounded to ``0``).
+    assert g1["elapsed_ms"]["median"] == 100.0
+    assert g1["elapsed_ms"]["max"] == 110.0
+    assert g1["elapsed_ms"]["n_samples"] == 2
+
+
+def test_aggregate_groups_collapsing_when_regex_only_captures_dataset(tmp_path: Path) -> None:
+    """Files differing only in run-number collapse into one group when the regex omits run capture."""
+    mod = _load_module()
+    f1 = tmp_path / "baseline-fixture-r1.jsonl"
+    f2 = tmp_path / "baseline-fixture-r2.jsonl"
+    f3 = tmp_path / "baseline-real-r1.jsonl"
+    _write_jsonl(f1, [{"stage": "s.a", "elapsed_ms": 10.0}])
+    _write_jsonl(f2, [{"stage": "s.a", "elapsed_ms": 20.0}])
+    _write_jsonl(f3, [{"stage": "s.a", "elapsed_ms": 1000.0}])
+    rx = re.compile(r"baseline-(?P<dataset>[^-]+)-r")
+    result = mod.aggregate(
+        [f1, f2, f3], group_regex=rx, stages=None, extra_keys=[]
+    )
+    assert set(result["groups"].keys()) == {"dataset=fixture", "dataset=real"}
+    fixture = result["groups"]["dataset=fixture"]["stages"]["s.a"]
+    assert fixture["n_runs"] == 2
+    assert fixture["events_per_run"] == [1, 1]
+    # Nearest-rank median on ``[10, 20]`` -> lower middle = 10.
+    assert fixture["elapsed_ms"]["median"] == 10.0
+
+
+def test_aggregate_pulls_extra_keys_from_nested_extra_and_top_level(tmp_path: Path) -> None:
+    """``extra_keys`` must look at both ``event.extra.<k>`` and top-level ``event.<k>``.
+
+    Top-level fallback is required for the E2E ``e2e.first_paint`` records since they store
+    fields like ``banner_ms`` at the top level rather than nested under ``extra``.
+    """
+    mod = _load_module()
+    f = tmp_path / "metrics.jsonl"
+    _write_jsonl(
+        f,
+        [
+            {
+                "stage": "prep.build_species_overlay_map",
+                "elapsed_ms": 100.0,
+                "extra": {"marker_count": 50, "popup_build_count": 10},
+            },
+            {
+                "stage": "e2e.first_paint",
+                "elapsed_ms": 5000.0,
+                "banner_ms": 5000.0,
+                "goto_ms": 800.0,
+            },
+        ],
+    )
+    result = mod.aggregate(
+        [f],
+        group_regex=None,
+        stages=None,
+        extra_keys=["marker_count", "banner_ms"],
+    )
+    stages = result["groups"]["metrics.jsonl"]["stages"]
+    assert stages["prep.build_species_overlay_map"]["extras"]["marker_count"]["max"] == 50
+    assert stages["e2e.first_paint"]["extras"]["banner_ms"]["max"] == 5000.0
+
+
+def test_render_text_includes_header_and_one_row_per_group_stage(tmp_path: Path) -> None:
+    mod = _load_module()
+    f = tmp_path / "a.jsonl"
+    _write_jsonl(f, [{"stage": "x", "elapsed_ms": 1.0}, {"stage": "y", "elapsed_ms": 2.0}])
+    result = mod.aggregate([f], group_regex=None, stages=None, extra_keys=[])
+    text = mod.render_text(result, [])
+    assert "group" in text
+    assert "stage" in text
+    assert "a.jsonl" in text
+    # Two stages -> two data rows + header + separator = at least 3 newlines.
+    assert text.count("\n") >= 4
+
+
+def test_main_returns_nonzero_for_missing_dir(tmp_path: Path) -> None:
+    mod = _load_module()
+    rc = mod.main([str(tmp_path / "does_not_exist")])
+    assert rc == 2

--- a/tests/explorer/test_map_controller.py
+++ b/tests/explorer/test_map_controller.py
@@ -349,3 +349,80 @@ def test_lifer_map_mode_builds_banner():
     assert "Lifer locations + subspecies" in html2
     assert "0 subspecies lifers" in html2.lower()
     assert "Visited:" not in html2
+
+
+def test_metrics_sink_populated_for_all_locations_view():
+    """``metrics_sink`` carries marker/popup counters back to the host (#205 batch 4 I1+I2)."""
+    df = _minimal_map_df()
+    sink: dict = {}
+    r = build_species_overlay_map(
+        **_common_kwargs(df),
+        selected_species="",
+        metrics_sink=sink,
+    )
+    assert r.warning is None
+    assert sink["view_path"] == "all_locations"
+    assert sink["marker_count"] == 1
+    # One location, no shared popup cache → exactly one popup is built, zero hits.
+    assert sink["popup_build_count"] == 1
+    assert sink["popup_cache_hit_count"] == 0
+    # Popup-build timing is real wall time and must be non-negative.
+    assert sink["popup_build_total_ms"] >= 0.0
+
+
+def test_metrics_sink_records_cache_hits_when_popup_cache_pre_warmed():
+    """A pre-warmed popup cache must report ``popup_cache_hit_count`` > 0 and zero builds."""
+    df = _minimal_map_df()
+    kwargs = _common_kwargs(df)
+    sink_cold: dict = {}
+    build_species_overlay_map(**kwargs, selected_species="", metrics_sink=sink_cold)
+    assert sink_cold["popup_build_count"] == 1
+    # Reuse the same caches (now warm) on a second build.
+    sink_warm: dict = {}
+    build_species_overlay_map(**kwargs, selected_species="", metrics_sink=sink_warm)
+    assert sink_warm["popup_build_count"] == 0
+    assert sink_warm["popup_cache_hit_count"] == 1
+
+
+def test_metrics_sink_populated_for_species_view():
+    df = _minimal_map_df()
+    sink: dict = {}
+    r = build_species_overlay_map(
+        **_common_kwargs(df),
+        selected_species="Anas gracilis",
+        selected_common_name="Grey Teal",
+        metrics_sink=sink,
+    )
+    assert r.warning is None
+    assert sink["view_path"] == "species"
+    assert sink["marker_count"] == 1
+    assert sink["popup_build_count"] == 1
+    assert sink["popup_cache_hit_count"] == 0
+    assert sink["popup_build_total_ms"] >= 0.0
+
+
+def test_metrics_sink_populated_for_lifer_view():
+    df = _minimal_map_df()
+    kwargs = _common_kwargs(df)
+    sink: dict = {}
+    r = build_species_overlay_map(
+        **kwargs,
+        selected_species="",
+        map_view_mode="lifers",
+        full_location_data=kwargs["location_data"],
+        metrics_sink=sink,
+    )
+    assert r.warning is None
+    assert sink["view_path"] == "lifer"
+    assert sink["marker_count"] == 1
+    assert sink["popup_build_count"] == 1
+    assert sink["popup_cache_hit_count"] == 0
+    assert sink["popup_build_total_ms"] >= 0.0
+
+
+def test_metrics_sink_default_none_is_a_no_op():
+    """Existing callers (no ``metrics_sink``) must continue to work unchanged."""
+    df = _minimal_map_df()
+    r = build_species_overlay_map(**_common_kwargs(df), selected_species="")
+    assert r.warning is None
+    assert r.map is not None

--- a/tests/explorer/test_map_perf_e2e.py
+++ b/tests/explorer/test_map_perf_e2e.py
@@ -22,9 +22,11 @@ pytest.importorskip("playwright.sync_api")
 
 from tests.explorer.e2e_support import (
     REPO_ROOT,
+    append_e2e_first_paint_record,
     choose_map_view_mode,
     launch_chromium_or_skip,
     max_elapsed_ms_by_stage,
+    measure_first_paint_ms,
     parse_perf_json_objects_from_log_lines,
     wait_for_pebird_map_markup,
 )
@@ -50,15 +52,27 @@ def test_map_perf_fixture_journey_emits_prep_stages_within_loose_ceiling(
 ) -> None:
     url, log_file = streamlit_perf_url_and_logfile
     ceilings = _load_stage_ceilings()
+    dataset_label = "real" if os.environ.get("EXPLORER_E2E_DATASET_CSV") else "fixture"
 
     with launch_chromium_or_skip() as browser:
         page = browser.new_page()
-        page.goto(url, wait_until="domcontentloaded")
-        page.get_by_text("Personal eBird Explorer").wait_for(timeout=20000)
-
-        wait_for_pebird_map_markup(
+        # I4 (#205 batch 4): measure end-to-end first paint *before* any other navigation work,
+        # so the timing captures the cold pipeline as a user would experience it.
+        first_paint = measure_first_paint_ms(
             page,
+            url,
             must_contain=['class="pebird-map-banner__title">All locations</span>'],
+        )
+        page.get_by_text("Personal eBird Explorer").wait_for(timeout=20000)
+        append_e2e_first_paint_record(
+            log_file,
+            {
+                "elapsed_ms": first_paint["banner_ms"],
+                "goto_ms": first_paint["goto_ms"],
+                "banner_ms": first_paint["banner_ms"],
+                "dataset_label": dataset_label,
+                "journey": "fixture_view_mode_cycle",
+            },
         )
         choose_map_view_mode(page, "Lifer locations")
         wait_for_pebird_map_markup(


### PR DESCRIPTION
## Summary

Ports the **Batch 4** performance instrumentation from the experimental investigation work into `beta-next` (cherry-pick of `f99d2e2` onto current `beta-next`). Tracking: closes #216; context [#205](https://github.com/jimchurches/myebirdstuff/issues/205).

### What changes

- **I1 + I2:** `build_species_overlay_map(..., metrics_sink=None)` — optional dict filled with `view_path`, `marker_count`, `popup_build_count`, `popup_cache_hit_count`, `popup_build_total_ms`. The Streamlit prep path passes the same dict into `perf_span(`\`prep.build_species_overlay_map\``, extra=...)` so each cache miss emits one enriched JSONL event when `EXPLORER_PERF=1`.
- **I4:** `measure_first_paint_ms` and `append_e2e_first_paint_record` in `tests/explorer/e2e_support.py`; the opt-in fixture perf journey appends `stage=e2e.first_paint` rows.
- **I5:** `scripts/aggregate_perf_jsonl.py` with unit tests in `tests/explorer/test_aggregate_perf_jsonl.py`.

No user-visible behaviour change when perf is off; `metrics_sink=None` is the default for all non-Streamlit callers.

### Verification

- `python -m pytest tests/explorer/` (excluding long E2E): **560 passed** locally.

### Note

`205-investigation-main` remains the home for experiments, baselines, and backlog edits; this PR is instrumentation only.

Closes #216

Made with [Cursor](https://cursor.com)