### PR TITLE
Add single-stack Leaflet map HTML export

### DIFF
--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -124,6 +124,7 @@ STREAMLIT_RESET_SETTINGS_BTN_KEY = "streamlit_reset_settings_btn"
 
 # Download/export button keys.
 EXPORT_MAP_HTML_BTN_KEY = "export_map_html_btn"
+EXPORT_MAP_HTML_BUILD_BTN_KEY = "export_map_html_build_btn"
 
 # Family map tab widget keys (refs #138). Highlight key is suffixed with selected family in the UI.
 STREAMLIT_FAMILY_MAP_FAMILY_KEY = "streamlit_family_map_family"
@@ -223,6 +224,10 @@ SPECIES_LEAFLET_PAYLOAD_CACHE_KEY = "_species_leaflet_payload_cache_v1"
 FAMILY_LEAFLET_PAYLOAD_CACHE_KEY = "_family_leaflet_payload_cache_v1"
 # Leaflet export HTML (``leaflet_map_to_html_bytes``) keyed by revision + overlay inputs.
 LEAFLET_EXPORT_HTML_CACHE_KEY = "_leaflet_export_html_cache_v1"
+# Inputs for on-demand export build (no HTML until user clicks export).
+LEAFLET_EXPORT_RECIPE_KEY = "_leaflet_export_recipe_v1"
+# Cache-key tuple for the last built Leaflet export matching the current recipe.
+LEAFLET_EXPORT_BUILT_CACHE_KEY = "_leaflet_export_built_cache_key_v1"
 # Go to GPS — session-only temporary marker (refs #199); never persisted to YAML.
 SESSION_GO_TO_GPS_PIN_KEY = "_session_go_to_gps_pin"
 STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY = "_streamlit_go_to_gps_draft_lat_txt"

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -221,6 +221,8 @@ LIFER_LEAFLET_PAYLOAD_CACHE_KEY = "_lifer_leaflet_payload_cache_v1"
 SPECIES_LEAFLET_PAYLOAD_CACHE_KEY = "_species_leaflet_payload_cache_v1"
 # Leaflet custom map (Family locations).
 FAMILY_LEAFLET_PAYLOAD_CACHE_KEY = "_family_leaflet_payload_cache_v1"
+# Leaflet export HTML (``leaflet_map_to_html_bytes``) keyed by revision + overlay inputs.
+LEAFLET_EXPORT_HTML_CACHE_KEY = "_leaflet_export_html_cache_v1"
 # Go to GPS — session-only temporary marker (refs #199); never persisted to YAML.
 SESSION_GO_TO_GPS_PIN_KEY = "_session_go_to_gps_pin"
 STREAMLIT_GO_TO_GPS_DRAFT_LAT_TEXT_KEY = "_streamlit_go_to_gps_draft_lat_txt"

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -5,8 +5,10 @@ Map build runs under the first spinner so the map can render before heavy checkl
 Leaflet Streamlit custom component; other modes use Folium + ``st_folium``. Tab session sync runs in a second spinner so
 other tabs get payloads before fragments run. Partial ``@st.fragment`` reruns do not use this path.
 
