### PR TITLE
fix: Map HTML export parity and one-click sidebar export (#222)

### DIFF
--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -199,6 +199,7 @@ Do not duplicate HTML in UI code — use shared formatters.
 - **Map marker design utility** — separate Streamlit app (not user-facing): `streamlit run explorer/app/streamlit/design_map_app.py`. Previews roles and exports scheme dicts; see [development.md](development.md#map-marker-colour-design-utility-developers).
 
 - **`explorer/app/streamlit/streamlit_ui_constants.py`** — **Fixed UI content**: tab labels, species-search widget strings, spinner text and emoji list, export filename, sidebar footer URLs. Not “tweak colour/size” defaults.
+- **Map HTML export UX** — Shipped one-click sidebar export; alternative two-button design and browser-risk notes: [docs/explorer/map-html-export-ux-alternative.md](explorer/map-html-export-ux-alternative.md) (use if users report export/download failures).
 
 - **`explorer/core/settings_schema_defaults.py`** — **Persisted YAML settings schema** defaults (tables, rankings bounds, taxonomy locale, maintenance distance, pin **colour** names allowed in settings).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -48,6 +48,8 @@ python3 scripts/build_all_locations_map_frontend.py
 
 That runs `npm ci` + `npm run build` and reports which `build/` files belong in git vs junk (e.g. macOS Finder duplicates). Details: [explorer/components/all_locations_map/README.md](../explorer/components/all_locations_map/README.md).
 
+**Map HTML export (sidebar):** Lazy build on user action; one-click download via Streamlit + optional auto-click. If users report failed exports, see [map-html-export-ux-alternative.md](explorer/map-html-export-ux-alternative.md) for a two-button fallback design and browser-risk notes.
+
 ---
 
 # Architecture Overview (Streamlit App)

--- a/docs/explorer/map-html-export-ux-alternative.md
+++ b/docs/explorer/map-html-export-ux-alternative.md
@@ -1,0 +1,166 @@
+# Map HTML export — UX design notes and alternative approach
+
+**Audience:** Maintainers and coding agents (not end-user documentation).  
+**Status:** The app ships the **one-click** flow described in §1. The **two-button** flow in §4 is a documented fallback if users report failed or confusing exports.
+
+**Related:** [#222](https://github.com/jimchurches/myebirdstuff/issues/222) · `explorer/components/all_locations_map/TODO.md` (§18) · `explorer/app/streamlit/app_prep_map_ui.py` · `explorer/app/streamlit/app_map_ui.py`
+
+---
+
+## 1. Shipped behaviour (May 2026)
+
+Sidebar control: single **`st.button`** labelled **“Export map HTML”**.
+
+1. User clicks once.
+2. If export bytes are not already in session or the Leaflet export LRU (`LEAFLET_EXPORT_HTML_CACHE_KEY`), build runs with **`st.spinner("Building map HTML…")`** via `_materialize_leaflet_export_html` (lazy — no export work on ordinary map reruns; recipe stored in `LEAFLET_EXPORT_RECIPE_KEY` by `_sync_leaflet_export_recipe` only).
+3. Bytes are stored in `EXPLORER_MAP_HTML_BYTES_KEY` + `LEAFLET_EXPORT_BUILT_CACHE_KEY`.
+4. `st.session_state[EXPORT_MAP_HTML_AUTO_DOWNLOAD_KEY]` is set and **`st.rerun()`** runs.
+5. On the next run, a real **`st.download_button`** (same label) is rendered with the finished bytes; **`inject_auto_click_streamlit_download_js`** (in `app_map_ui.py`) programmatically clicks that button in **`window.parent.document`** (retries at 50 / 200 / 500 ms).
+6. Caption **“Starting download…”** appears on the auto-download run; the download button stays visible as a manual fallback.
+
+**Design goals preserved:**
+
+| Goal | How |
+|------|-----|
+| Lazy export | HTML built only when the user uses Export, not on every map rerun |
+| Map tab stays fast | Recipe sync is cheap; heavy `leaflet_map_to_html_bytes` only on export |
+| Clear feedback | Spinner on build; caption on download pass; `st.error` via `EXPORT_MAP_HTML_ERROR_KEY` on failure |
+| Repeat export | Session + LRU skip rebuild when the map recipe is unchanged |
+
+---
+
+## 2. Why Streamlit makes this awkward
+
+- **`st.download_button`** needs file bytes when the widget is wired for that run. Building in an `on_click` callback on the *same* interaction often leaves users clicking again — the download for click *N* may still use empty or stale `data=` from before the build finished.
+- The old **two-widget** pattern (`st.button` → build → `st.rerun()` → `st.download_button`) worked but felt like “nothing happened” because both steps used the **same label** (“Export map HTML”).
+- **`st.components.v1.html`** runs in a **sandboxed iframe**. Creating a Blob and `<a download>` *inside* that iframe frequently produces **spinners with no file** (build succeeds; save does not). Do not revive that approach.
+
+---
+
+## 3. Approaches considered (history)
+
+| Approach | Result |
+|--------|--------|
+| `st.button` + `st.rerun()` + `st.download_button` (same label) | Works; **confusing** (feels like broken double-click) |
+| `st.download_button` + `on_click` build | Unreliable one-click; still often needs a second click |
+| Blob / anchor inside `st.components.v1.html` | **Failed** in practice (iframe); high block risk |
+| **Current:** build → rerun → `st.download_button` + parent-frame `.click()` | **Shipped**; one click on desktop Safari/macOS in maintainer testing |
+| **Alternative (§4):** explicit Prepare + Download buttons | Not shipped; fallback design |
+
+---
+
+## 4. Alternative approach — two explicit buttons (fallback)
+
+**Use this if users report:** export spins but no file; needing to click many times; confusion about whether anything ran; auto-download blocked in corporate/mobile browsers.
+
+Two controls with **different verbs** — not two buttons both saying “Export”.
+
+### Suggested labels
+
+**Option A (preferred wording)**
+
+| Control | Label | State |
+|---------|--------|--------|
+| 1 | **Prepare map export** | Always enabled (rebuild allowed) |
+| 2 | **Download map HTML** | **Disabled** until build succeeded for current recipe |
+
+Short caption under the pair: *“Prepare first, then download.”*
+
+**Option B (shorter)**
+
+| Control | Label |
+|---------|--------|
+| 1 | **Build export** |
+| 2 | **Save HTML file** |
+
+### UI behaviour
+
+- **Initially:** Prepare enabled · Download disabled (greyed).
+- **User clicks Prepare:** `st.spinner` during `_materialize_leaflet_export_html`; on success store session bytes + LRU; **enable Download**; optional `st.success("Export ready")` or caption with approximate size.
+- **User clicks Download:** native `st.download_button` only — **no JavaScript**, no auto-click.
+- **Map / recipe changes** (`_sync_leaflet_export_recipe` clears stale bytes): **disable Download** again until the next successful Prepare.
+- **Build error:** Download stays disabled; show `st.error` on Prepare.
+- **Unchanged map, already prepared:** Download stays enabled → **one click** for repeat save (same as today’s LRU/session benefit).
+
+### Implementation sketch (when implementing)
+
+- Replace `_render_leaflet_export_map_html_download` in `app_prep_map_ui.py`.
+- Remove `EXPORT_MAP_HTML_AUTO_DOWNLOAD_KEY` and `inject_auto_click_streamlit_download_js` (or keep JS unused).
+- Keys: e.g. `EXPORT_MAP_HTML_PREPARE_BTN_KEY`, `EXPORT_MAP_HTML_DOWNLOAD_BTN_KEY` in `app_constants.py`.
+- Reuse `_leaflet_export_download_bytes`, `_materialize_leaflet_export_html`, `_sync_leaflet_export_recipe` — **no change** to lazy recipe or LRU policy.
+- Style both with `inject_sidebar_outline_download_button_css` (extend selectors if Prepare is `st.button` only).
+
+### Trade-offs vs shipped one-click
+
+| | One-click (shipped) | Two-button (alternative) |
+|--|---------------------|---------------------------|
+| User gestures (cold) | 1 (when auto-click works) | 2 (always clear) |
+| Browser / policy risk | Low–medium (see §5) | **Very low** |
+| UX clarity | Excellent when it works | **Excellent always** |
+| Maintenance | DOM label match + timing retries | Streamlit-native only |
+
+---
+
+## 5. Risk assessment — shipped auto-click script
+
+The file is **not** saved by custom script logic. The script only **clicks Streamlit’s real download button**, which uses Streamlit’s normal server → browser download path (same as a manual click on that widget).
+
+### Unlikely to block (typical desktop)
+
+- macOS Safari, Chrome, Firefox (maintainer tested Safari — OK)
+- Windows Chrome / Edge
+- Repeat export in the same session when bytes are already built
+
+### Higher risk (plan for §4 or manual second click)
+
+| Scenario | Likelihood | Notes |
+|----------|------------|--------|
+| Strict corporate browser policy | Medium | May restrict programmatic clicks or downloads from embedded UIs |
+| Mobile browsers / in-app WebViews | Medium–higher | Smaller targets, different gesture rules, sidebar layout |
+| Privacy extensions | Low–medium | Rare; usually same-origin UI clicks are fine |
+| “Download without user gesture” rules | Low here | User clicked Export; rerun + auto-click is chained in practice but **not guaranteed** across reruns by browsers |
+
+### What was likely to block (avoid)
+
+**Blob + `<a download>` inside `st.components.v1.html`** — common failure mode (sandboxed iframe, no user gesture on that document). That was abandoned for good reason.
+
+### Residual risks — current script
+
+1. **Timing** — Retries at 50 / 200 / 500 ms if the download button is not in the DOM yet; very slow runs might still miss → user can click the visible download control on the auto-download run.
+2. **Label matching** — Script matches button text exactly `"Export map HTML"`; label changes break auto-click (manual download still works).
+3. **Multiple download buttons** — Selects from all `[data-testid="stDownloadButton"] button` (last match with label); unusual duplicate labels could mis-fire.
+4. **Streamlit DOM changes** — `data-testid="stDownloadButton"` is stable in practice but not a public API; major Streamlit UI changes could break auto-click.
+
+### Bottom line
+
+For the expected audience (desktop, normal settings): **blocking is unlikely**. Do not promise “one click everywhere” without qualification. The two-button design (§4) removes dependence on programmatic click if reports accumulate or if you want zero grey-area before a release.
+
+---
+
+## 6. Regression / support checklist
+
+**Shipped flow — quick test**
+
+1. Open Map tab with data loaded.
+2. Click **Export map HTML** once (cold build).
+3. Expect spinner, brief rerun, then browser save dialog / `ebird_map.html` (see `MAP_EXPORT_HTML_FILENAME` in `streamlit_ui_constants.py`).
+4. Click again without changing map — should be fast (LRU/session).
+
+**If user reports failure**
+
+- Ask: browser, OS, corporate device?, did “Starting download…” appear?, second visible Export button?
+- Consider switching to §4 two-button UX in a small PR.
+- Do not reintroduce iframe Blob download.
+
+---
+
+## 7. Key code locations
+
+| Piece | Location |
+|-------|----------|
+| Sidebar export UI | `explorer/app/streamlit/app_prep_map_ui.py` — `_render_leaflet_export_map_html_download` |
+| Auto-click JS | `explorer/app/streamlit/app_map_ui.py` — `inject_auto_click_streamlit_download_js` |
+| Session keys | `explorer/app/streamlit/app_constants.py` — `EXPORT_MAP_HTML_*`, `LEAFLET_EXPORT_*`, `EXPLORER_MAP_HTML_BYTES_KEY` |
+| HTML build | `explorer/presentation/leaflet_map_html_export.py` — `leaflet_map_to_html_bytes` |
+| Export LRU | `explorer/presentation/leaflet_map_export_cache.py` + `_leaflet_export_html_cache_*` in `app_prep_map_ui.py` |
+| Backlog | `explorer/components/all_locations_map/TODO.md` — §18 |

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -124,6 +124,8 @@ STREAMLIT_RESET_SETTINGS_BTN_KEY = "streamlit_reset_settings_btn"
 
 # Download/export button keys.
 EXPORT_MAP_HTML_BTN_KEY = "export_map_html_btn"
+EXPORT_MAP_HTML_DOWNLOAD_BTN_KEY = "export_map_html_download_btn"
+EXPORT_MAP_HTML_AUTO_DOWNLOAD_KEY = "_export_map_html_auto_download_v1"
 EXPORT_MAP_HTML_ERROR_KEY = "export_map_html_error"
 
 # Family map tab widget keys (refs #138). Highlight key is suffixed with selected family in the UI.

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -124,7 +124,7 @@ STREAMLIT_RESET_SETTINGS_BTN_KEY = "streamlit_reset_settings_btn"
 
 # Download/export button keys.
 EXPORT_MAP_HTML_BTN_KEY = "export_map_html_btn"
-EXPORT_MAP_HTML_BUILD_BTN_KEY = "export_map_html_build_btn"
+EXPORT_MAP_HTML_ERROR_KEY = "export_map_html_error"
 
 # Family map tab widget keys (refs #138). Highlight key is suffixed with selected family in the UI.
 STREAMLIT_FAMILY_MAP_FAMILY_KEY = "streamlit_family_map_family"

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -169,18 +169,20 @@ def sidebar_bottom_slot_end() -> None:
 
 
 def inject_sidebar_outline_download_button_css(outline_hex: str) -> None:
-    """Style the map **Export HTML** ``st.download_button`` like the outline support link (refs #127).
+    """Style the map **Export HTML** control like the outline support link (refs #127).
 
     Streamlit widgets are not plain ``<a>`` tags; we align them visually with scoped CSS on
     ``.ebird-sidebar-bottom-slot`` (see :func:`sidebar_bottom_slot_start`).
     Uses the same colour as the footer text links (see :data:`SIDEBAR_FOOTER_LINK_HEX`).
+    Covers both ``st.download_button`` (legacy path) and ``st.button`` (Leaflet one-click export).
     """
     h = outline_hex.strip()
     if not h.startswith("#") or len(h) not in (4, 7, 9):
         h = SIDEBAR_FOOTER_LINK_HEX
     st.html(
         f"""<style>
-.ebird-sidebar-bottom-slot [data-testid="stDownloadButton"] button {{
+.ebird-sidebar-bottom-slot [data-testid="stDownloadButton"] button,
+.ebird-sidebar-bottom-slot [data-testid="stButton"] button {{
   background: transparent !important;
   color: {h} !important;
   border: 1px solid {h} !important;
@@ -189,15 +191,59 @@ def inject_sidebar_outline_download_button_css(outline_hex: str) -> None:
   font-weight: 500 !important;
   box-shadow: none !important;
 }}
-.ebird-sidebar-bottom-slot [data-testid="stDownloadButton"] button:hover {{
+.ebird-sidebar-bottom-slot [data-testid="stDownloadButton"] button:hover,
+.ebird-sidebar-bottom-slot [data-testid="stButton"] button:hover {{
   background: color-mix(in srgb, {h} 14%, transparent) !important;
 }}
 @supports not (color: color-mix(in srgb, black 50%, transparent)) {{
-  .ebird-sidebar-bottom-slot [data-testid="stDownloadButton"] button:hover {{
+  .ebird-sidebar-bottom-slot [data-testid="stDownloadButton"] button:hover,
+  .ebird-sidebar-bottom-slot [data-testid="stButton"] button:hover {{
     background: rgba(134, 142, 150, 0.12) !important;
   }}
 }}
 </style>"""
+    )
+
+
+def trigger_browser_file_download(*, data: bytes, filename: str, mime: str) -> None:
+    """Start a browser file save in the same run as a button click.
+
+    Streamlit's ``st.download_button`` cannot reliably attach bytes that were built during the
+    same interaction (users see a second click). A zero-height HTML component creates a Blob URL
+    and programmatically clicks an anchor — one deliberate export action, build-then-save.
+    """
+    import base64
+    import json
+
+    if not data:
+        return
+    b64 = base64.b64encode(data).decode("ascii")
+    filename_js = json.dumps(filename)
+    mime_js = json.dumps(mime)
+    b64_js = json.dumps(b64)
+    st.components.v1.html(
+        f"""<script>
+(function () {{
+  try {{
+    const b64 = {b64_js};
+    const raw = atob(b64);
+    const arr = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
+    const blob = new Blob([arr], {{ type: {mime_js} }});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = {filename_js};
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }} catch (e) {{
+    console.error("pebird map export download failed", e);
+  }}
+}})();
+</script>""",
+        height=0,
     )
 
 

--- a/explorer/app/streamlit/app_map_ui.py
+++ b/explorer/app/streamlit/app_map_ui.py
@@ -205,41 +205,49 @@ def inject_sidebar_outline_download_button_css(outline_hex: str) -> None:
     )
 
 
-def trigger_browser_file_download(*, data: bytes, filename: str, mime: str) -> None:
-    """Start a browser file save in the same run as a button click.
+def inject_auto_click_streamlit_download_js(*, button_label: str) -> None:
+    """Click a parent-frame ``st.download_button`` after Streamlit renders it.
 
-    Streamlit's ``st.download_button`` cannot reliably attach bytes that were built during the
-    same interaction (users see a second click). A zero-height HTML component creates a Blob URL
-    and programmatically clicks an anchor — one deliberate export action, build-then-save.
+    ``st.components.v1.html`` runs in a sandboxed iframe — Blob/anchor downloads there do not
+    reach the user's filesystem. After export HTML is built, we render a real download_button in
+    the sidebar and programmatically click it in ``window.parent.document``.
     """
-    import base64
     import json
 
-    if not data:
-        return
-    b64 = base64.b64encode(data).decode("ascii")
-    filename_js = json.dumps(filename)
-    mime_js = json.dumps(mime)
-    b64_js = json.dumps(b64)
+    label_js = json.dumps(button_label)
+    st.html(
+        """<style>
+.ebird-export-auto-dl-host {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+</style>"""
+    )
     st.components.v1.html(
         f"""<script>
 (function () {{
-  try {{
-    const b64 = {b64_js};
-    const raw = atob(b64);
-    const arr = new Uint8Array(raw.length);
-    for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
-    const blob = new Blob([arr], {{ type: {mime_js} }});
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = {filename_js};
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  }} catch (e) {{
-    console.error("pebird map export download failed", e);
+  const want = {label_js};
+  function tryClick() {{
+    const root = window.parent && window.parent.document ? window.parent.document : document;
+    const buttons = root.querySelectorAll('[data-testid="stDownloadButton"] button');
+    for (let i = buttons.length - 1; i >= 0; i--) {{
+      const btn = buttons[i];
+      const text = (btn.innerText || btn.textContent || "").trim();
+      if (text === want) {{
+        btn.click();
+        return true;
+      }}
+    }}
+    return false;
+  }}
+  if (!tryClick()) {{
+    setTimeout(tryClick, 50);
+    setTimeout(tryClick, 200);
+    setTimeout(tryClick, 500);
   }}
 }})();
 </script>""",

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -290,7 +290,7 @@ def _render_leaflet_export_map_html_download(recipe: dict[str, Any]) -> None:
         if export_bytes is None:
             st.error("Map export was prepared but bytes are missing. Try Export again.")
             return
-        st.markdown('<div class="ebird-export-auto-dl-host">', unsafe_allow_html=True)
+        st.caption("Starting download…")
         st.download_button(
             "Export map HTML",
             data=export_bytes,
@@ -300,7 +300,6 @@ def _render_leaflet_export_map_html_download(recipe: dict[str, Any]) -> None:
             use_container_width=True,
             type="secondary",
         )
-        st.markdown("</div>", unsafe_allow_html=True)
         inject_auto_click_streamlit_download_js(button_label="Export map HTML")
         return
 

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -33,8 +33,8 @@ from explorer.app.streamlit.app_constants import (
     SPECIES_LEAFLET_PAYLOAD_CACHE_KEY,
     EBIRD_DATA_SIG_KEY,
     EXPLORER_MAP_HTML_BYTES_KEY,
-    EXPORT_MAP_HTML_BUILD_BTN_KEY,
     EXPORT_MAP_HTML_BTN_KEY,
+    EXPORT_MAP_HTML_ERROR_KEY,
     FILTERED_BY_LOC_CACHE_KEY,
     LEAFLET_MAP_MOUNT_NONCE_KEY,
     POPUP_FRAGMENT_CACHE_KEY,
@@ -255,6 +255,69 @@ def _sync_leaflet_export_recipe(
     if st.session_state.get(LEAFLET_EXPORT_BUILT_CACHE_KEY) != recipe_key:
         st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
         st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
+        st.session_state.pop(EXPORT_MAP_HTML_ERROR_KEY, None)
+
+
+def _leaflet_export_session_bytes(recipe: dict[str, Any]) -> bytes | None:
+    """Session snapshot of export HTML when it matches the current recipe."""
+    recipe_key = _leaflet_export_cache_key_for_recipe(recipe)
+    built_key = st.session_state.get(LEAFLET_EXPORT_BUILT_CACHE_KEY)
+    raw = st.session_state.get(EXPLORER_MAP_HTML_BYTES_KEY)
+    if isinstance(raw, (bytes, bytearray)) and built_key == recipe_key:
+        return bytes(raw)
+    return None
+
+
+def _leaflet_export_download_bytes(recipe: dict[str, Any]) -> bytes | None:
+    """Bytes for the sidebar download control without building (session or LRU)."""
+    ready = _leaflet_export_session_bytes(recipe)
+    if ready is not None:
+        return ready
+    return _leaflet_export_html_cache_lookup(_leaflet_export_cache_key_for_recipe(recipe))
+
+
+def _on_leaflet_export_map_html_download() -> None:
+    """Build export HTML on first use; LRU + session make repeat exports one click."""
+    recipe = st.session_state.get(LEAFLET_EXPORT_RECIPE_KEY)
+    if not isinstance(recipe, dict):
+        return
+    st.session_state.pop(EXPORT_MAP_HTML_ERROR_KEY, None)
+    if _leaflet_export_download_bytes(recipe) is not None:
+        return
+    try:
+        with st.spinner("Building map HTML…"):
+            built = _materialize_leaflet_export_html(recipe)
+    except Exception as exc:
+        st.session_state[EXPORT_MAP_HTML_ERROR_KEY] = str(exc)
+        st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
+        st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
+        return
+    st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = built
+    st.session_state[LEAFLET_EXPORT_BUILT_CACHE_KEY] = _leaflet_export_cache_key_for_recipe(recipe)
+    st.toast("Map HTML ready", icon="✅")
+
+
+def _render_leaflet_export_map_html_download(recipe: dict[str, Any]) -> None:
+    """Single Export control: download when cached; build on first click otherwise."""
+    err = st.session_state.get(EXPORT_MAP_HTML_ERROR_KEY)
+    if err:
+        st.error(f"Could not build map export: {err}")
+    export_bytes = _leaflet_export_download_bytes(recipe)
+    if export_bytes is None:
+        st.caption(
+            "First export builds the file (a moment). Click again to download if the file "
+            "does not start automatically."
+        )
+    st.download_button(
+        "Export map HTML",
+        data=export_bytes if export_bytes is not None else b"",
+        file_name=MAP_EXPORT_HTML_FILENAME,
+        mime="text/html",
+        key=EXPORT_MAP_HTML_BTN_KEY,
+        on_click=_on_leaflet_export_map_html_download,
+        use_container_width=True,
+        type="secondary",
+    )
 
 
 def _leaflet_payload_cache_lookup(
@@ -1224,35 +1287,7 @@ def render_prep_spinner_and_map_tab(
             with _ex2:
                 inject_sidebar_outline_download_button_css(SIDEBAR_FOOTER_LINK_HEX)
                 if isinstance(_leaflet_recipe, dict):
-                    _recipe_key = _leaflet_export_cache_key_for_recipe(_leaflet_recipe)
-                    _built_key = st.session_state.get(LEAFLET_EXPORT_BUILT_CACHE_KEY)
-                    _ready_bytes = (
-                        _export_html_bytes
-                        if isinstance(_export_html_bytes, (bytes, bytearray))
-                        and _built_key == _recipe_key
-                        else None
-                    )
-                    if _ready_bytes is not None:
-                        st.download_button(
-                            "Export map HTML",
-                            data=bytes(_ready_bytes),
-                            file_name=MAP_EXPORT_HTML_FILENAME,
-                            mime="text/html",
-                            key=EXPORT_MAP_HTML_BTN_KEY,
-                            use_container_width=True,
-                            type="secondary",
-                        )
-                    elif st.button(
-                        "Export map HTML",
-                        key=EXPORT_MAP_HTML_BUILD_BTN_KEY,
-                        use_container_width=True,
-                        type="secondary",
-                    ):
-                        with st.spinner("Building map HTML…"):
-                            _built = _materialize_leaflet_export_html(_leaflet_recipe)
-                        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = _built
-                        st.session_state[LEAFLET_EXPORT_BUILT_CACHE_KEY] = _recipe_key
-                        st.rerun()
+                    _render_leaflet_export_map_html_download(_leaflet_recipe)
                 elif isinstance(_export_html_bytes, (bytes, bytearray)):
                     st.download_button(
                         "Export map HTML",

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -33,7 +33,9 @@ from explorer.app.streamlit.app_constants import (
     SPECIES_LEAFLET_PAYLOAD_CACHE_KEY,
     EBIRD_DATA_SIG_KEY,
     EXPLORER_MAP_HTML_BYTES_KEY,
+    EXPORT_MAP_HTML_AUTO_DOWNLOAD_KEY,
     EXPORT_MAP_HTML_BTN_KEY,
+    EXPORT_MAP_HTML_DOWNLOAD_BTN_KEY,
     EXPORT_MAP_HTML_ERROR_KEY,
     FILTERED_BY_LOC_CACHE_KEY,
     LEAFLET_MAP_MOUNT_NONCE_KEY,
@@ -58,7 +60,7 @@ from explorer.app.streamlit.app_map_ui import (
     sidebar_bottom_slot_end,
     sidebar_bottom_slot_start,
     sidebar_footer_links,
-    trigger_browser_file_download,
+    inject_auto_click_streamlit_download_js,
 )
 from explorer.app.streamlit.checklist_stats_streamlit_html import (
     sync_checklist_stats_tab_session_inputs,
@@ -278,35 +280,52 @@ def _leaflet_export_download_bytes(recipe: dict[str, Any]) -> bytes | None:
 
 
 def _render_leaflet_export_map_html_download(recipe: dict[str, Any]) -> None:
-    """One-click export: build on button press (spinner), then browser-save via Blob URL."""
+    """One user click: build export HTML (spinner), rerun, auto-fire Streamlit download."""
     err = st.session_state.get(EXPORT_MAP_HTML_ERROR_KEY)
     if err:
         st.error(f"Could not build map export: {err}")
-    if not st.button(
+
+    if st.session_state.pop(EXPORT_MAP_HTML_AUTO_DOWNLOAD_KEY, False):
+        export_bytes = _leaflet_export_download_bytes(recipe)
+        if export_bytes is None:
+            st.error("Map export was prepared but bytes are missing. Try Export again.")
+            return
+        st.markdown('<div class="ebird-export-auto-dl-host">', unsafe_allow_html=True)
+        st.download_button(
+            "Export map HTML",
+            data=export_bytes,
+            file_name=MAP_EXPORT_HTML_FILENAME,
+            mime="text/html",
+            key=EXPORT_MAP_HTML_DOWNLOAD_BTN_KEY,
+            use_container_width=True,
+            type="secondary",
+        )
+        st.markdown("</div>", unsafe_allow_html=True)
+        inject_auto_click_streamlit_download_js(button_label="Export map HTML")
+        return
+
+    if st.button(
         "Export map HTML",
         key=EXPORT_MAP_HTML_BTN_KEY,
         use_container_width=True,
         type="secondary",
     ):
-        return
-    st.session_state.pop(EXPORT_MAP_HTML_ERROR_KEY, None)
-    export_bytes = _leaflet_export_download_bytes(recipe)
-    if export_bytes is None:
+        st.session_state.pop(EXPORT_MAP_HTML_ERROR_KEY, None)
         try:
-            with st.spinner("Building map HTML…"):
-                export_bytes = _materialize_leaflet_export_html(recipe)
+            export_bytes = _leaflet_export_download_bytes(recipe)
+            if export_bytes is None:
+                with st.spinner("Building map HTML…"):
+                    export_bytes = _materialize_leaflet_export_html(recipe)
+            recipe_key = _leaflet_export_cache_key_for_recipe(recipe)
+            st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = export_bytes
+            st.session_state[LEAFLET_EXPORT_BUILT_CACHE_KEY] = recipe_key
         except Exception as exc:
             st.session_state[EXPORT_MAP_HTML_ERROR_KEY] = str(exc)
             st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
             st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
             return
-        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = export_bytes
-        st.session_state[LEAFLET_EXPORT_BUILT_CACHE_KEY] = _leaflet_export_cache_key_for_recipe(recipe)
-    trigger_browser_file_download(
-        data=export_bytes,
-        filename=MAP_EXPORT_HTML_FILENAME,
-        mime="text/html",
-    )
+        st.session_state[EXPORT_MAP_HTML_AUTO_DOWNLOAD_KEY] = True
+        st.rerun()
 
 
 def _leaflet_payload_cache_lookup(

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -58,6 +58,7 @@ from explorer.app.streamlit.app_map_ui import (
     sidebar_bottom_slot_end,
     sidebar_bottom_slot_start,
     sidebar_footer_links,
+    trigger_browser_file_download,
 )
 from explorer.app.streamlit.checklist_stats_streamlit_html import (
     sync_checklist_stats_tab_session_inputs,
@@ -276,47 +277,35 @@ def _leaflet_export_download_bytes(recipe: dict[str, Any]) -> bytes | None:
     return _leaflet_export_html_cache_lookup(_leaflet_export_cache_key_for_recipe(recipe))
 
 
-def _on_leaflet_export_map_html_download() -> None:
-    """Build export HTML on first use; LRU + session make repeat exports one click."""
-    recipe = st.session_state.get(LEAFLET_EXPORT_RECIPE_KEY)
-    if not isinstance(recipe, dict):
-        return
-    st.session_state.pop(EXPORT_MAP_HTML_ERROR_KEY, None)
-    if _leaflet_export_download_bytes(recipe) is not None:
-        return
-    try:
-        with st.spinner("Building map HTML…"):
-            built = _materialize_leaflet_export_html(recipe)
-    except Exception as exc:
-        st.session_state[EXPORT_MAP_HTML_ERROR_KEY] = str(exc)
-        st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
-        st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
-        return
-    st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = built
-    st.session_state[LEAFLET_EXPORT_BUILT_CACHE_KEY] = _leaflet_export_cache_key_for_recipe(recipe)
-    st.toast("Map HTML ready", icon="✅")
-
-
 def _render_leaflet_export_map_html_download(recipe: dict[str, Any]) -> None:
-    """Single Export control: download when cached; build on first click otherwise."""
+    """One-click export: build on button press (spinner), then browser-save via Blob URL."""
     err = st.session_state.get(EXPORT_MAP_HTML_ERROR_KEY)
     if err:
         st.error(f"Could not build map export: {err}")
-    export_bytes = _leaflet_export_download_bytes(recipe)
-    if export_bytes is None:
-        st.caption(
-            "First export builds the file (a moment). Click again to download if the file "
-            "does not start automatically."
-        )
-    st.download_button(
+    if not st.button(
         "Export map HTML",
-        data=export_bytes if export_bytes is not None else b"",
-        file_name=MAP_EXPORT_HTML_FILENAME,
-        mime="text/html",
         key=EXPORT_MAP_HTML_BTN_KEY,
-        on_click=_on_leaflet_export_map_html_download,
         use_container_width=True,
         type="secondary",
+    ):
+        return
+    st.session_state.pop(EXPORT_MAP_HTML_ERROR_KEY, None)
+    export_bytes = _leaflet_export_download_bytes(recipe)
+    if export_bytes is None:
+        try:
+            with st.spinner("Building map HTML…"):
+                export_bytes = _materialize_leaflet_export_html(recipe)
+        except Exception as exc:
+            st.session_state[EXPORT_MAP_HTML_ERROR_KEY] = str(exc)
+            st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
+            st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
+            return
+        st.session_state[EXPLORER_MAP_HTML_BYTES_KEY] = export_bytes
+        st.session_state[LEAFLET_EXPORT_BUILT_CACHE_KEY] = _leaflet_export_cache_key_for_recipe(recipe)
+    trigger_browser_file_download(
+        data=export_bytes,
+        filename=MAP_EXPORT_HTML_FILENAME,
+        mime="text/html",
     )
 
 

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -11,7 +11,7 @@ Update this file as items ship so the backlog stays visible outside chat history
 
 ### #222 status and rollout (source narrative)
 
-**Where we are (May 2026):** All four Map-tab modes are on the **Leaflet custom component** on `beta-next`. **`222-folium-removal`**: Folium stack removed; **§16 design utility** Leaflet preview restored — **merge-ready** after PR smoke.
+**Where we are (May 2026):** All four Map-tab modes on **Leaflet** on `beta-next`. Folium stack **removed** (#232). **§17 Fix now** popup parity **shipped** (#233). Optional **§17 full pass** (design-review table) and **§10** docs remain.
 
 | Map mode | Status | PR (approx.) |
 |----------|--------|----------------|
@@ -20,15 +20,16 @@ Update this file as items ship so the backlog stays visible outside chat history
 | **Species locations** | **Done** — §6 (species row) | #226 |
 | **Family locations** | **Done** — §6 (family row) | #228 |
 | **Design utility (preview)** | **Done** — §16 | — |
-| **Popup template parity (all maps)** | **Next major step** — §17 | — |
+| **Popup template — Fix now (§17)** | **Done** | #233 |
+| **Popup template — full pass (§17)** | **Optional** — product choices | — |
 
-### Next major step — §17 (popup review)
+### §17 status
 
-**Goal:** One shared popup “template” as far as practical — fonts, sizes, heading row, section labels, link styles, spacing — across **All locations**, **Species**, **Lifer**, **Family**, **exported HTML**, and the design utility (simple name-only popups).
+**Fix now (#233):** Species rules mirrored in `AllLocationsMapPopup.css`; location headings wrap with `__heading-row` clearance (all modes); export popups use same BEM + `popup_v1_export_html.py` tests for all four payload types.
 
-**Approach:** Audit each mode side-by-side in the iframe + export file; align TS layouts (`AllLocationsMap.tsx`), `AllLocationsMapPopup.css`, and `map_popup_theme_stylesheet()` / `popup_v1_export_html.py`. **Some inconsistencies are worth fixing immediately** (see §17 **Fix now**); the rest can follow in a dedicated pass after `222-folium-removal` merges.
+**Optional full pass:** Heading margin 4px vs 6px (species), section-label uniformity, lifer line shape, manual cross-mode checklist — see §17 table below. Not blocking **#222** closure.
 
-**#222** can close after Folium-removal PR merges and brief smoke on `beta-next`. **§17** can continue on `beta-next` (or a follow-up branch) — not a blocker for landing Folium removal if obvious fixes are cherry-picked.
+**#222** can close after brief smoke on `beta-next` if you are satisfied with map parity; keep open only if you want the §17 full-pass checklist done first.
 
 **Integrate onto `beta-next` in batches:** Prefer **several small PRs into `beta-next` only** (per [CONTRIBUTING.md](../../../CONTRIBUTING.md)).
 
@@ -83,7 +84,8 @@ Width finalized in TS only (`AllLocationsMap.tsx` + `AllLocationsMapPopup.css`).
 
 **Do (export popup HTML):**
 
-- Add tests for `lifer_popup_v1`, `family_popup_v1`, and `species_popup_v1` via `popup_export_html_from_properties`.
+- [x] Tests for `lifer_popup_v1`, `family_popup_v1`, and `species_popup_v1` via `popup_export_html_from_properties` (#233).
+- [x] Export `visited_truncated` trunc-hint parity with live map (`popup_v1_export_html`, `visit_trunc_hint_html` on `LocationPopupModel`).
 - **Optional:** Assert banner/legend fragments in exported HTML.
 
 **Follow-up:** §18 — export button UX (single click, clear feedback).
@@ -143,11 +145,11 @@ Width finalized in TS only (`AllLocationsMap.tsx` + `AllLocationsMapPopup.css`).
 
 ---
 
-## 17. Popup template parity across all map modes — **next major step**
+## 17. Popup template parity across all map modes — **Fix now done (#233); full pass optional**
 
-Audit (May 2026): all four Leaflet modes share `map_overlay_theme_stylesheet()` injected into the iframe plus `AllLocationsMapPopup.css` (`.pebird-map-popup` base **0.8125rem**, green headings, green links). Structured payloads (`popup_v1`, `species_popup_v1`, `lifer_popup_v1`, `family_popup_v1`) are rendered by **one TS layout per mode** in `AllLocationsMap.tsx`; export uses `popup_v1_export_html.py` with the same BEM classes.
+Audit (May 2026): all four Leaflet modes share `map_overlay_theme_stylesheet()` injected into the iframe plus `AllLocationsMapPopup.css` (`.pebird-map-popup` base **0.8125rem**, green headings, green links). Structured payloads (`popup_v1`, `species_popup_v1`, `lifer_popup_v1`, `family_popup_v1`) are rendered by **one TS layout per mode** in `AllLocationsMap.tsx`; export uses `popup_v1_export_html.py` with the same BEM classes (standalone export also embeds `AllLocationsMapPopup.css`).
 
-**Headings are largely aligned** via `pebird-map-popup__location-heading`. Remaining work is spacing, section chrome, species-specific rules, export vs iframe parity, and documenting intentional differences.
+**Headings aligned** via `pebird-map-popup__location-heading` + `map_popup_heading_text.prevent_orphan_closing_punctuation` (Python + TS). Optional full pass: spacing choices, section chrome, manual cross-mode checklist.
 
 ### Architecture (target)
 
@@ -166,15 +168,15 @@ See [README.md](./README.md) — “Popup anchor vs iframe size” and structure
 - **Family body text:** Species rows → `pebird-map-popup__species-line`; empty state → `pebird-map-popup__summary-line`.
 - **Family width cap:** Removed `max-width:22rem`; species names `nowrap` + horizontal scroll on overflow (visit-list pattern).
 
-### Fix now (worth doing before or right after Folium-removal PR)
+### Fix now — **done (#233)**
 
-| Item | Maps | Notes |
+| Item | Maps | Status |
 |------|------|--------|
-| **Species-only CSS in component CSS file** | Species | `obs-line`, `species-seen`, disclosure chevrons live in Python `map_popup_theme_stylesheet` only; iframe relies on injected theme. **Folium is gone** — copy/mirror into `AllLocationsMapPopup.css` so popup styling survives theme injection changes. |
-| **Species map — long location heading** | Species | Long location names (e.g. Hooded Robin at “Nombinnie Nature Reserve (East)--…”) use `nowrap`; title can run under the close control. Align with All locations: `__heading-row` scroll and/or `padding-right`, or controlled wrap — pick one cross-map rule. |
-| **Export popup HTML parity** | All 4 | Spot-check exported HTML popups vs iframe for the same fixture pin; fix class/structure drift (feeds §7 tests). |
+| **Species-only CSS in component CSS file** | Species | **Done** — `obs-line`, `species-seen`, `all-visits`, chevrons, `media-link` in `AllLocationsMapPopup.css` (mirrors `map_popup_theme_stylesheet`). |
+| **Long location heading** | All 4 | **Done** — `white-space: normal` on `__location-heading`; `__heading-row` `padding-right: 2.25rem`; orphan punctuation helper (Python + TS). |
+| **Export popup HTML parity** | All 4 | **Done** — `popup_v1_export_html.py` + tests in `test_leaflet_map_html_export.py`; export HTML bundles component CSS. **Except:** `visited_truncated` trunc-hint block (see §7). |
 
-### Full pass (design review — after merge OK)
+### Full pass (design review — optional)
 
 | Item | Maps | Notes |
 |------|------|--------|
@@ -249,18 +251,17 @@ From PR #228. **Not blocking** merge.
 
 ## Agent handover
 
-*Last updated: May 2026 — **Folium removed**; **§16 done**; **§17 = next major step** (popup template parity); **§18** = export button UX follow-up.*
+*Last updated: May 2026 — **Folium removed** (#232); **§16 done**; **§17 Fix now done** (#233); **§18** = export button UX; optional §17 full pass + §10 docs.*
 
-**Before merge `222-folium-removal` → `beta-next`:** Smoke design utility + Map tab (regression checklist Map section).
+**Smoke (before closing #222):** Design utility + Map tab — regression checklist Map section.
 
-**Immediately after merge (recommended order):**
+**In progress (branch `222-export-html-ux`):** §7 export trunc-hint **done**; §18 export button single-click UX — next commit.
 
-1. **§17** — popup template parity (cherry-pick **Fix now** items if not in Folium-removal PR).
-2. §7 — export popup tests.
-3. §10 — documentation pass (Folium references).
-4. §13–§14 — cache polish (optional).
-5. §8 — perf (#205).
-6. §18 — export button single-click UX (when prioritised).
-7. Close **#222** when §17 fix-now + smoke are acceptable (or keep #222 open until §17 full pass — your call).
+**Recommended next work (after export PR):**
+
+1. §10 — documentation pass (Folium → Leaflet architecture).
+2. Close **#222** after smoke on `beta-next` (optional §17 full-pass checklist first).
+3. §13–§14 — cache polish (optional).
+4. §8 — perf (#205).
 
 **Recover lost §17 detail:** `git show bdfa70f1^:explorer/components/all_locations_map/TODO.md` (section “## 15. Popup typography…” before Folium-removal commit collapsed it).

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -174,7 +174,7 @@ See [README.md](./README.md) — “Popup anchor vs iframe size” and structure
 |------|------|--------|
 | **Species-only CSS in component CSS file** | Species | **Done** — `obs-line`, `species-seen`, `all-visits`, chevrons, `media-link` in `AllLocationsMapPopup.css` (mirrors `map_popup_theme_stylesheet`). |
 | **Long location heading** | All 4 | **Done** — `white-space: normal` on `__location-heading`; `__heading-row` `padding-right: 2.25rem`; orphan punctuation helper (Python + TS). |
-| **Export popup HTML parity** | All 4 | **Done** — `popup_v1_export_html.py` + tests in `test_leaflet_map_html_export.py`; export HTML bundles component CSS. **Except:** `visited_truncated` trunc-hint block (see §7). |
+| **Export popup HTML parity** | All 4 | **Done** — `popup_v1_export_html.py` + tests; export bundles `AllLocationsMapPopup.css`; trunc-hint when visits capped (§7). |
 
 ### Full pass (design review — optional)
 
@@ -225,37 +225,21 @@ From PR #228. **Not blocking** merge.
 
 ---
 
-## 18. Export map HTML — button UX (deferred)
+## 18. Export map HTML — button UX — **done**
 
-**Out of scope** for popup / §17 work (e.g. PR #233). Track here for a dedicated pass.
+**Shipped:** One sidebar `st.download_button` (“Export map HTML”) with `on_click` lazy build (`_on_leaflet_export_map_html_download`). Spinner + toast on first build; `st.error` on failure. Repeat exports use session bytes or `LEAFLET_EXPORT_HTML_CACHE_KEY` LRU without rebuilding — **one click** when cached. First build for a new recipe may still need a second click (Streamlit serves `data=` from the run after the build callback). Caption explains that case. Recipe sync still lazy (`_sync_leaflet_export_recipe` only); no export work on ordinary map reruns.
 
-**Reported (May 2026):** Users often need **multiple clicks** on “Export map HTML” before a download happens — easy to wonder whether anything ran.
-
-**Current design (intentional trade-off):** Export HTML is **not** built during normal Map-tab reruns. `_sync_leaflet_export_recipe` in `app_prep_map_ui.py` only stores inputs (`LEAFLET_EXPORT_RECIPE_KEY`); `_materialize_leaflet_export_html` runs on button use. Sidebar uses a **two-step Streamlit pattern**: `EXPORT_MAP_HTML_BUILD_BTN_KEY` (`st.button` → build + `st.rerun()`) then `EXPORT_MAP_HTML_BTN_KEY` (`st.download_button` on the next run). That keeps Explorer map interaction fast but splits build and download across runs.
-
-**Target outcomes:**
-
-| Outcome | Notes |
-|---------|--------|
-| **Single click starts export** | One deliberate action should produce the file (or an unmistakable in-progress state), not “click until something happens”. |
-| **Clear feedback** | Spinner/progress/success/error so the user is never left wondering. |
-| **No online slowdown** | Do **not** move export build back into every map rerun / payload prep path. |
-| **Lazy export only** | No export-specific work until the user uses the export control. |
-| **Low-use feature OK** | Slower export build is acceptable; Map-tab responsiveness is not. |
-
-**Do:** Revisit `app_prep_map_ui.py` export block (~`LEAFLET_EXPORT_*`, `EXPLORER_MAP_HTML_BYTES_KEY`) — e.g. one control that builds and downloads in one gesture (Streamlit constraints), or build-on-first-click with immediate download without a silent second click. Keep `LEAFLET_EXPORT_HTML_CACHE_KEY` LRU for repeat exports of the same recipe.
-
-**Files:** `app_prep_map_ui.py`, `app_constants.py` (`EXPORT_MAP_HTML_*` keys), `leaflet_map_html_export.py`, `leaflet_map_export_cache.py`.
+**Files:** `app_prep_map_ui.py`, `app_constants.py` (`EXPORT_MAP_HTML_BTN_KEY`, `EXPORT_MAP_HTML_ERROR_KEY`).
 
 ---
 
 ## Agent handover
 
-*Last updated: May 2026 — **Folium removed** (#232); **§16 done**; **§17 Fix now done** (#233); **§18** = export button UX; optional §17 full pass + §10 docs.*
+*Last updated: May 2026 — **§7 + §18 export HTML done** on `222-export-html-ux`; optional §17 full pass + §10 docs next.*
 
 **Smoke (before closing #222):** Design utility + Map tab — regression checklist Map section.
 
-**In progress (branch `222-export-html-ux`):** §7 export trunc-hint **done**; §18 export button single-click UX — next commit.
+**Branch `222-export-html-ux`:** §7 + §18 export HTML work.
 
 **Recommended next work (after export PR):**
 

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -227,9 +227,9 @@ From PR #228. **Not blocking** merge.
 
 ## 18. Export map HTML — button UX — **done**
 
-**Shipped:** One sidebar `st.download_button` (“Export map HTML”) with `on_click` lazy build (`_on_leaflet_export_map_html_download`). Spinner + toast on first build; `st.error` on failure. Repeat exports use session bytes or `LEAFLET_EXPORT_HTML_CACHE_KEY` LRU without rebuilding — **one click** when cached. First build for a new recipe may still need a second click (Streamlit serves `data=` from the run after the build callback). Caption explains that case. Recipe sync still lazy (`_sync_leaflet_export_recipe` only); no export work on ordinary map reruns.
+**Shipped:** One sidebar `st.button` (“Export map HTML”). On click: build if needed (`_materialize_leaflet_export_html` + spinner; session/LRU skip rebuild), then `trigger_browser_file_download` (Blob URL + anchor) so **one click** always saves the file. `st.download_button` cannot attach bytes built in the same interaction reliably (Streamlit widget lifecycle). Recipe sync stays lazy (`_sync_leaflet_export_recipe` only); no export work on ordinary map reruns.
 
-**Files:** `app_prep_map_ui.py`, `app_constants.py` (`EXPORT_MAP_HTML_BTN_KEY`, `EXPORT_MAP_HTML_ERROR_KEY`).
+**Files:** `app_prep_map_ui.py`, `app_map_ui.py` (`trigger_browser_file_download`), `app_constants.py`.
 
 ---
 

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -11,15 +11,17 @@ Update this file as items ship so the backlog stays visible outside chat history
 
 ### #222 status and rollout (source narrative)
 
-**Where we are (May 2026):** All four Map-tab modes on **Leaflet** on `beta-next`. Folium stack **removed** (#232). **§17 Fix now** popup parity **shipped** (#233). Optional **§17 full pass** (design-review table) and **§10** docs remain.
+**Where we are (May 2026):** All four Map-tab modes on **Leaflet** on `beta-next`. Folium stack **removed** (#232). **§7** export popup parity + **§18** export button UX **shipped** (`222-export-html-ux`). **§17 Fix now** popup parity **shipped** (#233). Optional **§17 full pass** and **§10** docs remain. **#222** stays open until smoke / optional follow-ups.
 
-| Map mode | Status | PR (approx.) |
-|----------|--------|----------------|
+| Map mode / workstream | Status | PR (approx.) |
+|-----------------------|--------|----------------|
 | **All locations** | **Done** — §1–5 | #224 |
 | **Lifer locations** | **Done** — §6 (lifer row) | #225 |
 | **Species locations** | **Done** — §6 (species row) | #226 |
 | **Family locations** | **Done** — §6 (family row) | #228 |
 | **Design utility (preview)** | **Done** — §16 | — |
+| **Export HTML — popup parity (§7)** | **Done** | `222-export-html-ux` |
+| **Export HTML — button UX (§18)** | **Done** | `222-export-html-ux` |
 | **Popup template — Fix now (§17)** | **Done** | #233 |
 | **Popup template — full pass (§17)** | **Optional** — product choices | — |
 
@@ -78,17 +80,15 @@ Width finalized in TS only (`AllLocationsMap.tsx` + `AllLocationsMapPopup.css`).
 
 ---
 
-## 7. Export map HTML — **done (single-stack HTML)**
+## 7. Export map HTML — **done**
 
-**Shipped:** `leaflet_map_to_html_bytes` — standalone HTML with CDN Leaflet + MarkerCluster.
+**Shipped:** `leaflet_map_to_html_bytes` — standalone HTML with CDN Leaflet + MarkerCluster (#230). Export popup HTML tests (#233). **`visited_truncated` trunc-hint** in export path matches live map (`popup_v1_export_html`, `visit_trunc_hint_html` on `LocationPopupModel`) — `222-export-html-ux`.
 
 **Do (export popup HTML):**
 
 - [x] Tests for `lifer_popup_v1`, `family_popup_v1`, and `species_popup_v1` via `popup_export_html_from_properties` (#233).
-- [x] Export `visited_truncated` trunc-hint parity with live map (`popup_v1_export_html`, `visit_trunc_hint_html` on `LocationPopupModel`).
+- [x] Export `visited_truncated` trunc-hint parity with live map (`222-export-html-ux`).
 - **Optional:** Assert banner/legend fragments in exported HTML.
-
-**Follow-up:** §18 — export button UX (single click, clear feedback).
 
 ---
 
@@ -227,7 +227,9 @@ From PR #228. **Not blocking** merge.
 
 ## 18. Export map HTML — button UX — **done**
 
-**Shipped:** One sidebar `st.button` (“Export map HTML”). On click: build if needed (spinner; session/LRU skip rebuild), `st.rerun()`, hidden `st.download_button` with bytes, parent-frame JS auto-clicks it (iframe Blob downloads do not work). One user click; lazy recipe sync unchanged.
+**Shipped (`222-export-html-ux`):** One sidebar `st.button` (“Export map HTML”). On click: build if needed (spinner; session/LRU skip rebuild), `st.rerun()`, `st.download_button` + parent-frame JS auto-click. One user click on typical desktop browsers (maintainer-tested Safari/macOS); lazy recipe sync unchanged.
+
+**Alternative (if exports fail in the field):** Two-button Prepare + Download UX — see [`docs/explorer/map-html-export-ux-alternative.md`](../../../docs/explorer/map-html-export-ux-alternative.md).
 
 **Files:** `app_prep_map_ui.py`, `app_map_ui.py` (`inject_auto_click_streamlit_download_js`), `app_constants.py`.
 
@@ -235,16 +237,14 @@ From PR #228. **Not blocking** merge.
 
 ## Agent handover
 
-*Last updated: May 2026 — **§7 + §18 export HTML done** on `222-export-html-ux`; optional §17 full pass + §10 docs next.*
+*Last updated: May 2026 — **§7 + §18 done**; merge `222-export-html-ux` → `beta-next` (Refs #222).*
 
-**Smoke (before closing #222):** Design utility + Map tab — regression checklist Map section.
+**Smoke (before closing #222):** Design utility + Map tab — regression checklist Map section; Export map HTML once (cold + repeat).
 
-**Branch `222-export-html-ux`:** §7 + §18 export HTML work.
-
-**Recommended next work (after export PR):**
+**Recommended next work (after this PR merges):**
 
 1. §10 — documentation pass (Folium → Leaflet architecture).
-2. Close **#222** after smoke on `beta-next` (optional §17 full-pass checklist first).
+2. Optional §17 full-pass checklist; then close **#222** when satisfied.
 3. §13–§14 — cache polish (optional).
 4. §8 — perf (#205).
 

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -227,9 +227,9 @@ From PR #228. **Not blocking** merge.
 
 ## 18. Export map HTML — button UX — **done**
 
-**Shipped:** One sidebar `st.button` (“Export map HTML”). On click: build if needed (`_materialize_leaflet_export_html` + spinner; session/LRU skip rebuild), then `trigger_browser_file_download` (Blob URL + anchor) so **one click** always saves the file. `st.download_button` cannot attach bytes built in the same interaction reliably (Streamlit widget lifecycle). Recipe sync stays lazy (`_sync_leaflet_export_recipe` only); no export work on ordinary map reruns.
+**Shipped:** One sidebar `st.button` (“Export map HTML”). On click: build if needed (spinner; session/LRU skip rebuild), `st.rerun()`, hidden `st.download_button` with bytes, parent-frame JS auto-clicks it (iframe Blob downloads do not work). One user click; lazy recipe sync unchanged.
 
-**Files:** `app_prep_map_ui.py`, `app_map_ui.py` (`trigger_browser_file_download`), `app_constants.py`.
+**Files:** `app_prep_map_ui.py`, `app_map_ui.py` (`inject_auto_click_streamlit_download_js`), `app_constants.py`.
 
 ---
 

--- a/explorer/presentation/map_popup_models.py
+++ b/explorer/presentation/map_popup_models.py
@@ -27,6 +27,7 @@ class LocationPopupModel:
     show_visit_history: bool
     lifer_heading_html: str
     location_heading_margin_px: int
+    visit_trunc_hint_html: str = ""
 
 
 def assemble_location_popup_html(m: LocationPopupModel) -> str:
@@ -55,10 +56,11 @@ def assemble_location_popup_html(m: LocationPopupModel) -> str:
         if m.show_visit_history
         else ""
     )
+    trunc_hint = m.visit_trunc_hint_html or ""
     if visited_section and extra_section:
-        inner_html = visited_section + "<br>" + extra_section
+        inner_html = visited_section + trunc_hint + "<br>" + extra_section
     else:
-        inner_html = visited_section + extra_section
+        inner_html = visited_section + trunc_hint + extra_section
     return (
         f'<div class="pebird-map-popup popup-scroll-wrapper" style="position:relative;">'
         f'<div class="pebird-map-popup__heading-row" style="margin-bottom:{int(m.location_heading_margin_px)}px;">{loc_link}</div>'

--- a/explorer/presentation/popup_v1_export_html.py
+++ b/explorer/presentation/popup_v1_export_html.py
@@ -51,6 +51,39 @@ def _loc_id_from_props(props: dict[str, Any]) -> str:
     return ""
 
 
+def _visited_trunc_hint_html(
+    *,
+    entries: list[Any],
+    lifelist_url: str,
+    loc_id: str,
+    popup: dict[str, Any],
+) -> str:
+    """Mirror ``popupHtmlVisitedLayout`` trunc block in ``AllLocationsMap.tsx``."""
+    if popup.get("visited_truncated") is not True:
+        return ""
+    try:
+        omitted = int(popup.get("visited_omitted") or 0)
+    except (TypeError, ValueError):
+        omitted = 0
+    if omitted <= 0:
+        return ""
+    href = _lifelist_href(lifelist_url, loc_id)
+    if not href:
+        return ""
+    shown = len(entries)
+    try:
+        total = int(popup.get("visited_total"))
+    except (TypeError, ValueError):
+        total = shown + omitted
+    return (
+        f'<div class="pebird-map-popup__trunc-hint">'
+        f"{esc_text(str(shown))} of {esc_text(str(total))} checklists shown. "
+        f'<a href="{esc_attr(href)}" target="_blank" rel="noopener noreferrer">Open lifelist</a> '
+        f"for full history ({esc_text(str(omitted))} more)."
+        f"</div>"
+    )
+
+
 def _visit_entries_html(entries: list[dict[str, str]]) -> str:
     parts: list[str] = []
     for e in entries:
@@ -190,6 +223,12 @@ def _popup_v1_html(name: str, lifelist_url: str, popup: dict[str, Any]) -> str:
     if isinstance(visited, dict):
         entries = visited.get("entries") if isinstance(visited.get("entries"), list) else []
         loc_id = _loc_id_from_props({"lifelist_url": lifelist_url})
+        trunc_hint = _visited_trunc_hint_html(
+            entries=entries,
+            lifelist_url=lifelist_url,
+            loc_id=loc_id,
+            popup=popup,
+        )
         return assemble_location_popup_html(
             LocationPopupModel(
                 loc_name=name,
@@ -200,6 +239,7 @@ def _popup_v1_html(name: str, lifelist_url: str, popup: dict[str, Any]) -> str:
                 show_visit_history=True,
                 lifer_heading_html="",
                 location_heading_margin_px=_HEADING_MARGIN_ALL,
+                visit_trunc_hint_html=trunc_hint,
             )
         )
     summary_lines = popup.get("summary_lines") if isinstance(popup.get("summary_lines"), list) else []

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -46,6 +46,36 @@ def test_popup_export_html_all_locations_visited():
     assert "popup-scroll-wrapper" in html
 
 
+def test_popup_export_html_visited_truncated_hint():
+    html = popup_export_html_from_properties(
+        {
+            "name": "Busy Hotspot",
+            "lifelist_url": "https://ebird.org/lifelist/L42",
+            "popup_v1": {
+                "v": 1,
+                "visited": {
+                    "label": "Visited:",
+                    "entries": [
+                        {
+                            "label": f"2024-01-{d:02d}",
+                            "href": f"https://ebird.org/checklist/S{d}",
+                        }
+                        for d in range(1, 6)
+                    ],
+                },
+                "visited_truncated": True,
+                "visited_total": 50,
+                "visited_omitted": 45,
+            },
+        }
+    )
+    assert "pebird-map-popup__trunc-hint" in html
+    assert "5 of 50 checklists shown" in html
+    assert "Open lifelist" in html
+    assert "(45 more)" in html
+    assert 'href="https://ebird.org/lifelist/L42"' in html
+
+
 def test_popup_export_html_long_location_heading_wraps_in_row():
     long_name = (
         "Lake Gilles Conservation Park--Track off Lake Gilles Rd at -33.0123, 137.4567"


### PR DESCRIPTION
## Summary

Completes **#222** export HTML follow-ups **§7** (exported popup trunc-hint parity) and **§18** (sidebar export UX). Does not close #222 — Folium→Leaflet migration and optional backlog (§10 docs, §17 full pass) remain.

## Changes

### §7 — Export popup parity
- Emit `visited_truncated` / `pebird-map-popup__trunc-hint` in `popup_v1_export_html` when All locations caps inline visits (`EXPLORER_EXPERIMENTAL_VISITS_INLINE_CAP`)
- `visit_trunc_hint_html` on `LocationPopupModel`
- Test: `test_popup_export_html_visited_truncated_hint`

### §18 — Export button UX
- Replace build-then-rerun two-widget pattern with one **Export map HTML** button
- Lazy build on click (`_materialize_leaflet_export_html` + spinner); session + `LEAFLET_EXPORT_HTML_CACHE_KEY` LRU for repeats
- After build: `st.download_button` + parent-frame auto-click (`inject_auto_click_streamlit_download_js`) — one click on typical desktop browsers
- Manual download fallback visible on auto-download run if JS cannot fire

### Docs
- Mark §7 / §18 **done** in `explorer/components/all_locations_map/TODO.md`
- Add [`docs/explorer/map-html-export-ux-alternative.md`](docs/explorer/map-html-export-ux-alternative.md) — two-button fallback design + browser-risk notes for agents/maintainers
- Cross-links from `docs/development.md`, `docs/AI_CONTEXT.md`

## Testing

- `python3 -m ruff check explorer/` — pass
- `python3 -m pytest tests/ -q` — 553 passed, 4 skipped
- Manual: Export map HTML on Map tab (cold build + repeat); Safari/macOS OK per maintainer

## Notes

- Export HTML is still **not** built on ordinary map reruns (recipe sync only).
- **#222** remains open for smoke on `beta-next` and optional §10 / §17 work.

## Issues

Refs #222

Made with [Cursor](https://cursor.com)