-**Export map HTML** uses :func:`~explorer.app.streamlit.map_working.folium_map_to_html_bytes` on a
-**deep-copied** Folium map (``branca`` mutates on render), with ``html_bytes`` cached on hit. The live
+**Export map HTML** (Folium path only) uses :func:`~explorer.app.streamlit.map_working.folium_map_to_html_bytes` on a
+**deep-copied** Folium map (``branca`` mutates on render), with ``html_bytes`` cached on hit. Leaflet
+component modes clear ``EXPLORER_MAP_HTML_BYTES_KEY`` — no parallel Folium build for export (#222 §7).
+The live
 Folium map uses **streamlit-folium** ``st_folium`` with a **deep copy** of the cached map so embed
 rendering cannot strip layers from the session cache. Session :data:`FOLIUM_STATIC_MAP_CACHE_KEY`
 stores unrendered Folium :class:`folium.Map` entries for the LRU. Leaflet GeoJSON payloads are cached under
@@ -72,6 +74,7 @@ from explorer.app.streamlit.checklist_stats_streamlit_html import (
 from explorer.app.streamlit.country_stats_streamlit_html import sync_country_tab_session_inputs
 from explorer.app.streamlit.maintenance_streamlit_html import sync_maintenance_tab_session_inputs
 from explorer.app.streamlit.map_working import folium_map_to_html_bytes
+from explorer.presentation.leaflet_map_html_export import leaflet_map_to_html_bytes
 from explorer.app.streamlit.rankings_streamlit_html import (
     build_rankings_tab_bundle,
     sync_rankings_tab_session_inputs,
@@ -562,7 +565,6 @@ def render_prep_spinner_and_map_tab(
                             blank_viewport_recipe=blank_viewport_recipe,
                             highlight_framed=family_highlight_framed,
                         )
-                    st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
                 else:
                     overlay_common = (
                         (species_pick_common or "").strip() if map_view_mode == "species" else ""
@@ -792,7 +794,6 @@ def render_prep_spinner_and_map_tab(
                         result_map = None
                         result_warning = None
                         folium_st_key = None
-                        st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
                     elif use_lifer_leaflet:
                         result_warning = None
                         leaflet_cluster_opts = {
@@ -904,7 +905,6 @@ def render_prep_spinner_and_map_tab(
                                     )
                         result_map = None
                         folium_st_key = None
-                        st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
                     elif use_species_leaflet:
                         result_warning = None
                         leaflet_cluster_opts = {
@@ -1066,7 +1066,6 @@ def render_prep_spinner_and_map_tab(
                                     )
                         result_map = None
                         folium_st_key = None
-                        st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
                     else:
                         _cached = _map_cache_lookup(_ck)
                         if isinstance(_cached, dict) and _cached.get("map") is not None:
@@ -1111,14 +1110,31 @@ def render_prep_spinner_and_map_tab(
                                     },
                                 )
 
-                if use_all_locations_leaflet and leaflet_revision and leaflet_geojson is not None:
-                    pass
-                elif use_lifer_leaflet and leaflet_revision and leaflet_geojson is not None:
-                    pass
-                elif use_species_leaflet and leaflet_revision and leaflet_geojson is not None:
-                    pass
-                elif use_family_leaflet and leaflet_revision and leaflet_geojson is not None:
-                    pass
+                if (
+                    (
+                        use_all_locations_leaflet
+                        or use_lifer_leaflet
+                        or use_species_leaflet
+                        or use_family_leaflet
+                    )
+                    and leaflet_revision
+                    and leaflet_geojson is not None
+                    and leaflet_cluster_opts is not None
+                    and leaflet_circle_style is not None
+                ):
+                    with perf_span("prep.leaflet_map_to_html_bytes"):
+                        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = leaflet_map_to_html_bytes(
+                            geojson=leaflet_geojson,
+                            height=int(map_height),
+                            map_style=map_style,
+                            cluster_options=leaflet_cluster_opts,
+                            circle_marker_style=leaflet_circle_style,
+                            cluster_icon_style=leaflet_cluster_icon_style or {},
+                            viewport=leaflet_viewport or {},
+                            map_theme_css=map_overlay_theme_stylesheet(),
+                            banner_html=all_locations_leaflet_banner_html,
+                            legend_html=all_locations_leaflet_legend_html,
+                        )
                 elif result_warning:
                     map_warning_text = result_warning
                     st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -5,11 +5,10 @@ Map build runs under the first spinner so the map can render before heavy checkl
 Leaflet Streamlit custom component; other modes use Folium + ``st_folium``. Tab session sync runs in a second spinner so
 other tabs get payloads before fragments run. Partial ``@st.fragment`` reruns do not use this path.
 
-**Export map HTML:** Leaflet modes use
-:func:`~explorer.presentation.leaflet_map_html_export.leaflet_map_to_html_bytes` with bytes cached under
-:data:`LEAFLET_EXPORT_HTML_CACHE_KEY` (revision + basemap, viewport, banner/legend, etc.). Folium modes use
-:func:`~explorer.app.streamlit.map_working.folium_map_to_html_bytes` on a **deep-copied** map, with ``html_bytes``
-cached on the map LRU hit.
+**Export map HTML:** Leaflet modes store an export **recipe** in session
+(:data:`LEAFLET_EXPORT_RECIPE_KEY`); ``leaflet_map_to_html_bytes`` runs only when the user clicks export, with
+results cached under :data:`LEAFLET_EXPORT_HTML_CACHE_KEY`. Folium modes still build ``html_bytes`` during prep
+(cached on the map LRU hit).
 The live
 Folium map uses **streamlit-folium** ``st_folium`` with a **deep copy** of the cached map so embed
 rendering cannot strip layers from the session cache. Session :data:`FOLIUM_STATIC_MAP_CACHE_KEY`
@@ -40,11 +39,14 @@ from explorer.app.streamlit.app_caches import (
 from explorer.app.streamlit.app_constants import (
     ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY,
     FAMILY_LEAFLET_PAYLOAD_CACHE_KEY,
+    LEAFLET_EXPORT_BUILT_CACHE_KEY,
     LEAFLET_EXPORT_HTML_CACHE_KEY,
+    LEAFLET_EXPORT_RECIPE_KEY,
     LIFER_LEAFLET_PAYLOAD_CACHE_KEY,
     SPECIES_LEAFLET_PAYLOAD_CACHE_KEY,
     EBIRD_DATA_SIG_KEY,
     EXPLORER_MAP_HTML_BYTES_KEY,
+    EXPORT_MAP_HTML_BUILD_BTN_KEY,
     EXPORT_MAP_HTML_BTN_KEY,
     FILTERED_BY_LOC_CACHE_KEY,
     FOLIUM_MAP_MOUNT_NONCE_KEY,
@@ -199,6 +201,79 @@ def _leaflet_export_html_cache_store(cache_key: tuple[str, ...], html_bytes: byt
     st.session_state[LEAFLET_EXPORT_HTML_CACHE_KEY] = cached
 
 
+def _leaflet_export_cache_key_for_recipe(recipe: dict[str, Any]) -> tuple[str, ...]:
+    return leaflet_export_html_cache_key(
+        leaflet_revision=str(recipe["leaflet_revision"]),
+        map_height=int(recipe["map_height"]),
+        map_style=str(recipe.get("map_style") or "default"),
+        cluster_options=recipe.get("cluster_options") or {},
+        circle_marker_style=recipe.get("circle_marker_style") or {},
+        cluster_icon_style=recipe.get("cluster_icon_style") or {},
+        viewport=recipe.get("viewport") or {},
+        map_theme_css=str(recipe.get("map_theme_css") or ""),
+        banner_html=str(recipe.get("banner_html") or ""),
+        legend_html=str(recipe.get("legend_html") or ""),
+    )
+
+
+def _materialize_leaflet_export_html(recipe: dict[str, Any]) -> bytes:
+    cache_key = _leaflet_export_cache_key_for_recipe(recipe)
+    cached = _leaflet_export_html_cache_lookup(cache_key)
+    if cached is not None:
+        perf_record_point("prep.leaflet_map_html_cache_hit")
+        return cached
+    perf_record_point("prep.leaflet_map_html_cache_miss")
+    with perf_span("prep.leaflet_map_to_html_bytes"):
+        built = leaflet_map_to_html_bytes(
+            geojson=recipe["geojson"],
+            height=int(recipe["map_height"]),
+            map_style=str(recipe.get("map_style") or "default"),
+            cluster_options=recipe.get("cluster_options") or {},
+            circle_marker_style=recipe.get("circle_marker_style") or {},
+            cluster_icon_style=recipe.get("cluster_icon_style") or {},
+            viewport=recipe.get("viewport") or {},
+            map_theme_css=str(recipe.get("map_theme_css") or ""),
+            banner_html=str(recipe.get("banner_html") or ""),
+            legend_html=str(recipe.get("legend_html") or ""),
+        )
+    _leaflet_export_html_cache_store(cache_key, built)
+    return built
+
+
+def _sync_leaflet_export_recipe(
+    *,
+    leaflet_revision: str,
+    leaflet_geojson: dict[str, Any],
+    map_height: int,
+    map_style: str,
+    leaflet_cluster_opts: dict[str, Any],
+    leaflet_circle_style: dict[str, Any],
+    leaflet_cluster_icon_style: dict[str, Any] | None,
+    leaflet_viewport: dict[str, Any] | None,
+    banner_html: str,
+    legend_html: str,
+) -> None:
+    """Store export inputs; clear stale download bytes when the recipe changes."""
+    recipe = {
+        "leaflet_revision": leaflet_revision,
+        "geojson": leaflet_geojson,
+        "map_height": int(map_height),
+        "map_style": str(map_style or "default"),
+        "cluster_options": leaflet_cluster_opts,
+        "circle_marker_style": leaflet_circle_style,
+        "cluster_icon_style": leaflet_cluster_icon_style or {},
+        "viewport": leaflet_viewport or {},
+        "map_theme_css": map_overlay_theme_stylesheet(),
+        "banner_html": banner_html,
+        "legend_html": legend_html,
+    }
+    st.session_state[LEAFLET_EXPORT_RECIPE_KEY] = recipe
+    recipe_key = _leaflet_export_cache_key_for_recipe(recipe)
+    if st.session_state.get(LEAFLET_EXPORT_BUILT_CACHE_KEY) != recipe_key:
+        st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
+        st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
+
+
 def _leaflet_payload_cache_lookup(
     session_key: str,
     payload_cache_key: tuple[Any, ...],
@@ -325,6 +400,8 @@ def render_prep_spinner_and_map_tab(
                     st.session_state.pop(SPECIES_LEAFLET_PAYLOAD_CACHE_KEY, None)
                     st.session_state.pop(FAMILY_LEAFLET_PAYLOAD_CACHE_KEY, None)
                     st.session_state.pop(LEAFLET_EXPORT_HTML_CACHE_KEY, None)
+                    st.session_state.pop(LEAFLET_EXPORT_RECIPE_KEY, None)
+                    st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
 
             map_warning_text: str | None = None
             map_hint_text: str | None = None
@@ -336,6 +413,8 @@ def render_prep_spinner_and_map_tab(
             except ValueError as e:
                 map_warning_text = str(e)
                 st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
+                st.session_state.pop(LEAFLET_EXPORT_RECIPE_KEY, None)
+                st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
             else:
                 # Blank-map viewport recipe (session-only): same framing recipe as all-data All locations
                 # for non-country scopes, so Species/Families blank maps match the initial data framing.
@@ -1149,46 +1228,31 @@ def render_prep_spinner_and_map_tab(
                     and leaflet_cluster_opts is not None
                     and leaflet_circle_style is not None
                 ):
-                    _export_cache_key = leaflet_export_html_cache_key(
+                    _sync_leaflet_export_recipe(
                         leaflet_revision=leaflet_revision,
+                        leaflet_geojson=leaflet_geojson,
                         map_height=int(map_height),
                         map_style=map_style,
-                        cluster_options=leaflet_cluster_opts,
-                        circle_marker_style=leaflet_circle_style,
-                        cluster_icon_style=leaflet_cluster_icon_style or {},
-                        viewport=leaflet_viewport or {},
-                        map_theme_css=map_overlay_theme_stylesheet(),
+                        leaflet_cluster_opts=leaflet_cluster_opts,
+                        leaflet_circle_style=leaflet_circle_style,
+                        leaflet_cluster_icon_style=leaflet_cluster_icon_style,
+                        leaflet_viewport=leaflet_viewport,
                         banner_html=all_locations_leaflet_banner_html,
                         legend_html=all_locations_leaflet_legend_html,
                     )
-                    _cached_export_html = _leaflet_export_html_cache_lookup(_export_cache_key)
-                    if _cached_export_html is not None:
-                        perf_record_point("prep.leaflet_map_html_cache_hit")
-                        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = _cached_export_html
-                    else:
-                        perf_record_point("prep.leaflet_map_html_cache_miss")
-                        with perf_span("prep.leaflet_map_to_html_bytes"):
-                            _built_export_html = leaflet_map_to_html_bytes(
-                                geojson=leaflet_geojson,
-                                height=int(map_height),
-                                map_style=map_style,
-                                cluster_options=leaflet_cluster_opts,
-                                circle_marker_style=leaflet_circle_style,
-                                cluster_icon_style=leaflet_cluster_icon_style or {},
-                                viewport=leaflet_viewport or {},
-                                map_theme_css=map_overlay_theme_stylesheet(),
-                                banner_html=all_locations_leaflet_banner_html,
-                                legend_html=all_locations_leaflet_legend_html,
-                            )
-                        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = _built_export_html
-                        _leaflet_export_html_cache_store(_export_cache_key, _built_export_html)
                 elif result_warning:
                     map_warning_text = result_warning
                     st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
+                    st.session_state.pop(LEAFLET_EXPORT_RECIPE_KEY, None)
+                    st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
                 elif result_map is None:
                     map_warning_text = "Map could not be built."
                     st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
+                    st.session_state.pop(LEAFLET_EXPORT_RECIPE_KEY, None)
+                    st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
                 else:
+                    st.session_state.pop(LEAFLET_EXPORT_RECIPE_KEY, None)
+                    st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
                     _cached_for_html = _map_cache_lookup(_ck)
                     _cached_html = (
                         _cached_for_html.get("html_bytes")
@@ -1337,22 +1401,56 @@ def render_prep_spinner_and_map_tab(
                 sync_country_tab_session_inputs(checklist_payload)
 
         _spinner_emoji_placeholder.empty()
-        _has_map_export = bool(st.session_state.get(EXPLORER_MAP_HTML_BYTES_KEY))
+        _leaflet_recipe = st.session_state.get(LEAFLET_EXPORT_RECIPE_KEY)
+        _export_html_bytes = st.session_state.get(EXPLORER_MAP_HTML_BYTES_KEY)
+        _has_map_export = _leaflet_recipe is not None or _export_html_bytes is not None
         if _has_map_export:
             st.divider()
             _ex1, _ex2, _ex3 = st.columns([1, 3, 1])
             with _ex2:
-                # Match outline “Buy me a coffee” pill (``st.download_button`` is a real widget, not an ``<a>``).
                 inject_sidebar_outline_download_button_css(SIDEBAR_FOOTER_LINK_HEX)
-                st.download_button(
-                    "Export map HTML",
-                    data=st.session_state[EXPLORER_MAP_HTML_BYTES_KEY],
-                    file_name=MAP_EXPORT_HTML_FILENAME,
-                    mime="text/html",
-                    key=EXPORT_MAP_HTML_BTN_KEY,
-                    help="Standalone HTML for the current map.",
-                    use_container_width=True,
-                    type="secondary",
-                )
+                if isinstance(_leaflet_recipe, dict):
+                    _recipe_key = _leaflet_export_cache_key_for_recipe(_leaflet_recipe)
+                    _built_key = st.session_state.get(LEAFLET_EXPORT_BUILT_CACHE_KEY)
+                    _ready_bytes = (
+                        _export_html_bytes
+                        if isinstance(_export_html_bytes, (bytes, bytearray))
+                        and _built_key == _recipe_key
+                        else None
+                    )
+                    if _ready_bytes is not None:
+                        st.download_button(
+                            "Export map HTML",
+                            data=bytes(_ready_bytes),
+                            file_name=MAP_EXPORT_HTML_FILENAME,
+                            mime="text/html",
+                            key=EXPORT_MAP_HTML_BTN_KEY,
+                            help="Download standalone HTML for the current map.",
+                            use_container_width=True,
+                            type="secondary",
+                        )
+                    elif st.button(
+                        "Export map HTML",
+                        key=EXPORT_MAP_HTML_BUILD_BTN_KEY,
+                        help="Builds the HTML file on click (large maps may take a moment).",
+                        use_container_width=True,
+                        type="secondary",
+                    ):
+                        with st.spinner("Building map HTML…"):
+                            _built = _materialize_leaflet_export_html(_leaflet_recipe)
+                        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = _built
+                        st.session_state[LEAFLET_EXPORT_BUILT_CACHE_KEY] = _recipe_key
+                        st.rerun()
+                elif isinstance(_export_html_bytes, (bytes, bytearray)):
+                    st.download_button(
+                        "Export map HTML",
+                        data=bytes(_export_html_bytes),
+                        file_name=MAP_EXPORT_HTML_FILENAME,
+                        mime="text/html",
+                        key=EXPORT_MAP_HTML_BTN_KEY,
+                        help="Standalone HTML for the current map.",
+                        use_container_width=True,
+                        type="secondary",
+                    )
         sidebar_footer_links(leading_divider=not _has_map_export)
         sidebar_bottom_slot_end()

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -1425,14 +1425,12 @@ def render_prep_spinner_and_map_tab(
                             file_name=MAP_EXPORT_HTML_FILENAME,
                             mime="text/html",
                             key=EXPORT_MAP_HTML_BTN_KEY,
-                            help="Download standalone HTML for the current map.",
                             use_container_width=True,
                             type="secondary",
                         )
                     elif st.button(
                         "Export map HTML",
                         key=EXPORT_MAP_HTML_BUILD_BTN_KEY,
-                        help="Builds the HTML file on click (large maps may take a moment).",
                         use_container_width=True,
                         type="secondary",
                     ):
@@ -1448,7 +1446,6 @@ def render_prep_spinner_and_map_tab(
                         file_name=MAP_EXPORT_HTML_FILENAME,
                         mime="text/html",
                         key=EXPORT_MAP_HTML_BTN_KEY,
-                        help="Standalone HTML for the current map.",
                         use_container_width=True,
                         type="secondary",
                     )

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -5,9 +5,11 @@ Map build runs under the first spinner so the map can render before heavy checkl
 Leaflet Streamlit custom component; other modes use Folium + ``st_folium``. Tab session sync runs in a second spinner so
 other tabs get payloads before fragments run. Partial ``@st.fragment`` reruns do not use this path.
 
-**Export map HTML** (Folium path only) uses :func:`~explorer.app.streamlit.map_working.folium_map_to_html_bytes` on a
-**deep-copied** Folium map (``branca`` mutates on render), with ``html_bytes`` cached on hit. Leaflet
-component modes clear ``EXPLORER_MAP_HTML_BYTES_KEY`` — no parallel Folium build for export (#222 §7).
+**Export map HTML:** Leaflet modes use
+:func:`~explorer.presentation.leaflet_map_html_export.leaflet_map_to_html_bytes` with bytes cached under
+:data:`LEAFLET_EXPORT_HTML_CACHE_KEY` (revision + basemap, viewport, banner/legend, etc.). Folium modes use
+:func:`~explorer.app.streamlit.map_working.folium_map_to_html_bytes` on a **deep-copied** map, with ``html_bytes``
+cached on the map LRU hit.
 The live
 Folium map uses **streamlit-folium** ``st_folium`` with a **deep copy** of the cached map so embed
 rendering cannot strip layers from the session cache. Session :data:`FOLIUM_STATIC_MAP_CACHE_KEY`
@@ -38,6 +40,7 @@ from explorer.app.streamlit.app_caches import (
 from explorer.app.streamlit.app_constants import (
     ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY,
     FAMILY_LEAFLET_PAYLOAD_CACHE_KEY,
+    LEAFLET_EXPORT_HTML_CACHE_KEY,
     LIFER_LEAFLET_PAYLOAD_CACHE_KEY,
     SPECIES_LEAFLET_PAYLOAD_CACHE_KEY,
     EBIRD_DATA_SIG_KEY,
@@ -74,6 +77,7 @@ from explorer.app.streamlit.checklist_stats_streamlit_html import (
 from explorer.app.streamlit.country_stats_streamlit_html import sync_country_tab_session_inputs
 from explorer.app.streamlit.maintenance_streamlit_html import sync_maintenance_tab_session_inputs
 from explorer.app.streamlit.map_working import folium_map_to_html_bytes
+from explorer.presentation.leaflet_map_export_cache import leaflet_export_html_cache_key
 from explorer.presentation.leaflet_map_html_export import leaflet_map_to_html_bytes
 from explorer.app.streamlit.rankings_streamlit_html import (
     build_rankings_tab_bundle,
@@ -171,6 +175,28 @@ _MAP_RENDER_CACHE_MAX_ENTRIES = 6
 # Species map: cache hide-only vs all-locations payloads separately (toggle thrashes a single slot).
 _SPECIES_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES = 2
 _FAMILY_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES = 4
+_LEAFLET_EXPORT_HTML_CACHE_MAX_ENTRIES = 6
+
+
+def _leaflet_export_html_cache_lookup(cache_key: tuple[str, ...]) -> bytes | None:
+    cached = st.session_state.get(LEAFLET_EXPORT_HTML_CACHE_KEY)
+    if isinstance(cached, OrderedDict):
+        entry = cached.get(cache_key)
+        if isinstance(entry, (bytes, bytearray)):
+            cached.move_to_end(cache_key)
+            return bytes(entry)
+    return None
+
+
+def _leaflet_export_html_cache_store(cache_key: tuple[str, ...], html_bytes: bytes) -> None:
+    cached = st.session_state.get(LEAFLET_EXPORT_HTML_CACHE_KEY)
+    if not isinstance(cached, OrderedDict):
+        cached = OrderedDict()
+    cached[cache_key] = html_bytes
+    cached.move_to_end(cache_key)
+    while len(cached) > _LEAFLET_EXPORT_HTML_CACHE_MAX_ENTRIES:
+        cached.popitem(last=False)
+    st.session_state[LEAFLET_EXPORT_HTML_CACHE_KEY] = cached
 
 
 def _leaflet_payload_cache_lookup(
@@ -298,6 +324,7 @@ def render_prep_spinner_and_map_tab(
                     st.session_state.pop(LIFER_LEAFLET_PAYLOAD_CACHE_KEY, None)
                     st.session_state.pop(SPECIES_LEAFLET_PAYLOAD_CACHE_KEY, None)
                     st.session_state.pop(FAMILY_LEAFLET_PAYLOAD_CACHE_KEY, None)
+                    st.session_state.pop(LEAFLET_EXPORT_HTML_CACHE_KEY, None)
 
             map_warning_text: str | None = None
             map_hint_text: str | None = None
@@ -1122,19 +1149,39 @@ def render_prep_spinner_and_map_tab(
                     and leaflet_cluster_opts is not None
                     and leaflet_circle_style is not None
                 ):
-                    with perf_span("prep.leaflet_map_to_html_bytes"):
-                        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = leaflet_map_to_html_bytes(
-                            geojson=leaflet_geojson,
-                            height=int(map_height),
-                            map_style=map_style,
-                            cluster_options=leaflet_cluster_opts,
-                            circle_marker_style=leaflet_circle_style,
-                            cluster_icon_style=leaflet_cluster_icon_style or {},
-                            viewport=leaflet_viewport or {},
-                            map_theme_css=map_overlay_theme_stylesheet(),
-                            banner_html=all_locations_leaflet_banner_html,
-                            legend_html=all_locations_leaflet_legend_html,
-                        )
+                    _export_cache_key = leaflet_export_html_cache_key(
+                        leaflet_revision=leaflet_revision,
+                        map_height=int(map_height),
+                        map_style=map_style,
+                        cluster_options=leaflet_cluster_opts,
+                        circle_marker_style=leaflet_circle_style,
+                        cluster_icon_style=leaflet_cluster_icon_style or {},
+                        viewport=leaflet_viewport or {},
+                        map_theme_css=map_overlay_theme_stylesheet(),
+                        banner_html=all_locations_leaflet_banner_html,
+                        legend_html=all_locations_leaflet_legend_html,
+                    )
+                    _cached_export_html = _leaflet_export_html_cache_lookup(_export_cache_key)
+                    if _cached_export_html is not None:
+                        perf_record_point("prep.leaflet_map_html_cache_hit")
+                        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = _cached_export_html
+                    else:
+                        perf_record_point("prep.leaflet_map_html_cache_miss")
+                        with perf_span("prep.leaflet_map_to_html_bytes"):
+                            _built_export_html = leaflet_map_to_html_bytes(
+                                geojson=leaflet_geojson,
+                                height=int(map_height),
+                                map_style=map_style,
+                                cluster_options=leaflet_cluster_opts,
+                                circle_marker_style=leaflet_circle_style,
+                                cluster_icon_style=leaflet_cluster_icon_style or {},
+                                viewport=leaflet_viewport or {},
+                                map_theme_css=map_overlay_theme_stylesheet(),
+                                banner_html=all_locations_leaflet_banner_html,
+                                legend_html=all_locations_leaflet_legend_html,
+                            )
+                        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = _built_export_html
+                        _leaflet_export_html_cache_store(_export_cache_key, _built_export_html)
                 elif result_warning:
                     map_warning_text = result_warning
                     st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -97,7 +97,7 @@ Implemented in `AllLocationsMap.tsx` (`syncGoToGpsMarker`, `goToGpsMarkerIcon`) 
 
 ## 7. Export map HTML — **done (single-stack HTML)**
 
-**Shipped (branch ``222-export-map-html``):** Leaflet maps export via ``leaflet_map_to_html_bytes`` — standalone HTML with CDN Leaflet 1.9.4 + MarkerCluster, same GeoJSON/theme/banner/legend as the live component. Popups pre-rendered in Python (``popup_v1_export_html``) into ``export_popup_html`` on each feature; viewer in ``explorer/presentation/static/leaflet_map_export.js``. Prep sets ``EXPLORER_MAP_HTML_BYTES_KEY`` for all four Leaflet modes (sidebar **Export map HTML** visible again).
+**Shipped (branch ``222-export-map-html``):** Leaflet maps export via ``leaflet_map_to_html_bytes`` — standalone HTML with CDN Leaflet 1.9.4 + MarkerCluster, same GeoJSON/theme/banner/legend as the live component. Popups pre-rendered in Python (``popup_v1_export_html``) into ``export_popup_html`` on each feature; viewer in ``explorer/presentation/static/leaflet_map_export.js``. Prep stores ``LEAFLET_EXPORT_RECIPE_KEY`` only; HTML builds on sidebar **Export map HTML** click (§8 LRU cache for repeat downloads).
 
 **Constraints:** Downloaded file needs network for tiles + CDN scripts. Not fully offline.
 
@@ -117,7 +117,7 @@ Implemented in `AllLocationsMap.tsx` (`syncGoToGpsMarker`, `goToGpsMarkerIcon`) 
 ## 8. Performance / benchmarks (#205)
 
 - Optional: extend map perf harness / snapshots for the component path vs Folium HTML size and interaction.
-- ~~**Leaflet export HTML cache (§7 follow-up):**~~ **Done** — ``LEAFLET_EXPORT_HTML_CACHE_KEY`` LRU (6 entries) keyed by ``leaflet_export_html_cache_key`` (revision + height, basemap, cluster/circle/viewport, theme, banner, legend). Warm reruns emit ``prep.leaflet_map_html_cache_hit``; cleared on eBird data signature change.
+- ~~**Leaflet export HTML cache (§7 follow-up):**~~ **Done** — ``LEAFLET_EXPORT_HTML_CACHE_KEY`` LRU (6 entries) keyed by ``leaflet_export_html_cache_key``. Build runs **on export button click** only (recipe in ``LEAFLET_EXPORT_RECIPE_KEY`` during prep); repeat export for the same map uses cache hit. Cleared on eBird data signature change.
 
 ---
 

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -103,11 +103,21 @@ Implemented in `AllLocationsMap.tsx` (`syncGoToGpsMarker`, `goToGpsMarkerIcon`) 
 
 **No dual stack:** Folium builders are not run for export on Leaflet paths.
 
+### Testing
+
+**Shipped:** `tests/explorer/test_leaflet_map_html_export.py` — all-locations ``popup_v1``, ``javascript:`` href blocked, integration smoke; `tests/explorer/test_leaflet_map_export_cache.py` — export cache keys; `tests/explorer/test_stats_html_helpers.py` — ``safe_http_url``.
+
+**Do (export popup HTML):**
+
+- Add tests for ``lifer_popup_v1``, ``family_popup_v1``, and ``species_popup_v1`` via ``popup_export_html_from_properties`` (minimal fixture per mode; assert mode-specific markup classes / structure).
+- **Optional:** Assert banner/legend fragments passed to ``leaflet_map_to_html_bytes`` appear in the decoded HTML (e.g. ``pebird-map-banner``, ``pebird-map-legend`` inside ``pebird-export-map-host``).
+
 ---
 
 ## 8. Performance / benchmarks (#205)
 
 - Optional: extend map perf harness / snapshots for the component path vs Folium HTML size and interaction.
+- ~~**Leaflet export HTML cache (§7 follow-up):**~~ **Done** — ``LEAFLET_EXPORT_HTML_CACHE_KEY`` LRU (6 entries) keyed by ``leaflet_export_html_cache_key`` (revision + height, basemap, cluster/circle/viewport, theme, banner, legend). Warm reruns emit ``prep.leaflet_map_html_cache_hit``; cleared on eBird data signature change.
 
 ---
 

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -5,7 +5,7 @@ Update this file as items ship so the backlog stays visible outside chat history
 
 **Related:** [README.md](./README.md) (build, clustering, banner/legend, popups).
 
-**Working principles (#222):** All four Map-tab modes now use the Leaflet component in production prep. Legacy Folium builders remain for tests and optional export paths until §7 — defer cross-stack DRY and deep edge-case polish until Folium is removed.
+**Working principles (#222):** All four Map-tab modes now use the Leaflet component in production prep. Legacy Folium builders remain for **unit tests only** until Folium removal — **not** for production map display or export (§7 rules out a parallel Folium export stack). Defer cross-stack DRY and deep edge-case polish until Folium is removed.
 
 ---
 
@@ -95,9 +95,13 @@ Implemented in `AllLocationsMap.tsx` (`syncGoToGpsMarker`, `goToGpsMarkerIcon`) 
 
 ---
 
-## 7. Export map HTML
+## 7. Export map HTML — **done (single-stack HTML)**
 
-- Export path today serializes Folium. All component map modes clear `EXPLORER_MAP_HTML_BYTES_KEY` in prep — sidebar **Export map HTML** is hidden on Leaflet embeds. Decide whether component maps need HTML export or a different artifact.
+**Shipped (branch ``222-export-map-html``):** Leaflet maps export via ``leaflet_map_to_html_bytes`` — standalone HTML with CDN Leaflet 1.9.4 + MarkerCluster, same GeoJSON/theme/banner/legend as the live component. Popups pre-rendered in Python (``popup_v1_export_html``) into ``export_popup_html`` on each feature; viewer in ``explorer/presentation/static/leaflet_map_export.js``. Prep sets ``EXPLORER_MAP_HTML_BYTES_KEY`` for all four Leaflet modes (sidebar **Export map HTML** visible again).
+
+**Constraints:** Downloaded file needs network for tiles + CDN scripts. Not fully offline.
+
+**No dual stack:** Folium builders are not run for export on Leaflet paths.
 
 ---
 
@@ -243,7 +247,7 @@ From post–PR #226 code review. **Not blocking** merge; revisit during Folium r
 
 1. Merge **`222-family-locations-leaflet`** → `beta-next`, dogfood, close **#222** (or keep open for cleanup epic).
 2. ~~§11 — zoom debug overlay on component maps.~~ **Done** on ``222-zoom-debug-overlay``.
-3. §7 — export strategy for Leaflet modes.
+3. ~~§7 — export strategy for Leaflet modes.~~ **Done** on ``222-export-map-html``.
 4. §10 — documentation pass; optional rename of `all_locations_map` component directory.
 5. Remove or gate Folium map builders; §13–§14 cache polish; §15 popup typography pass; §8 perf (#205).
 6. Standalone comments: remaining `refs #NNN` in `map_renderer.py` docstrings (popup HTML builders) — batch cleanup.

--- a/explorer/presentation/leaflet_map_export_cache.py
+++ b/explorer/presentation/leaflet_map_export_cache.py
@@ -1,0 +1,44 @@
+"""Cache-key helpers for Leaflet standalone map HTML export."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def _digest_json(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _digest_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def leaflet_export_html_cache_key(
+    *,
+    leaflet_revision: str,
+    map_height: int,
+    map_style: str,
+    cluster_options: dict[str, Any],
+    circle_marker_style: dict[str, Any],
+    cluster_icon_style: dict[str, Any],
+    viewport: dict[str, Any],
+    map_theme_css: str,
+    banner_html: str,
+    legend_html: str,
+) -> tuple[str, ...]:
+    """Stable session-cache key for :func:`~explorer.presentation.leaflet_map_html_export.leaflet_map_to_html_bytes` output."""
+    return (
+        str(leaflet_revision),
+        str(int(map_height)),
+        str(map_style or "default"),
+        _digest_json(cluster_options or {}),
+        _digest_json(circle_marker_style or {}),
+        _digest_json(cluster_icon_style or {}),
+        _digest_json(viewport or {}),
+        _digest_text(map_theme_css or ""),
+        _digest_text(banner_html or ""),
+        _digest_text(legend_html or ""),
+    )

--- a/explorer/presentation/leaflet_map_html_export.py
+++ b/explorer/presentation/leaflet_map_html_export.py
@@ -99,10 +99,14 @@ def leaflet_map_to_html_bytes(
 </style>
 </head>
 <body>
+<div class="pebird-export-shell">
+<div class="pebird-export-map-host">
 {banner}
 <div id="pebird-export-map"></div>
 {legend}
+</div>
 <p class="pebird-export-meta">Exported from Personal eBird Explorer — map tiles load from the internet.</p>
+</div>
 <script type="application/json" id="pebird-map-export-config">{config_json}</script>
 <script src="{_LEAFLET_JS}"></script>
 <script src="{_CLUSTER_JS}"></script>

--- a/explorer/presentation/leaflet_map_html_export.py
+++ b/explorer/presentation/leaflet_map_html_export.py
@@ -1,0 +1,115 @@
+"""Standalone HTML export for Leaflet map component embeds (#222 §7).
+
+Single-stack: uses the same GeoJSON + theme CSS as production, with a small vanilla JS viewer
+(``static/leaflet_map_export.js``). No Folium build at export time.
+"""
+
+from __future__ import annotations
+
+import html as html_module
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from explorer.presentation.popup_v1_export_html import enrich_geojson_for_export
+
+_STATIC = Path(__file__).resolve().parent / "static"
+_COMPONENT_CSS = (
+    Path(__file__).resolve().parents[1]
+    / "components"
+    / "all_locations_map"
+    / "frontend"
+    / "src"
+    / "AllLocationsMapPopup.css"
+)
+
+_LEAFLET_CSS = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+_LEAFLET_JS = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+_CLUSTER_CSS = "https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css"
+_CLUSTER_DEFAULT_CSS = (
+    "https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css"
+)
+_CLUSTER_JS = "https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"
+
+
+def _read_static(name: str) -> str:
+    return (_STATIC / name).read_text(encoding="utf-8")
+
+
+def _extract_style_inner(css_bundle: str) -> str:
+    parts = re.findall(r"<style[^>]*>(.*?)</style>", css_bundle, flags=re.DOTALL | re.IGNORECASE)
+    return "\n".join(p.strip() for p in parts if p.strip())
+
+
+def _json_for_script(data: Any) -> str:
+    raw = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return raw.replace("</", "<\\/")
+
+
+def leaflet_map_to_html_bytes(
+    *,
+    geojson: dict[str, Any],
+    height: int,
+    map_style: str = "default",
+    cluster_options: dict[str, Any] | None = None,
+    circle_marker_style: dict[str, Any] | None = None,
+    cluster_icon_style: dict[str, Any] | None = None,
+    viewport: dict[str, Any] | None = None,
+    map_theme_css: str = "",
+    banner_html: str = "",
+    legend_html: str = "",
+    title: str = "eBird map export",
+) -> bytes:
+    """Build a self-contained HTML file (network required for tiles + CDN scripts)."""
+    enriched = enrich_geojson_for_export(geojson)
+    config = {
+        "geojson": enriched,
+        "height": int(height),
+        "map_style": str(map_style or "default"),
+        "cluster_options": cluster_options if cluster_options is not None else {},
+        "circle_marker_style": circle_marker_style if circle_marker_style is not None else {},
+        "cluster_icon_style": cluster_icon_style if cluster_icon_style is not None else {},
+        "viewport": viewport if viewport is not None else {},
+    }
+    theme_inner = _extract_style_inner(map_theme_css)
+    popup_css = ""
+    if _COMPONENT_CSS.is_file():
+        popup_css = _COMPONENT_CSS.read_text(encoding="utf-8")
+    page_css = _read_static("leaflet_map_export_page.css")
+    viewer_js = _read_static("leaflet_map_export.js")
+    esc_title = html_module.escape(title, quote=False)
+    banner = (banner_html or "").strip()
+    legend = (legend_html or "").strip()
+    config_json = _json_for_script(config)
+
+    doc = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>{esc_title}</title>
+<link rel="stylesheet" href="{_LEAFLET_CSS}"/>
+<link rel="stylesheet" href="{_CLUSTER_CSS}"/>
+<link rel="stylesheet" href="{_CLUSTER_DEFAULT_CSS}"/>
+<style>
+{theme_inner}
+{popup_css}
+{page_css}
+</style>
+</head>
+<body>
+{banner}
+<div id="pebird-export-map"></div>
+{legend}
+<p class="pebird-export-meta">Exported from Personal eBird Explorer — map tiles load from the internet.</p>
+<script type="application/json" id="pebird-map-export-config">{config_json}</script>
+<script src="{_LEAFLET_JS}"></script>
+<script src="{_CLUSTER_JS}"></script>
+<script>
+{viewer_js}
+</script>
+</body>
+</html>
+"""
+    return doc.encode("utf-8")

--- a/explorer/presentation/popup_v1_export_html.py
+++ b/explorer/presentation/popup_v1_export_html.py
@@ -1,0 +1,286 @@
+"""Render GeoJSON popup properties to HTML for standalone Leaflet map export (#222 §7).
+
+Mirrors the component iframe templates in ``AllLocationsMap.tsx`` without a second Folium stack.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from explorer.presentation.map_popup_models import (
+    LocationPopupModel,
+    SpeciesMapLocationPopupModel,
+    assemble_location_popup_html,
+    assemble_species_map_location_popup_html,
+)
+from explorer.presentation.map_renderer import (
+    MAP_POPUP_MACAULAY_LINK_SYMBOL,
+    esc_attr,
+    esc_text,
+)
+
+_HEADING_MARGIN_ALL = 4
+
+
+def _lifelist_href(lifelist_url: str, loc_id: str | None = None) -> str:
+    u = str(lifelist_url or "").strip()
+    if u:
+        return u
+    lid = str(loc_id or "").strip()
+    if lid:
+        return f"https://ebird.org/lifelist/{esc_attr(lid)}"
+    return ""
+
+
+def _loc_id_from_props(props: dict[str, Any]) -> str:
+    for key in ("loc_id", "location_id", "Location ID"):
+        v = props.get(key)
+        if v is not None and str(v).strip():
+            return str(v).strip()
+    url = str(props.get("lifelist_url") or "").strip()
+    if "/lifelist/" in url:
+        return url.rsplit("/lifelist/", 1)[-1].split("?")[0].strip()
+    return ""
+
+
+def _visit_entries_html(entries: list[dict[str, str]]) -> str:
+    parts: list[str] = []
+    for e in entries:
+        href = str(e.get("href") or "").strip()
+        label = esc_text(str(e.get("label") or href or "—"))
+        if href:
+            parts.append(
+                f'<a href="{esc_attr(href)}" target="_blank" rel="noopener noreferrer">{label}</a>'
+            )
+        else:
+            parts.append(f'<span class="pebird-map-popup__visit-link-text">{label}</span>')
+    return "<br>".join(parts)
+
+
+def _species_obs_line(obs: dict[str, Any]) -> str:
+    dt = esc_text(str(obs.get("datetime_label") or "—").strip())
+    href = str(obs.get("checklist_href") or "").strip()
+    count = esc_text(str(obs.get("observed_count") or "").strip())
+    media = str(obs.get("media_href") or "").strip()
+    if href:
+        line = (
+            f'<a href="{esc_attr(href)}" target="_blank" rel="noopener noreferrer">{dt}</a>'
+        )
+    else:
+        line = f"<span>{dt}</span>"
+    line += f' <span class="pebird-map-popup__obs-count">(Observed: {count})</span>'
+    if media:
+        line += (
+            f' <a class="pebird-map-popup__media-link" href="{esc_attr(media)}" '
+            f'target="_blank" rel="noopener noreferrer" title="media">'
+            f"{MAP_POPUP_MACAULAY_LINK_SYMBOL}</a>"
+        )
+    return f'<div class="pebird-map-popup__obs-line">{line}</div>'
+
+
+def _species_sections_html(sections: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    for sec in sections:
+        name = esc_text(str(sec.get("common_name") or ""))
+        n_obs = int(sec.get("observation_count") or 0)
+        open_attr = " open" if sec.get("open_by_default") else ""
+        rows = "".join(_species_obs_line(o) for o in (sec.get("observations") or []))
+        parts.append(
+            f'<details class="pebird-map-popup__species-seen"{open_attr}>'
+            f'<summary class="pebird-map-popup__section-label">{name}: ({n_obs})</summary>'
+            f'<div class="pebird-map-popup__obs-list">{rows}</div>'
+            f"</details>"
+        )
+    return "".join(parts)
+
+
+def _lifer_popup_html(name: str, lifelist_url: str, payload: dict[str, Any]) -> str:
+    lines = payload.get("lines") if isinstance(payload.get("lines"), list) else []
+    inner_parts: list[str] = []
+    for i, row in enumerate(lines):
+        if not isinstance(row, dict):
+            continue
+        label = esc_text(str(row.get("label") or "—"))
+        date_s = esc_text(str(row.get("date") or "?"))
+        href = str(row.get("checklist_href") or "").strip()
+        prefix = "<br>" if i else ""
+        if href:
+            inner_parts.append(
+                f'{prefix}<a href="{esc_attr(href)}" target="_blank" rel="noopener noreferrer">'
+                f"{label} : {date_s}</a>"
+            )
+        else:
+            inner_parts.append(f"{prefix}<span>{label} : {date_s}</span>")
+    loc_id = _loc_id_from_props({"lifelist_url": lifelist_url})
+    model = LocationPopupModel(
+        loc_name=name,
+        loc_id=loc_id or "0",
+        visit_info_html="".join(inner_parts),
+        sightings_html="",
+        lifer_species_html="",
+        show_visit_history=True,
+        lifer_heading_html="",
+        location_heading_margin_px=_HEADING_MARGIN_ALL,
+    )
+    return assemble_location_popup_html(model)
+
+
+def _family_popup_html(name: str, lifelist_url: str, payload: dict[str, Any]) -> str:
+    species_lines = payload.get("species_lines") if isinstance(payload.get("species_lines"), list) else []
+    line_html: list[str] = []
+    for row in species_lines:
+        if not isinstance(row, dict):
+            continue
+        n = esc_text(str(row.get("name") or "").strip())
+        if not n:
+            continue
+        href = str(row.get("species_href") or "").strip()
+        if href:
+            line_html.append(
+                f'<div class="pebird-map-popup__species-line"><a href="{esc_attr(href)}" '
+                f'target="_blank" rel="noopener noreferrer">{n}</a></div>'
+            )
+        else:
+            line_html.append(f'<div class="pebird-map-popup__species-line">{n}</div>')
+    body = (
+        "".join(line_html)
+        if line_html
+        else '<div class="pebird-map-popup__summary-line">No species lines</div>'
+    )
+    loc_id = _loc_id_from_props({"lifelist_url": lifelist_url})
+    url = _lifelist_href(lifelist_url, loc_id)
+    esc_name = esc_text(name)
+    if url:
+        head = (
+            f'<a class="pebird-map-popup__location-heading" href="{esc_attr(url)}" '
+            f'target="_blank" rel="noopener noreferrer">{esc_name}</a>'
+        )
+    else:
+        head = f'<span class="pebird-map-popup__location-heading">{esc_name}</span>'
+    return (
+        f'<div class="pebird-map-popup popup-scroll-wrapper">'
+        f'<div class="pebird-map-popup__heading-row" style="margin-bottom:{_HEADING_MARGIN_ALL}px;">{head}</div>'
+        f'<div class="pebird-map-popup__scroll" style="max-height:300px;overflow-y:auto;">{body}</div>'
+        f"</div>"
+    )
+
+
+def _species_popup_html(name: str, lifelist_url: str, payload: dict[str, Any]) -> str:
+    sections = payload.get("species_sections") if isinstance(payload.get("species_sections"), list) else []
+    visits = payload.get("visits") if isinstance(payload.get("visits"), dict) else {}
+    visit_entries = visits.get("entries") if isinstance(visits.get("entries"), list) else []
+    visit_count = len(visit_entries)
+    margin = int(payload.get("location_heading_margin_px") or 6)
+    loc_id = _loc_id_from_props({"lifelist_url": lifelist_url})
+    return assemble_species_map_location_popup_html(
+        SpeciesMapLocationPopupModel(
+            loc_name=name,
+            loc_id=loc_id or "0",
+            species_sections_html=_species_sections_html(sections),
+            visit_info_html=_visit_entries_html(visit_entries),
+            visit_record_count=visit_count,
+            location_heading_margin_px=margin,
+        )
+    )
+
+
+def _popup_v1_html(name: str, lifelist_url: str, popup: dict[str, Any]) -> str:
+    visited = popup.get("visited")
+    if isinstance(visited, dict):
+        entries = visited.get("entries") if isinstance(visited.get("entries"), list) else []
+        loc_id = _loc_id_from_props({"lifelist_url": lifelist_url})
+        return assemble_location_popup_html(
+            LocationPopupModel(
+                loc_name=name,
+                loc_id=loc_id or "0",
+                visit_info_html=_visit_entries_html(entries),
+                sightings_html="",
+                lifer_species_html="",
+                show_visit_history=True,
+                lifer_heading_html="",
+                location_heading_margin_px=_HEADING_MARGIN_ALL,
+            )
+        )
+    summary_lines = popup.get("summary_lines") if isinstance(popup.get("summary_lines"), list) else []
+    links = popup.get("links") if isinstance(popup.get("links"), list) else []
+    loc_id = _loc_id_from_props({"lifelist_url": lifelist_url})
+    url = _lifelist_href(lifelist_url, loc_id)
+    esc_name = esc_text(name)
+    head = (
+        f'<a class="pebird-map-popup__location-heading" href="{esc_attr(url)}" '
+        f'target="_blank" rel="noopener noreferrer">{esc_name}</a>'
+        if url
+        else f'<span class="pebird-map-popup__location-heading">{esc_name}</span>'
+    )
+    body_parts = [
+        f'<span class="pebird-map-popup__summary-line">{esc_text(str(ln))}</span>'
+        for ln in summary_lines
+        if str(ln).strip()
+    ]
+    for link in links:
+        if not isinstance(link, dict):
+            continue
+        href = str(link.get("href") or "").strip()
+        label = esc_text(str(link.get("label") or "Link"))
+        if href:
+            body_parts.append(
+                f'<span class="pebird-map-popup__summary-line"><a href="{esc_attr(href)}" '
+                f'target="_blank" rel="noopener noreferrer">{label}</a></span>'
+            )
+    return (
+        f'<div class="pebird-map-popup">'
+        f'<div class="pebird-map-popup__heading-row" style="margin-bottom:{_HEADING_MARGIN_ALL}px;">{head}</div>'
+        f"{''.join(body_parts)}</div>"
+    )
+
+
+def popup_export_html_from_properties(props: dict[str, Any] | None) -> str:
+    """Build popup HTML for one GeoJSON feature (export / offline HTML)."""
+    props = props or {}
+    name = str(props.get("name") or props.get("Location") or "Location")
+    lifelist_url = str(props.get("lifelist_url") or "")
+    lifer = props.get("lifer_popup_v1")
+    if isinstance(lifer, dict) and lifer.get("v") == 1:
+        return _lifer_popup_html(name, lifelist_url, lifer)
+    family = props.get("family_popup_v1")
+    if isinstance(family, dict) and family.get("v") == 1:
+        return _family_popup_html(name, lifelist_url, family)
+    species = props.get("species_popup_v1")
+    if isinstance(species, dict) and species.get("v") == 1:
+        return _species_popup_html(name, lifelist_url, species)
+    popup = props.get("popup_v1")
+    if isinstance(popup, dict) and popup.get("v") == 1:
+        return _popup_v1_html(name, lifelist_url, popup)
+    loc_id = _loc_id_from_props(props)
+    url = _lifelist_href(lifelist_url, loc_id)
+    esc_name = esc_text(name)
+    head = (
+        f'<a class="pebird-map-popup__location-heading" href="{esc_attr(url)}" '
+        f'target="_blank" rel="noopener noreferrer">{esc_name}</a>'
+        if url
+        else f'<span class="pebird-map-popup__location-heading">{esc_name}</span>'
+    )
+    visits = props.get("visit_checklists")
+    extra = (
+        f'<span class="pebird-map-popup__summary-line">Checklists: {esc_text(str(visits))}</span>'
+        if visits not in (None, "")
+        else ""
+    )
+    return (
+        f'<div class="pebird-map-popup">'
+        f'<div class="pebird-map-popup__heading-row" style="margin-bottom:{_HEADING_MARGIN_ALL}px;">{head}</div>'
+        f"{extra}</div>"
+    )
+
+
+def enrich_geojson_for_export(geojson: dict[str, Any]) -> dict[str, Any]:
+    """Copy GeoJSON and add ``export_popup_html`` on each feature for the export viewer."""
+    features_in = geojson.get("features") if isinstance(geojson.get("features"), list) else []
+    features_out: list[dict[str, Any]] = []
+    for feat in features_in:
+        if not isinstance(feat, dict):
+            continue
+        props = dict(feat.get("properties") or {})
+        props["export_popup_html"] = popup_export_html_from_properties(props)
+        features_out.append({**feat, "properties": props})
+    return {**geojson, "type": geojson.get("type") or "FeatureCollection", "features": features_out}

--- a/explorer/presentation/popup_v1_export_html.py
+++ b/explorer/presentation/popup_v1_export_html.py
@@ -13,22 +13,19 @@ from explorer.presentation.map_popup_models import (
     assemble_location_popup_html,
     assemble_species_map_location_popup_html,
 )
-from explorer.presentation.map_renderer import (
-    MAP_POPUP_MACAULAY_LINK_SYMBOL,
-    esc_attr,
-    esc_text,
-)
+from explorer.presentation.map_renderer import MAP_POPUP_MACAULAY_LINK_SYMBOL, esc_attr, esc_text
+from explorer.presentation.stats_html_helpers import safe_http_url
 
 _HEADING_MARGIN_ALL = 4
 
 
 def _lifelist_href(lifelist_url: str, loc_id: str | None = None) -> str:
-    u = str(lifelist_url or "").strip()
+    u = safe_http_url(lifelist_url)
     if u:
         return u
     lid = str(loc_id or "").strip()
     if lid:
-        return f"https://ebird.org/lifelist/{esc_attr(lid)}"
+        return safe_http_url(f"https://ebird.org/lifelist/{lid}")
     return ""
 
 
@@ -46,7 +43,7 @@ def _loc_id_from_props(props: dict[str, Any]) -> str:
 def _visit_entries_html(entries: list[dict[str, str]]) -> str:
     parts: list[str] = []
     for e in entries:
-        href = str(e.get("href") or "").strip()
+        href = safe_http_url(str(e.get("href") or ""))
         label = esc_text(str(e.get("label") or href or "—"))
         if href:
             parts.append(
@@ -59,9 +56,9 @@ def _visit_entries_html(entries: list[dict[str, str]]) -> str:
 
 def _species_obs_line(obs: dict[str, Any]) -> str:
     dt = esc_text(str(obs.get("datetime_label") or "—").strip())
-    href = str(obs.get("checklist_href") or "").strip()
+    href = safe_http_url(str(obs.get("checklist_href") or ""))
     count = esc_text(str(obs.get("observed_count") or "").strip())
-    media = str(obs.get("media_href") or "").strip()
+    media = safe_http_url(str(obs.get("media_href") or ""))
     if href:
         line = (
             f'<a href="{esc_attr(href)}" target="_blank" rel="noopener noreferrer">{dt}</a>'
@@ -102,7 +99,7 @@ def _lifer_popup_html(name: str, lifelist_url: str, payload: dict[str, Any]) -> 
             continue
         label = esc_text(str(row.get("label") or "—"))
         date_s = esc_text(str(row.get("date") or "?"))
-        href = str(row.get("checklist_href") or "").strip()
+        href = safe_http_url(str(row.get("checklist_href") or ""))
         prefix = "<br>" if i else ""
         if href:
             inner_parts.append(
@@ -134,7 +131,7 @@ def _family_popup_html(name: str, lifelist_url: str, payload: dict[str, Any]) ->
         n = esc_text(str(row.get("name") or "").strip())
         if not n:
             continue
-        href = str(row.get("species_href") or "").strip()
+        href = safe_http_url(str(row.get("species_href") or ""))
         if href:
             line_html.append(
                 f'<div class="pebird-map-popup__species-line"><a href="{esc_attr(href)}" '
@@ -220,7 +217,7 @@ def _popup_v1_html(name: str, lifelist_url: str, popup: dict[str, Any]) -> str:
     for link in links:
         if not isinstance(link, dict):
             continue
-        href = str(link.get("href") or "").strip()
+        href = safe_http_url(str(link.get("href") or ""))
         label = esc_text(str(link.get("label") or "Link"))
         if href:
             body_parts.append(

--- a/explorer/presentation/static/leaflet_map_export.js
+++ b/explorer/presentation/static/leaflet_map_export.js
@@ -1,0 +1,239 @@
+/** Standalone Leaflet viewer for exported HTML (#222). Popups use pre-rendered export_popup_html from Python. */
+(function () {
+  "use strict";
+  var DEFAULT_CLUSTER = {
+    enabled: true,
+    max_cluster_radius: 40,
+    disable_clustering_at_zoom: 9,
+    spiderfy_on_max_zoom: false,
+    remove_outside_visible_bounds: false,
+  };
+  var BASEMAPS = {
+    default: {
+      url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+      opts: { maxZoom: 19, attribution: "&copy; OpenStreetMap contributors" },
+    },
+    google: {
+      url: "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
+      opts: { maxZoom: 22, attribution: "Google" },
+    },
+    carto: {
+      url: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+      opts: {
+        maxZoom: 20,
+        subdomains: "abcd",
+        attribution: "&copy; OpenStreetMap &copy; CARTO",
+      },
+    },
+  };
+
+  function basemap(style) {
+    var s = String(style || "default").toLowerCase();
+    return BASEMAPS[s === "google" || s === "carto" ? s : "default"];
+  }
+
+  function mergeCluster(raw) {
+    var o = {};
+    var k;
+    for (k in DEFAULT_CLUSTER) o[k] = DEFAULT_CLUSTER[k];
+    if (raw && typeof raw === "object") {
+      for (k in raw) if (Object.prototype.hasOwnProperty.call(raw, k)) o[k] = raw[k];
+    }
+    return o;
+  }
+
+  function clusterOpts(p) {
+    return {
+      maxClusterRadius: Number(p.max_cluster_radius) || 40,
+      disableClusteringAtZoom: Number(p.disable_clustering_at_zoom) || 9,
+      spiderfyOnMaxZoom: !!p.spiderfy_on_max_zoom,
+      removeOutsideVisibleBounds: !!p.remove_outside_visible_bounds,
+      chunkedLoading: true,
+    };
+  }
+
+  function parseVp(raw) {
+    if (!raw || raw.v !== 1) return null;
+    return raw;
+  }
+
+  function applyVp(map, vp, layer) {
+    var pad = function (n) {
+      return L.point(n, n);
+    };
+    if (!vp) {
+      if (layer) {
+        try {
+          var b = layer.getBounds();
+          if (b.isValid()) map.fitBounds(b.pad(0.12));
+          else map.setView([20, 0], 2);
+        } catch (e) {
+          map.setView([20, 0], 2);
+        }
+      } else map.setView([20, 0], 2);
+      return;
+    }
+    if (vp.mode === "go_to_gps") {
+      var d = vp.epsilon_delta;
+      map.fitBounds(
+        [
+          [vp.lat - d, vp.lon - d],
+          [vp.lat + d, vp.lon + d],
+        ],
+        { padding: pad(vp.padding_px), maxZoom: vp.max_zoom, animate: false },
+      );
+    } else if (vp.mode === "center_zoom") {
+      map.setView(vp.center, vp.zoom, { animate: false });
+    } else if (vp.mode === "fit_bounds") {
+      if (vp.single_point) {
+        var e = vp.epsilon_delta;
+        map.fitBounds(
+          [
+            [vp.lat - e, vp.lon - e],
+            [vp.lat + e, vp.lon + e],
+          ],
+          { padding: pad(vp.padding_px), maxZoom: vp.max_zoom, animate: false },
+        );
+      } else if (vp.pairs && vp.pairs.length) {
+        map.fitBounds(
+          vp.pairs.map(function (p) {
+            return L.latLng(p[0], p[1]);
+          }),
+          { padding: pad(vp.padding_px), maxZoom: vp.max_zoom, animate: false },
+        );
+      }
+    }
+  }
+
+  function pinOpts(props, cm) {
+    function hex(s, fb) {
+      return typeof s === "string" && /^#[0-9a-fA-F]{6}$/.test(s) ? s : fb;
+    }
+    var pin = props.circle_pin;
+    return {
+      radius:
+        (pin && pin.radius_px) || (cm && cm.radius_px) || 7,
+      weight:
+        (pin && pin.stroke_weight) || (cm && cm.stroke_weight) || 1,
+      color: hex(pin && pin.stroke_hex, hex(cm && cm.stroke_hex, "#1c2630")),
+      fillColor: hex(
+        pin && pin.fill_hex,
+        hex(cm && cm.fill_hex, hex(props.colour, "#3388ff")),
+      ),
+      fillOpacity:
+        pin && pin.fill_opacity != null ? pin.fill_opacity : 0.88,
+    };
+  }
+
+  function init() {
+    var el = document.getElementById("pebird-map-export-config");
+    if (!el || !window.L) return;
+    var cfg = JSON.parse(el.textContent || "{}");
+    var mapNode = document.getElementById("pebird-export-map");
+    if (!mapNode) return;
+    var h = Number(cfg.height) || 500;
+    mapNode.style.height = h + "px";
+    var map = L.map(mapNode, { zoomControl: true, attributionControl: true });
+    mapNode.classList.add("pebird-export-map-pane");
+    var bm = basemap(cfg.map_style);
+    L.tileLayer(bm.url, bm.opts).addTo(map);
+    var clusterCfg = mergeCluster(cfg.cluster_options);
+    var overlay;
+    if (clusterCfg.enabled !== false) {
+      var opts = clusterOpts(clusterCfg);
+      var ics = cfg.cluster_icon_style;
+      if (ics && ics.fills_rgba && ics.fills_rgba.length === 3) {
+        opts.iconCreateFunction = function (cluster) {
+          var n = cluster.getChildCount();
+          var i = n < 10 ? 0 : n < 100 ? 1 : 2;
+          var html =
+            '<div style="background:' +
+            ics.fills_rgba[i] +
+            ";border:" +
+            ics.border_width_px +
+            "px solid " +
+            ics.borders_rgba[i] +
+            ";box-shadow:0 0 0 " +
+            ics.halo_spread_px +
+            "px " +
+            ics.halos_rgba[i] +
+            ';"><span>' +
+            n +
+            "</span></div>";
+          var cls =
+            n < 10
+              ? "marker-cluster-small"
+              : n < 100
+                ? "marker-cluster-medium"
+                : "marker-cluster-large";
+          return L.divIcon({
+            html: html,
+            className: "marker-cluster " + cls,
+            iconSize: L.point(40, 40),
+          });
+        };
+      }
+      overlay = L.markerClusterGroup(opts);
+    } else {
+      overlay = L.layerGroup();
+    }
+    overlay.addTo(map);
+    var gj = L.geoJSON(cfg.geojson || { type: "FeatureCollection", features: [] }, {
+      pointToLayer: function (f, latlng) {
+        var pr = f.properties || {};
+        var o = pinOpts(pr, cfg.circle_marker_style || {});
+        var main = L.circleMarker(latlng, {
+          radius: o.radius,
+          weight: o.weight,
+          color: o.color,
+          fillColor: o.fillColor,
+          fillOpacity: o.fillOpacity,
+          stroke: true,
+        });
+        var halo = pr.highlight_halo_circle;
+        if (halo) {
+          var ho = pinOpts({ circle_pin: halo }, {});
+          var haloM = L.circleMarker(latlng, {
+            radius: ho.radius,
+            weight: ho.weight,
+            color: ho.color,
+            fillColor: ho.fillColor,
+            fillOpacity: ho.fillOpacity,
+            stroke: true,
+          });
+          return L.layerGroup([haloM, main]);
+        }
+        return main;
+      },
+      onEachFeature: function (f, layer) {
+        var pr = f.properties || {};
+        var html = pr.export_popup_html || pr.name || "Location";
+        layer.bindPopup(html, { maxWidth: 420 });
+      },
+    });
+    overlay.addLayer(gj);
+    applyVp(map, parseVp(cfg.viewport), gj);
+    var vp = parseVp(cfg.viewport);
+    if (vp && vp.mode === "go_to_gps") {
+      var gm = L.marker([vp.lat, vp.lon], {
+        icon: L.divIcon({
+          className: "all-locations-gps-marker",
+          html: '<span class="all-locations-gps-marker__glyph"></span>',
+          iconSize: [30, 40],
+          iconAnchor: [15, 40],
+        }),
+      });
+      gm.bindPopup(
+        "<div style='font-size:13px'><strong>Temporary GPS marker</strong></div>",
+      );
+      gm.addTo(map);
+    }
+    map.invalidateSize();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/explorer/presentation/static/leaflet_map_export.js
+++ b/explorer/presentation/static/leaflet_map_export.js
@@ -131,8 +131,6 @@
     var cfg = JSON.parse(el.textContent || "{}");
     var mapNode = document.getElementById("pebird-export-map");
     if (!mapNode) return;
-    var h = Number(cfg.height) || 500;
-    mapNode.style.height = h + "px";
     var map = L.map(mapNode, { zoomControl: true, attributionControl: true });
     mapNode.classList.add("pebird-export-map-pane");
     var bm = basemap(cfg.map_style);
@@ -228,7 +226,13 @@
       );
       gm.addTo(map);
     }
-    map.invalidateSize();
+    function bumpSize() {
+      map.invalidateSize({ debounceMoveend: true });
+    }
+    bumpSize();
+    window.addEventListener("resize", bumpSize);
+    requestAnimationFrame(bumpSize);
+    setTimeout(bumpSize, 100);
   }
 
   if (document.readyState === "loading") {

--- a/explorer/presentation/static/leaflet_map_export_page.css
+++ b/explorer/presentation/static/leaflet_map_export_page.css
@@ -1,4 +1,4 @@
-/* Standalone export page shell (banner/legend HTML carries inline position from Python). */
+/* Standalone export: map fills the viewport; banner/legend overlay the map host (not document bottom). */
 html,
 body {
   margin: 0;
@@ -7,9 +7,48 @@ body {
   font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-#pebird-export-map {
+.pebird-export-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
+}
+
+.pebird-export-map-host {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
   width: 100%;
+  overflow: hidden;
+}
+
+#pebird-export-map {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   box-sizing: border-box;
+}
+
+/* Component iframe uses fixed banner + absolute legend on the frame root; export uses one positioned host. */
+.pebird-export-map-host .pebird-map-banner {
+  position: absolute !important;
+  top: 16px !important;
+  right: 16px !important;
+  left: auto !important;
+  bottom: auto !important;
+  z-index: 1000;
+}
+
+.pebird-export-map-host .pebird-map-legend {
+  position: absolute !important;
+  bottom: 16px !important;
+  left: 8px !important;
+  right: auto !important;
+  top: auto !important;
+  z-index: 1000;
 }
 
 .pebird-export-map-pane.leaflet-container {
@@ -23,6 +62,7 @@ body {
 }
 
 .pebird-export-meta {
+  flex: 0 0 auto;
   font-size: 12px;
   color: rgba(26, 46, 34, 0.65);
   padding: 6px 10px;

--- a/explorer/presentation/static/leaflet_map_export_page.css
+++ b/explorer/presentation/static/leaflet_map_export_page.css
@@ -1,0 +1,30 @@
+/* Standalone export page shell (banner/legend HTML carries inline position from Python). */
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+#pebird-export-map {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.pebird-export-map-pane.leaflet-container {
+  padding-bottom: 20px;
+  padding-right: 8px;
+}
+
+.pebird-export-map-pane.leaflet-container .leaflet-bottom.leaflet-right {
+  bottom: 10px;
+  right: 8px;
+}
+
+.pebird-export-meta {
+  font-size: 12px;
+  color: rgba(26, 46, 34, 0.65);
+  padding: 6px 10px;
+  text-align: center;
+}

--- a/explorer/presentation/stats_html_helpers.py
+++ b/explorer/presentation/stats_html_helpers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import html as html_module
 from typing import Any
+from urllib.parse import urlparse
 
 # Right-aligned numeric / emphasis cells used across rankings-style tables.
 METRIC_CELL_STYLE = "text-align:right;font-weight:600;"
@@ -21,6 +22,24 @@ def esc_text(value: Any) -> str:
 def esc_attr(value: Any) -> str:
     """Escape for HTML attribute values (e.g. ``href``)."""
     return html_module.escape(str(value) if value is not None else "", quote=True)
+
+
+def safe_http_url(raw: Any) -> str:
+    """Return *raw* trimmed only when it is an ``http`` or ``https`` URL; otherwise ``""``.
+
+    Blocks ``javascript:``, ``data:``, protocol-relative URLs, and other non-http(s) schemes.
+    Matches the Leaflet component ``safeHttpUrlForAnchor`` in ``AllLocationsMap.tsx``.
+    """
+    t = str(raw or "").strip()
+    if not t:
+        return ""
+    try:
+        parsed = urlparse(t)
+    except ValueError:
+        return ""
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return ""
+    return t
 
 
 def tr_row(*cells_html: str) -> str:
@@ -59,7 +78,10 @@ def a_external(
     target: str = "_blank",
 ) -> str:
     """Standard external link: escaped ``href`` and visible text, ``target`` + ``rel`` on anchor."""
+    safe = safe_http_url(href)
+    if not safe:
+        return esc_text(visible_text)
     return (
-        f'<a href="{esc_attr(href)}" target="{esc_attr(target)}" rel="{esc_attr(rel)}">'
+        f'<a href="{esc_attr(safe)}" target="{esc_attr(target)}" rel="{esc_attr(rel)}">'
         f"{esc_text(visible_text)}</a>"
     )

--- a/tests/explorer/test_leaflet_map_export_cache.py
+++ b/tests/explorer/test_leaflet_map_export_cache.py
@@ -1,0 +1,34 @@
+"""Tests for Leaflet export HTML session cache keys."""
+
+from __future__ import annotations
+
+from explorer.presentation.leaflet_map_export_cache import leaflet_export_html_cache_key
+
+
+def _base_key(**overrides):
+    defaults = dict(
+        leaflet_revision="rev1",
+        map_height=500,
+        map_style="default",
+        cluster_options={"enabled": True},
+        circle_marker_style={"fill_hex": "#3388ff"},
+        cluster_icon_style={},
+        viewport={"v": 1, "mode": "center_zoom", "center": [0, 0], "zoom": 5},
+        map_theme_css="<style>.x{}</style>",
+        banner_html="<motion class='pebird-map-banner'>",
+        legend_html="<div class='pebird-map-legend'>",
+    )
+    defaults.update(overrides)
+    return leaflet_export_html_cache_key(**defaults)
+
+
+def test_cache_key_stable_for_same_inputs():
+    assert _base_key() == _base_key()
+
+
+def test_cache_key_changes_when_revision_changes():
+    assert _base_key(leaflet_revision="rev1") != _base_key(leaflet_revision="rev2")
+
+
+def test_cache_key_changes_when_banner_changes():
+    assert _base_key(banner_html="a") != _base_key(banner_html="b")

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -55,3 +55,5 @@ def test_leaflet_map_to_html_bytes_includes_viewer_and_geojson():
     assert "export_popup_html" in text
     assert "Pin A" in text
     assert "pebird-export-map" in text
+    assert "pebird-export-map-host" in text
+    assert "pebird-export-shell" in text

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -1,0 +1,57 @@
+"""Tests for standalone Leaflet map HTML export (#222 §7)."""
+
+from __future__ import annotations
+
+from explorer.presentation.leaflet_map_html_export import leaflet_map_to_html_bytes
+from explorer.presentation.popup_v1_export_html import popup_export_html_from_properties
+
+
+def test_popup_export_html_all_locations_visited():
+    html = popup_export_html_from_properties(
+        {
+            "name": "Test Reserve",
+            "lifelist_url": "https://ebird.org/lifelist/L123",
+            "popup_v1": {
+                "v": 1,
+                "visited": {
+                    "label": "Visited:",
+                    "entries": [{"label": "2024-01-01", "href": "https://ebird.org/checklist/S1"}],
+                },
+            },
+        }
+    )
+    assert "Test Reserve" in html
+    assert "Visited:" in html
+    assert "pebird-map-popup__visit-dates" in html
+
+
+def test_leaflet_map_to_html_bytes_includes_viewer_and_geojson():
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [145.0, -37.0]},
+                "properties": {
+                    "name": "Pin A",
+                    "popup_v1": {"v": 1, "summary_lines": ["Checklists: 1"], "links": []},
+                },
+            }
+        ],
+    }
+    raw = leaflet_map_to_html_bytes(
+        geojson=geojson,
+        height=400,
+        map_style="default",
+        cluster_options={"enabled": False},
+        circle_marker_style={"fill_hex": "#3388ff", "stroke_hex": "#1c2630", "radius_px": 7},
+        viewport={"v": 1, "mode": "center_zoom", "center": [-37.0, 145.0], "zoom": 10},
+        map_theme_css="<style>.pebird-map-popup { color: #000; }</style>",
+    )
+    text = raw.decode("utf-8")
+    assert "leaflet@1.9.4" in text
+    assert "leaflet.markercluster" in text
+    assert "pebird-map-export-config" in text
+    assert "export_popup_html" in text
+    assert "Pin A" in text
+    assert "pebird-export-map" in text

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -6,6 +6,24 @@ from explorer.presentation.leaflet_map_html_export import leaflet_map_to_html_by
 from explorer.presentation.popup_v1_export_html import popup_export_html_from_properties
 
 
+def test_popup_export_html_blocks_javascript_href():
+    html = popup_export_html_from_properties(
+        {
+            "name": "Evil",
+            "lifelist_url": "https://ebird.org/lifelist/L1",
+            "popup_v1": {
+                "v": 1,
+                "visited": {
+                    "label": "Visited:",
+                    "entries": [{"label": "bad", "href": "javascript:alert(1)"}],
+                },
+            },
+        }
+    )
+    assert "javascript:" not in html
+    assert "pebird-map-popup__visit-link-text" in html
+
+
 def test_popup_export_html_all_locations_visited():
     html = popup_export_html_from_properties(
         {

--- a/tests/explorer/test_stats_html_helpers.py
+++ b/tests/explorer/test_stats_html_helpers.py
@@ -7,6 +7,7 @@ from explorer.presentation.stats_html_helpers import (
     a_external,
     esc_attr,
     esc_text,
+    safe_http_url,
     td_plain,
     th_plain,
     tr_row,
@@ -42,3 +43,22 @@ def test_a_external_escapes_and_attributes():
     assert "Bird &amp; co" in html
     assert 'target="_blank"' in html
     assert "noopener" in html
+
+
+def test_safe_http_url_accepts_http_and_https():
+    assert safe_http_url("https://ebird.org/checklist/S1") == "https://ebird.org/checklist/S1"
+    assert safe_http_url("  http://example.com/x  ") == "http://example.com/x"
+
+
+def test_safe_http_url_rejects_non_http_schemes():
+    assert safe_http_url("") == ""
+    assert safe_http_url("javascript:alert(1)") == ""
+    assert safe_http_url("data:text/html,hi") == ""
+    assert safe_http_url("//evil.example/") == ""
+    assert safe_http_url("/relative/path") == ""
+
+
+def test_a_external_unsafe_href_renders_plain_text():
+    html = a_external("javascript:alert(1)", "Click me")
+    assert "<a " not in html
+    assert html == "Click me"


### PR DESCRIPTION
## Summary

Implements TODO §7 for #222: restore **Export map HTML** on all four Leaflet map modes without building Folium in parallel. Exported files are standalone HTML (CDN Leaflet + MarkerCluster) using the same GeoJSON, theme CSS, banner, legend, and viewport as the live component.

**Does not close #222** — remaining work includes §10 docs, §15 popup typography, Folium removal, etc.

## Changes

- `leaflet_map_to_html_bytes` — builds self-contained HTML with embedded config JSON
- `popup_v1_export_html` — pre-renders popup HTML from structured GeoJSON properties (no second Folium stack); uses `safe_http_url` for anchor hrefs (parity with component TS)
- `leaflet_map_export.js` — vanilla viewer (markers, clusters, viewport, basemaps)
- `leaflet_map_export_cache.py` — stable cache keys for export HTML LRU
- `app_prep_map_ui.py` — stores `LEAFLET_EXPORT_RECIPE_KEY` during prep; builds HTML on export button click; `LEAFLET_EXPORT_HTML_CACHE_KEY` avoids rebuild on repeat export
- Export page layout: map fills viewport (`100vh`); banner/legend overlay the map host (not document footer)
- Export UX: no hover help on export control
- TODO §7 marked done; §8 export cache / lazy build noted in TODO

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` — 595 passed, 4 skipped
- `tests/explorer/test_leaflet_map_html_export.py`, `test_leaflet_map_export_cache.py`, `test_stats_html_helpers.py` (`safe_http_url`)
- Manual smoke: all four map modes, basemap change, export open in browser; first export (build + download); repeat export (cache hit)

## Notes

- Export requires network for tiles + CDN scripts (acceptable for sharing, not archival).
- Leaflet export does not run during normal map prep — only when the user clicks **Export map HTML**.
- Popup heading overflow matches live maps; deferred to §15.

## Issues

Refs #222