### PR TITLE
Leaflet map payload cache polish and lifer export popup parity

### DIFF
--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -160,7 +160,9 @@ from explorer.presentation.map_renderer import (
 )
 
 
-# Species map: cache hide-only vs all-locations payloads separately (toggle thrashes a single slot).
+# Leaflet payload LRU sizes (variants per map — e.g. cluster / hide-non-matching / subspecies toggles).
+_ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES = 4
+_LIFER_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES = 2
 _SPECIES_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES = 2
 _FAMILY_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES = 4
 _LEAFLET_EXPORT_HTML_CACHE_MAX_ENTRIES = 6
@@ -562,62 +564,10 @@ def render_prep_spinner_and_map_tab(
 
                     if not fam:
                         map_hint_text = "Select a family in the sidebar to load the map data"
-                        all_locations_leaflet_banner_html = ""
-                        all_locations_leaflet_legend_html = ""
                     elif fam not in fams or work is None or getattr(work, "empty", True):
                         map_hint_text = "No family data available (taxonomy may not have loaded)."
-                        all_locations_leaflet_banner_html = ""
-                        all_locations_leaflet_legend_html = ""
                     else:
                         map_hint_text = None
-                        with perf_span("prep.family_map_composition_with_pins"):
-                            wf = filter_work_to_family(work, fam)
-                            metrics = (
-                                compute_family_map_banner_metrics(work, fam, tax_merged)
-                                if tax_merged is not None
-                                else None
-                            )
-                            pins = build_family_location_pins(
-                                wf,
-                                highlight_base_species=hl or None,
-                            )
-                            family_species_url_by_common = (
-                                build_common_name_to_species_url(
-                                    wf,
-                                    tax_merged,
-                                    fallback_fn=species_url_fn,
-                                )
-                                if tax_merged is not None and not getattr(tax_merged, "empty", True)
-                                else {}
-                            )
-                            base_to_common = bundle.get("base_to_common") or {}
-                            hl_label = (base_to_common.get(hl) or hl) if hl else ""
-                            sel_counts = (
-                                selected_species_checklist_individual_counts(wf, hl)
-                                if hl and metrics
-                                else None
-                            )
-                            hl_species_url = None
-                            if hl and hl_label:
-                                _u = species_url_fn(hl_label)
-                                hl_species_url = _u if _u else None
-                            all_locations_leaflet_banner_html = (
-                                build_family_map_banner_overlay_html(
-                                    metrics,
-                                    selected_species_n_checklists=sel_counts[0] if sel_counts else None,
-                                    selected_species_n_individuals=sel_counts[1] if sel_counts else None,
-                                    selected_species_display_name=hl_label or None,
-                                    selected_species_url=hl_species_url,
-                                )
-                                if metrics
-                                else ""
-                            )
-                            all_locations_leaflet_legend_html = build_family_map_legend_overlay_html_for_pins(
-                                pins,
-                                highlight_label=hl_label or None,
-                                highlight_species_url=hl_species_url,
-                                style=_visit_sch,
-                            )
 
                     _perf_family: dict[str, Any] = {
                         "embed": "family_leaflet",
@@ -635,9 +585,16 @@ def render_prep_spinner_and_map_tab(
                             leaflet_geojson = cached_fam["geojson"]
                             family_framing_pairs = list(cached_fam.get("framing_pairs") or [])
                             family_highlight_framed = bool(cached_fam.get("highlight_framed"))
+                            all_locations_leaflet_banner_html = str(
+                                cached_fam.get("banner_html") or ""
+                            )
+                            all_locations_leaflet_legend_html = str(
+                                cached_fam.get("legend_html") or ""
+                            )
                             _perf_family["payload_cache_hit"] = True
                         elif not fam or fam not in fams or work is None or getattr(work, "empty", True):
                             family_framing_pairs = []
+                            family_highlight_framed = False
                             empty_features: list[dict[str, Any]] = []
                             rev_payload = (
                                 json.dumps(empty_features, separators=(",", ":"))
@@ -651,7 +608,75 @@ def render_prep_spinner_and_map_tab(
                                 "type": "FeatureCollection",
                                 "features": empty_features,
                             }
+                            _leaflet_payload_cache_store(
+                                FAMILY_LEAFLET_PAYLOAD_CACHE_KEY,
+                                payload_cache_key,
+                                {
+                                    "revision": leaflet_revision,
+                                    "geojson": leaflet_geojson,
+                                    "framing_pairs": family_framing_pairs,
+                                    "highlight_framed": family_highlight_framed,
+                                    "banner_html": "",
+                                    "legend_html": "",
+                                },
+                                max_entries=_FAMILY_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES,
+                            )
                         else:
+                            with perf_span("prep.family_map_composition_with_pins"):
+                                wf = filter_work_to_family(work, fam)
+                                metrics = (
+                                    compute_family_map_banner_metrics(work, fam, tax_merged)
+                                    if tax_merged is not None
+                                    else None
+                                )
+                                pins = build_family_location_pins(
+                                    wf,
+                                    highlight_base_species=hl or None,
+                                )
+                                family_species_url_by_common = (
+                                    build_common_name_to_species_url(
+                                        wf,
+                                        tax_merged,
+                                        fallback_fn=species_url_fn,
+                                    )
+                                    if tax_merged is not None
+                                    and not getattr(tax_merged, "empty", True)
+                                    else {}
+                                )
+                                base_to_common = bundle.get("base_to_common") or {}
+                                hl_label = (base_to_common.get(hl) or hl) if hl else ""
+                                sel_counts = (
+                                    selected_species_checklist_individual_counts(wf, hl)
+                                    if hl and metrics
+                                    else None
+                                )
+                                hl_species_url = None
+                                if hl and hl_label:
+                                    _u = species_url_fn(hl_label)
+                                    hl_species_url = _u if _u else None
+                                all_locations_leaflet_banner_html = (
+                                    build_family_map_banner_overlay_html(
+                                        metrics,
+                                        selected_species_n_checklists=(
+                                            sel_counts[0] if sel_counts else None
+                                        ),
+                                        selected_species_n_individuals=(
+                                            sel_counts[1] if sel_counts else None
+                                        ),
+                                        selected_species_display_name=hl_label or None,
+                                        selected_species_url=hl_species_url,
+                                    )
+                                    if metrics
+                                    else ""
+                                )
+                                all_locations_leaflet_legend_html = (
+                                    build_family_map_legend_overlay_html_for_pins(
+                                        pins,
+                                        highlight_label=hl_label or None,
+                                        highlight_species_url=hl_species_url,
+                                        style=_visit_sch,
+                                    )
+                                )
                             (
                                 leaflet_revision,
                                 leaflet_geojson,
@@ -676,6 +701,8 @@ def render_prep_spinner_and_map_tab(
                                     "geojson": leaflet_geojson,
                                     "framing_pairs": family_framing_pairs,
                                     "highlight_framed": family_highlight_framed,
+                                    "banner_html": all_locations_leaflet_banner_html,
+                                    "legend_html": all_locations_leaflet_legend_html,
                                 },
                                 max_entries=_FAMILY_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES,
                             )
@@ -847,13 +874,19 @@ def render_prep_spinner_and_map_tab(
                             "visits_inline_cap": visits_inline_max,
                         }
                         with perf_span("map.all_locations_leaflet.payload", extra=_perf_leaflet):
-                            cached_pl = st.session_state.get(ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY)
-                            if (
-                                isinstance(cached_pl, dict)
-                                and cached_pl.get("payload_cache_key") == payload_cache_key
-                            ):
+                            cached_pl = _leaflet_payload_cache_lookup(
+                                ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY,
+                                payload_cache_key,
+                            )
+                            if cached_pl is not None:
                                 leaflet_revision = str(cached_pl["revision"])
                                 leaflet_geojson = cached_pl["geojson"]
+                                all_locations_leaflet_banner_html = str(
+                                    cached_pl.get("banner_html") or ""
+                                )
+                                all_locations_leaflet_legend_html = str(
+                                    cached_pl.get("legend_html") or ""
+                                )
                                 _perf_leaflet["payload_cache_hit"] = True
                             else:
                                 loc_df = ctx["location_data"]
@@ -871,24 +904,30 @@ def render_prep_spinner_and_map_tab(
                                     omit_pin_colour=True,
                                     revision_extra=revision_extra_json,
                                 )
-                                st.session_state[ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY] = {
-                                    "payload_cache_key": payload_cache_key,
-                                    "revision": leaflet_revision,
-                                    "geojson": leaflet_geojson,
-                                }
-                        n_loc, n_chk, n_sp, n_ind = ctx["effective_totals"]
-                        all_locations_leaflet_banner_html = build_all_locations_banner_html(
-                            n_loc,
-                            n_chk,
-                            n_sp,
-                            n_ind,
-                        )
-                        _ls = str(leaflet_circle_style.get("stroke_hex") or "#1c2630")
-                        _lf = str(leaflet_circle_style.get("fill_hex") or "#3388ff")
-                        all_locations_leaflet_legend_html = build_legend_html(
-                            [(_ls, _lf, "All locations")],
-                            container_style=STREAMLIT_COMPONENT_MAP_LEGEND_STYLE,
-                        )
+                                n_loc, n_chk, n_sp, n_ind = ctx["effective_totals"]
+                                all_locations_leaflet_banner_html = build_all_locations_banner_html(
+                                    n_loc,
+                                    n_chk,
+                                    n_sp,
+                                    n_ind,
+                                )
+                                _ls = str(leaflet_circle_style.get("stroke_hex") or "#1c2630")
+                                _lf = str(leaflet_circle_style.get("fill_hex") or "#3388ff")
+                                all_locations_leaflet_legend_html = build_legend_html(
+                                    [(_ls, _lf, "All locations")],
+                                    container_style=STREAMLIT_COMPONENT_MAP_LEGEND_STYLE,
+                                )
+                                _leaflet_payload_cache_store(
+                                    ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY,
+                                    payload_cache_key,
+                                    {
+                                        "revision": leaflet_revision,
+                                        "geojson": leaflet_geojson,
+                                        "banner_html": all_locations_leaflet_banner_html,
+                                        "legend_html": all_locations_leaflet_legend_html,
+                                    },
+                                    max_entries=_ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES,
+                                )
                         result_warning = None
                     elif use_lifer_leaflet:
                         result_warning = None
@@ -920,14 +959,20 @@ def render_prep_spinner_and_map_tab(
                             "payload_cache_hit": False,
                         }
                         with perf_span("map.lifer_leaflet.payload", extra=_perf_lifer):
-                            cached_lif = st.session_state.get(LIFER_LEAFLET_PAYLOAD_CACHE_KEY)
-                            if (
-                                isinstance(cached_lif, dict)
-                                and cached_lif.get("payload_cache_key") == payload_cache_key
-                            ):
+                            cached_lif = _leaflet_payload_cache_lookup(
+                                LIFER_LEAFLET_PAYLOAD_CACHE_KEY,
+                                payload_cache_key,
+                            )
+                            if cached_lif is not None:
                                 leaflet_revision = str(cached_lif["revision"])
                                 leaflet_geojson = cached_lif["geojson"]
                                 lifer_framing_pairs = list(cached_lif.get("framing_pairs") or [])
+                                all_locations_leaflet_banner_html = str(
+                                    cached_lif.get("banner_html") or ""
+                                )
+                                all_locations_leaflet_legend_html = str(
+                                    cached_lif.get("legend_html") or ""
+                                )
                                 _perf_lifer["payload_cache_hit"] = True
                             else:
                                 (
@@ -951,54 +996,62 @@ def render_prep_spinner_and_map_tab(
                                     leaflet_geojson = None
                                     lifer_framing_pairs = []
                                 else:
-                                    st.session_state[LIFER_LEAFLET_PAYLOAD_CACHE_KEY] = {
-                                        "payload_cache_key": payload_cache_key,
-                                        "revision": leaflet_revision,
-                                        "geojson": leaflet_geojson,
-                                        "framing_pairs": lifer_framing_pairs,
-                                    }
+                                    n_lifer_sp = len(ctx["true_lifer_locations"])
+                                    n_pin = len(leaflet_geojson.get("features") or [])
+                                    all_locations_leaflet_banner_html = (
+                                        build_lifer_locations_banner_html(
+                                            n_lifer_sp,
+                                            n_pin,
+                                            include_subspecies=subsp,
+                                            n_subspecies_lifers=(
+                                                count_subspecies_lifer_taxa(
+                                                    ctx["lifer_lookup_df"],
+                                                    ctx["true_lifer_locations_taxon"],
+                                                )
+                                                if subsp
+                                                else None
+                                            ),
+                                        )
+                                    )
+                                    le, lf, se, sp, _rl, _rs, _sw, _fo1, _fo2 = (
+                                        resolve_lifer_overlay_pin_params(_visit_sch)
+                                    )
+                                    if not subsp:
+                                        all_locations_leaflet_legend_html = build_legend_html(
+                                            [(le, lf, "Lifer")],
+                                            container_style=STREAMLIT_COMPONENT_MAP_LEGEND_STYLE,
+                                        )
+                                    else:
+                                        kinds_present: set[str] = set()
+                                        for f in leaflet_geojson.get("features") or []:
+                                            pr = f.get("properties")
+                                            if isinstance(pr, dict):
+                                                pk = pr.get("pin_kind")
+                                                if pk:
+                                                    kinds_present.add(str(pk))
+                                        legend_rows: list[tuple[str, str, str]] = []
+                                        if "lifer" in kinds_present:
+                                            legend_rows.append((le, lf, "Lifer"))
+                                        if "subspecies" in kinds_present:
+                                            legend_rows.append((se, sp, "Subspecies"))
+                                        all_locations_leaflet_legend_html = build_legend_html(
+                                            legend_rows,
+                                            container_style=STREAMLIT_COMPONENT_MAP_LEGEND_STYLE,
+                                        )
+                                    _leaflet_payload_cache_store(
+                                        LIFER_LEAFLET_PAYLOAD_CACHE_KEY,
+                                        payload_cache_key,
+                                        {
+                                            "revision": leaflet_revision,
+                                            "geojson": leaflet_geojson,
+                                            "framing_pairs": lifer_framing_pairs,
+                                            "banner_html": all_locations_leaflet_banner_html,
+                                            "legend_html": all_locations_leaflet_legend_html,
+                                        },
+                                        max_entries=_LIFER_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES,
+                                    )
                             if leaflet_revision and leaflet_geojson is not None:
                                 leaflet_viewport = lifer_leaflet_viewport_recipe(lifer_framing_pairs)
-                                n_lifer_sp = len(ctx["true_lifer_locations"])
-                                n_pin = len(leaflet_geojson.get("features") or [])
-                                all_locations_leaflet_banner_html = build_lifer_locations_banner_html(
-                                    n_lifer_sp,
-                                    n_pin,
-                                    include_subspecies=subsp,
-                                    n_subspecies_lifers=(
-                                        count_subspecies_lifer_taxa(
-                                            ctx["lifer_lookup_df"],
-                                            ctx["true_lifer_locations_taxon"],
-                                        )
-                                        if subsp
-                                        else None
-                                    ),
-                                )
-                                le, lf, se, sp, _rl, _rs, _sw, _fo1, _fo2 = (
-                                    resolve_lifer_overlay_pin_params(_visit_sch)
-                                )
-                                if not subsp:
-                                    all_locations_leaflet_legend_html = build_legend_html(
-                                        [(le, lf, "Lifer")],
-                                        container_style=STREAMLIT_COMPONENT_MAP_LEGEND_STYLE,
-                                    )
-                                else:
-                                    kinds_present: set[str] = set()
-                                    for f in leaflet_geojson.get("features") or []:
-                                        pr = f.get("properties")
-                                        if isinstance(pr, dict):
-                                            pk = pr.get("pin_kind")
-                                            if pk:
-                                                kinds_present.add(str(pk))
-                                    legend_rows: list[tuple[str, str, str]] = []
-                                    if "lifer" in kinds_present:
-                                        legend_rows.append((le, lf, "Lifer"))
-                                    if "subspecies" in kinds_present:
-                                        legend_rows.append((se, sp, "Subspecies"))
-                                    all_locations_leaflet_legend_html = build_legend_html(
-                                        legend_rows,
-                                        container_style=STREAMLIT_COMPONENT_MAP_LEGEND_STYLE,
-                                    )
                     elif use_species_leaflet:
                         result_warning = None
                         leaflet_cluster_opts = {
@@ -1042,9 +1095,16 @@ def render_prep_spinner_and_map_tab(
                                 leaflet_geojson = cached_sp["geojson"]
                                 species_framing_pairs = list(cached_sp.get("framing_pairs") or [])
                                 species_pin_roles = set(cached_sp.get("pin_roles") or [])
+                                all_locations_leaflet_banner_html = str(
+                                    cached_sp.get("banner_html") or ""
+                                )
+                                all_locations_leaflet_legend_html = str(
+                                    cached_sp.get("legend_html") or ""
+                                )
                                 _perf_species["payload_cache_hit"] = True
                             elif not overlay_sci:
                                 species_framing_pairs = []
+                                species_pin_roles = set()
                                 empty_features: list[dict[str, Any]] = []
                                 rev_payload = (
                                     json.dumps(empty_features, separators=(",", ":"))
@@ -1058,6 +1118,23 @@ def render_prep_spinner_and_map_tab(
                                     "type": "FeatureCollection",
                                     "features": empty_features,
                                 }
+                                all_locations_leaflet_banner_html = (
+                                    build_species_locations_awaiting_selection_banner_html()
+                                )
+                                all_locations_leaflet_legend_html = ""
+                                _leaflet_payload_cache_store(
+                                    SPECIES_LEAFLET_PAYLOAD_CACHE_KEY,
+                                    payload_cache_key,
+                                    {
+                                        "revision": leaflet_revision,
+                                        "geojson": leaflet_geojson,
+                                        "framing_pairs": species_framing_pairs,
+                                        "pin_roles": [],
+                                        "banner_html": all_locations_leaflet_banner_html,
+                                        "legend_html": all_locations_leaflet_legend_html,
+                                    },
+                                    max_entries=_SPECIES_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES,
+                                )
                             else:
                                 popup_visit_dates_ascending = (
                                     str(popup_sort_order).strip().lower() != "descending"
@@ -1095,31 +1172,6 @@ def render_prep_spinner_and_map_tab(
                                     pin_roles = set()
                                 else:
                                     species_pin_roles = set(pin_roles)
-                                    _leaflet_payload_cache_store(
-                                        SPECIES_LEAFLET_PAYLOAD_CACHE_KEY,
-                                        payload_cache_key,
-                                        {
-                                            "revision": leaflet_revision,
-                                            "geojson": leaflet_geojson,
-                                            "framing_pairs": species_framing_pairs,
-                                            "pin_roles": sorted(species_pin_roles),
-                                        },
-                                        max_entries=_SPECIES_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES,
-                                    )
-                            if leaflet_revision and leaflet_geojson is not None:
-                                leaflet_viewport = species_leaflet_viewport_recipe(
-                                    species_framing_pairs,
-                                    go_to_gps_pin=_go_pin,
-                                    blank_viewport_recipe=blank_viewport_recipe
-                                    if not overlay_sci
-                                    else None,
-                                )
-                                if not overlay_sci:
-                                    all_locations_leaflet_banner_html = (
-                                        build_species_locations_awaiting_selection_banner_html()
-                                    )
-                                    all_locations_leaflet_legend_html = ""
-                                else:
                                     _filtered_sp = filter_species(ctx["df"], overlay_sci)
                                     _banner_fields = compute_species_map_banner_fields(
                                         filtered=_filtered_sp,
@@ -1158,6 +1210,27 @@ def render_prep_spinner_and_map_tab(
                                         if legend_rows
                                         else ""
                                     )
+                                    _leaflet_payload_cache_store(
+                                        SPECIES_LEAFLET_PAYLOAD_CACHE_KEY,
+                                        payload_cache_key,
+                                        {
+                                            "revision": leaflet_revision,
+                                            "geojson": leaflet_geojson,
+                                            "framing_pairs": species_framing_pairs,
+                                            "pin_roles": sorted(species_pin_roles),
+                                            "banner_html": all_locations_leaflet_banner_html,
+                                            "legend_html": all_locations_leaflet_legend_html,
+                                        },
+                                        max_entries=_SPECIES_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES,
+                                    )
+                            if leaflet_revision and leaflet_geojson is not None:
+                                leaflet_viewport = species_leaflet_viewport_recipe(
+                                    species_framing_pairs,
+                                    go_to_gps_pin=_go_pin,
+                                    blank_viewport_recipe=blank_viewport_recipe
+                                    if not overlay_sci
+                                    else None,
+                                )
                 if (
                     (
                         use_all_locations_leaflet

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -7,11 +7,13 @@ Update this file as items ship so the backlog stays visible outside chat history
 
 **Working principles:** Production Map tab uses **only** the Leaflet component. Folium / `streamlit-folium` / `map_controller` were removed on branch **`222-folium-removal`** (May 2026).
 
+**Leaflet payload cache contract (all four maps):** Session LRU via `_leaflet_payload_cache_lookup` / `_store` in `app_prep_map_ui.py`. Each entry holds `revision`, `geojson`, and (where applicable) `banner_html`, `legend_html`, plus mode-specific fields (`framing_pairs`, `pin_roles`, …). Warm reruns skip GeoJSON and overlay HTML rebuilds. LRU sizes: all-locations **4**, lifer **2**, species **2**, family **4** — sized for common toggle pairs (cluster, hide-non-matching, subspecies, highlight).
+
 ---
 
 ### #222 status and rollout (source narrative)
 
-**Where we are (May 2026):** All four Map-tab modes on **Leaflet** on `beta-next`. Folium stack **removed** (#232). **§7** export popup parity + **§18** export button UX **shipped** (`222-export-html-ux`). **§17 Fix now** popup parity **shipped** (#233). Optional **§17 full pass** and **§10** docs remain. **#222** stays open until smoke / optional follow-ups.
+**Where we are (May 2026):** All four Map-tab modes on **Leaflet** on `beta-next`. Folium stack **removed** (#232). **§7** export popup parity + **§18** export button UX **shipped** (`222-export-html-ux`). **§17 Fix now** popup parity **shipped** (#233). **§13–§14** species/family payload cache polish **shipped** (`222-optional-polish-maps`). Optional **§17 full pass** and **§10** docs remain. **#222** stays open until smoke / optional follow-ups.
 
 | Map mode / workstream | Status | PR (approx.) |
 |-----------------------|--------|----------------|
@@ -191,21 +193,17 @@ See [README.md](./README.md) — “Popup anchor vs iframe size” and structure
 
 ---
 
-## 13. Species locations — optional polish (deferred)
+## 13. Species locations — optional polish — **done**
 
 From post–PR #226. **Not blocking** merge.
 
-### Cache banner on payload hit
+### Cache banner on payload hit — **done**
 
-**Gap:** Species Leaflet branch recomputes banner HTML on every rerun even when `SPECIES_LEAFLET_PAYLOAD_CACHE_KEY` hits.
+**Shipped:** `banner_html` and `legend_html` stored in `SPECIES_LEAFLET_PAYLOAD_CACHE_KEY` LRU entries and restored on payload cache hit (no banner recompute on warm rerun).
 
-**Do:** Cache banner fields or HTML in the payload LRU entry.
+### Cache awaiting-selection empty payload — **done**
 
-### Cache awaiting-selection empty payload
-
-**Gap:** Empty GeoJSON when no species selected is rebuilt each rerun; not stored in species payload LRU.
-
-**Do:** Optional — store in 2-entry LRU.
+**Shipped:** Empty GeoJSON + awaiting-selection banner stored in the 2-entry species payload LRU when no species is selected.
 
 ### DRY species banner stats
 
@@ -213,15 +211,17 @@ From post–PR #226. **Not blocking** merge.
 
 ---
 
-## 14. Family locations — optional polish (deferred)
+## 14. Family locations — optional polish — **done**
 
 From PR #228. **Not blocking** merge.
 
-### Cache empty / awaiting-selection payloads
+### Cache empty / awaiting-selection payloads — **done**
 
-**Gap:** Empty family payloads rebuilt each rerun; not stored in `FAMILY_LEAFLET_PAYLOAD_CACHE_KEY`.
+**Shipped:** Empty family GeoJSON (no family selected / invalid family) stored in `FAMILY_LEAFLET_PAYLOAD_CACHE_KEY` 4-entry LRU.
 
-**Do:** Optional — store in 4-entry LRU.
+### Cache banner + composition on payload hit — **done**
+
+**Shipped:** Family pin composition, banner, and legend run only on cache miss; full entries include `banner_html` / `legend_html` restored on hit.
 
 ---
 
@@ -241,11 +241,10 @@ From PR #228. **Not blocking** merge.
 
 **Smoke (before closing #222):** Design utility + Map tab — regression checklist Map section; Export map HTML once (cold + repeat).
 
-**Recommended next work (after this PR merges):**
+**Recommended next work:**
 
 1. §10 — documentation pass (Folium → Leaflet architecture).
 2. Optional §17 full-pass checklist; then close **#222** when satisfied.
-3. §13–§14 — cache polish (optional).
-4. §8 — perf (#205).
+3. §8 — perf / benchmarks (#205).
 
 **Recover lost §17 detail:** `git show bdfa70f1^:explorer/components/all_locations_map/TODO.md` (section “## 15. Popup typography…” before Folium-removal commit collapsed it).

--- a/explorer/components/all_locations_map/TODO.md
+++ b/explorer/components/all_locations_map/TODO.md
@@ -13,7 +13,7 @@ Update this file as items ship so the backlog stays visible outside chat history
 
 ### #222 status and rollout (source narrative)
 
-**Where we are (May 2026):** All four Map-tab modes on **Leaflet** on `beta-next`. Folium stack **removed** (#232). **§7** export popup parity + **§18** export button UX **shipped** (`222-export-html-ux`). **§17 Fix now** popup parity **shipped** (#233). **§13–§14** species/family payload cache polish **shipped** (`222-optional-polish-maps`). Optional **§17 full pass** and **§10** docs remain. **#222** stays open until smoke / optional follow-ups.
+**Where we are (May 2026):** All four Map-tab modes on **Leaflet** on `beta-next`. Folium stack **removed** (#232). **§17** popup parity **done** (#233 + `222-optional-polish-maps`). **§13–§15** four-map payload cache **done** on **`222-optional-polish-maps`** (PR → `beta-next`). **#222** stays **open** for **§8** perf/instrumentation (#205) and **§10** docs (planned after merge). Experimental spike branch retirement is **out of scope** for #222 (separate issues).
 
 | Map mode / workstream | Status | PR (approx.) |
 |-----------------------|--------|----------------|
@@ -24,16 +24,12 @@ Update this file as items ship so the backlog stays visible outside chat history
 | **Design utility (preview)** | **Done** — §16 | — |
 | **Export HTML — popup parity (§7)** | **Done** | `222-export-html-ux` |
 | **Export HTML — button UX (§18)** | **Done** | `222-export-html-ux` |
-| **Popup template — Fix now (§17)** | **Done** | #233 |
-| **Popup template — full pass (§17)** | **Optional** — product choices | — |
+| **Popup template parity (§17)** | **Done** | #233, `222-optional-polish-maps` |
+| **Leaflet payload cache — all four maps (§13–§15)** | **Done** | `222-optional-polish-maps` |
 
-### §17 status
+### §17 status — **done**
 
-**Fix now (#233):** Species rules mirrored in `AllLocationsMapPopup.css`; location headings wrap with `__heading-row` clearance (all modes); export popups use same BEM + `popup_v1_export_html.py` tests for all four payload types.
-
-**Optional full pass:** Heading margin 4px vs 6px (species), section-label uniformity, lifer line shape, manual cross-mode checklist — see §17 table below. Not blocking **#222** closure.
-
-**#222** can close after brief smoke on `beta-next` if you are satisfied with map parity; keep open only if you want the §17 full-pass checklist done first.
+Popup parity accepted for #222 (better than legacy Folium). Remaining visual nits (e.g. species **6px** vs **4px** heading margin, mode-specific section chrome) may be tuned **outside #222** if they show up in use.
 
 **Integrate onto `beta-next` in batches:** Prefer **several small PRs into `beta-next` only** (per [CONTRIBUTING.md](../../../CONTRIBUTING.md)).
 
@@ -101,12 +97,6 @@ Width finalized in TS only (`AllLocationsMap.tsx` + `AllLocationsMapPopup.css`).
 
 ---
 
-## 9. Branch / spike cleanup
-
-- When #222 is landed, retire branch `221-streamlit-custom-map-component-spike` per original plan.
-
----
-
 ## 10. Repository documentation — custom map architecture
 
 **When:** After `222-folium-removal` merges.
@@ -147,11 +137,11 @@ Width finalized in TS only (`AllLocationsMap.tsx` + `AllLocationsMapPopup.css`).
 
 ---
 
-## 17. Popup template parity across all map modes — **Fix now done (#233); full pass optional**
+## 17. Popup template parity across all map modes — **done**
 
 Audit (May 2026): all four Leaflet modes share `map_overlay_theme_stylesheet()` injected into the iframe plus `AllLocationsMapPopup.css` (`.pebird-map-popup` base **0.8125rem**, green headings, green links). Structured payloads (`popup_v1`, `species_popup_v1`, `lifer_popup_v1`, `family_popup_v1`) are rendered by **one TS layout per mode** in `AllLocationsMap.tsx`; export uses `popup_v1_export_html.py` with the same BEM classes (standalone export also embeds `AllLocationsMapPopup.css`).
 
-**Headings aligned** via `pebird-map-popup__location-heading` + `map_popup_heading_text.prevent_orphan_closing_punctuation` (Python + TS). Optional full pass: spacing choices, section chrome, manual cross-mode checklist.
+**Headings aligned** via `pebird-map-popup__location-heading` + `map_popup_heading_text.prevent_orphan_closing_punctuation` (Python + TS).
 
 ### Architecture (target)
 
@@ -170,22 +160,16 @@ See [README.md](./README.md) — “Popup anchor vs iframe size” and structure
 - **Family body text:** Species rows → `pebird-map-popup__species-line`; empty state → `pebird-map-popup__summary-line`.
 - **Family width cap:** Removed `max-width:22rem`; species names `nowrap` + horizontal scroll on overflow (visit-list pattern).
 
-### Fix now — **done (#233)**
-
-| Item | Maps | Status |
-|------|------|--------|
-| **Species-only CSS in component CSS file** | Species | **Done** — `obs-line`, `species-seen`, `all-visits`, chevrons, `media-link` in `AllLocationsMapPopup.css` (mirrors `map_popup_theme_stylesheet`). |
-| **Long location heading** | All 4 | **Done** — `white-space: normal` on `__location-heading`; `__heading-row` `padding-right: 2.25rem`; orphan punctuation helper (Python + TS). |
-| **Export popup HTML parity** | All 4 | **Done** — `popup_v1_export_html.py` + tests; export bundles `AllLocationsMapPopup.css`; trunc-hint when visits capped (§7). |
-
-### Full pass (design review — optional)
+### Shipped
 
 | Item | Maps | Notes |
 |------|------|--------|
-| **Heading margin below title** | All 4 | All/Lifer/Family **4px**; Species **6px** (legacy Folium). Pick one default or document exceptions in `map_popup_models.py` / TS constants. |
-| **Section labels** | Lifer, Family | No `Visited:` / `<details>` chrome (content-driven); All + Species use `__section-label`. Revisit if we want uniform “data block” labels. |
-| **Lifer line format** | Lifer | `Species : date` in one link vs All locations visit rows — **content** shape, not font size; only change if product wants structural parity. |
-| **Cross-mode checklist** | All 4 + export | Open the same location/species on each map mode; compare font size, link colour, bold, truncation hints, scroll regions, popup max width. Update regression checklist Map section if needed. |
+| **Species-only CSS in component CSS file** | Species | `AllLocationsMapPopup.css` mirrors `map_popup_theme_stylesheet` (#233). |
+| **Long location heading** | All 4 | `__heading-row` clearance + orphan punctuation (Python + TS) (#233). |
+| **Export popup HTML parity** | All 4 | `popup_v1_export_html.py` + tests; trunc-hint (§7). |
+| **Lifer export layout (no `Visited:` label)** | Lifer export | `222-optional-polish-maps` — matches `popupHtmlLiferLayout`. |
+
+**Accepted for #222 (change only if noticed in use):** species heading margin **6px** vs **4px** elsewhere; lifer/family content-driven blocks without all-locations `Visited:` chrome; lifer `Species : date` line shape.
 
 **Files:** `AllLocationsMap.tsx`, `AllLocationsMapPopup.css`, `map_renderer.py`, `popup_v1_export_html.py`, `map_popup_models.py`, `map_overlay_species_popups.py`, `map_overlay_family_popups.py`, geojson builders under `explorer/core/`.
 
@@ -225,6 +209,25 @@ From PR #228. **Not blocking** merge.
 
 ---
 
+## 15. Leaflet payload cache — all four maps — **done (`222-optional-polish-maps`)**
+
+Aligns warm-rerun behaviour across modes (builds on §13–§14).
+
+| Map | LRU | Banner / legend on payload hit | Empty / awaiting-selection cached |
+|-----|-----|--------------------------------|-----------------------------------|
+| **All locations** | 4 entries (`_leaflet_payload_cache_*`) | **Done** | N/A |
+| **Lifer** | 2 entries | **Done** | N/A |
+| **Species** | 2 entries | **Done** (§13) | **Done** (§13) |
+| **Family** | 4 entries | **Done** (§14) | **Done** (§14) |
+
+**Shipped:** All-locations and lifer migrated from legacy single-slot session dicts to shared `_leaflet_payload_cache_lookup` / `_store`; `banner_html` + `legend_html` stored and restored on hit (same contract as species/family).
+
+**Files:** `app_prep_map_ui.py` (`_ALL_LOCATIONS_*`, `_LIFER_*`, `_SPECIES_*`, `_FAMILY_*` max entry constants).
+
+**Out of scope (future enhancement):** Per-mode **camera** memory when switching Map view (pan/zoom); payload cache does not remount iframe or preserve user framing.
+
+---
+
 ## 18. Export map HTML — button UX — **done**
 
 **Shipped (`222-export-html-ux`):** One sidebar `st.button` (“Export map HTML”). On click: build if needed (spinner; session/LRU skip rebuild), `st.rerun()`, `st.download_button` + parent-frame JS auto-click. One user click on typical desktop browsers (maintainer-tested Safari/macOS); lazy recipe sync unchanged.
@@ -237,14 +240,25 @@ From PR #228. **Not blocking** merge.
 
 ## Agent handover
 
-*Last updated: May 2026 — **§7 + §18 done**; merge `222-export-html-ux` → `beta-next` (Refs #222).*
+*Last updated: May 2026 — branch **`222-optional-polish-maps`** (PR → `beta-next`, Refs #222).*
 
-**Smoke (before closing #222):** Design utility + Map tab — regression checklist Map section; Export map HTML once (cold + repeat).
+### Shipped on this branch
 
-**Recommended next work:**
+- **§13** — Species payload LRU: banner/legend on hit; empty awaiting-selection payload cached.
+- **§14** — Family payload LRU: empty payloads; composition + banner/legend only on cache miss.
+- **§15** — All-locations + lifer: same LRU helper + banner/legend on hit (four-map contract at top of this file).
+- **§17 export** — Lifer export popup HTML matches live map (no `Visited:` section label).
 
-1. §10 — documentation pass (Folium → Leaflet architecture).
-2. Optional §17 full-pass checklist; then close **#222** when satisfied.
-3. §8 — perf / benchmarks (#205).
+### PR smoke (after merge to `beta-next`)
 
-**Recover lost §17 detail:** `git show bdfa70f1^:explorer/components/all_locations_map/TODO.md` (section “## 15. Popup typography…” before Folium-removal commit collapsed it).
+- Map tab: switch all four **Map view** modes; repeat visit same mode — no unnecessary spinner from banner/geojson rebuild when inputs unchanged.
+- Species: no species selected → repeat rerun; family: no family selected → repeat rerun (empty map cached).
+- Export map HTML: open exported file; lifer pin popup — no `Visited:` label above species lines.
+
+### Recommended next work (post-merge; **#222** remains open)
+
+1. **§8** — perf harness / instrumentation (#205).
+2. **§10** — documentation pass (Folium → Leaflet architecture), last.
+3. Close **#222** when §8 + §10 + smoke are satisfied.
+
+**Recover lost §17 detail:** `git show bdfa70f1^:explorer/components/all_locations_map/TODO.md` (section “## 15. Popup typography…” before Folium-removal commit collapsed it; current **§15** is payload cache).

--- a/explorer/presentation/popup_v1_export_html.py
+++ b/explorer/presentation/popup_v1_export_html.py
@@ -136,6 +136,7 @@ def _species_sections_html(sections: list[dict[str, Any]]) -> str:
 
 
 def _lifer_popup_html(name: str, lifelist_url: str, payload: dict[str, Any]) -> str:
+    """Mirror ``popupHtmlLiferLayout`` in ``AllLocationsMap.tsx`` (no ``Visited:`` section label)."""
     lines = payload.get("lines") if isinstance(payload.get("lines"), list) else []
     inner_parts: list[str] = []
     for i, row in enumerate(lines):
@@ -153,17 +154,17 @@ def _lifer_popup_html(name: str, lifelist_url: str, payload: dict[str, Any]) -> 
         else:
             inner_parts.append(f"{prefix}<span>{label} : {date_s}</span>")
     loc_id = _loc_id_from_props({"lifelist_url": lifelist_url})
-    model = LocationPopupModel(
-        loc_name=name,
-        loc_id=loc_id or "0",
-        visit_info_html="".join(inner_parts),
-        sightings_html="",
-        lifer_species_html="",
-        show_visit_history=True,
-        lifer_heading_html="",
-        location_heading_margin_px=_HEADING_MARGIN_ALL,
+    url = _lifelist_href(lifelist_url, loc_id)
+    head = _location_heading_element(name, url or None)
+    inner = "".join(inner_parts)
+    return (
+        f'<div class="pebird-map-popup popup-scroll-wrapper" style="position:relative;">'
+        f'<div class="pebird-map-popup__heading-row" style="margin-bottom:{_HEADING_MARGIN_ALL}px;">{head}</div>'
+        f'<div class="pebird-map-popup__scroll" style="max-height:300px;overflow-y:auto;">'
+        f'<div class="pebird-map-popup__visited-block">'
+        f'<div class="pebird-map-popup__visit-dates">{inner}</div>'
+        f"</div></div></div>"
     )
-    return assemble_location_popup_html(model)
 
 
 def _family_popup_html(name: str, lifelist_url: str, payload: dict[str, Any]) -> str:

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -118,7 +118,10 @@ def test_popup_export_html_lifer_popup_v1():
     assert "Lifer Site" in html
     assert "Superb Fairywren" in html
     assert "pebird-map-popup__visit-dates" in html
+    assert "pebird-map-popup__visited-block" in html
     assert "popup-scroll-wrapper" in html
+    assert "Visited:" not in html
+    assert "pebird-map-popup__section-label" not in html
 
 
 def test_popup_export_html_family_popup_v1():


### PR DESCRIPTION
## Summary

Optional #222 polish: align Leaflet **payload session cache** across all four Map-tab modes (GeoJSON + banner/legend on warm reruns), and fix **lifer export** popup HTML to match the live component (no spurious `Visited:` label). Updates `TODO.md` — §13–§17 and cache work marked done; **#222 stays open** for §8 perf (#205) and §10 docs.

## Changes

- **§13–§15 — Payload cache (`app_prep_map_ui.py`)**
  - Species: cache banner/legend on LRU hit; cache empty awaiting-selection payload.
  - Family: cache empty payloads; pin composition + banner/legend only on cache miss.
  - All locations + lifer: migrate to shared `_leaflet_payload_cache_lookup` / `_store` with `banner_html` / `legend_html` on hit (LRU sizes 4 / 2 / 2 / 4).
- **§17 — Lifer export popup (`popup_v1_export_html.py`)**
  - `_lifer_popup_html` mirrors `popupHtmlLiferLayout` (heading + visit lines; no `Visited:` section label).
  - Test asserts export HTML matches live layout.
- **`TODO.md`**
  - §17 marked done for #222; §9 experimental branch retirement removed from #222 scope.
  - Handover points to §8 then §10 before closing #222.

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` — 553 passed, 4 skipped

### Manual smoke (suggested after merge)

- Switch Map view across all four modes; revisit same mode — warm rerun should skip banner/geojson rebuild when inputs unchanged.
- Export map HTML → lifer pin popup: no `Visited:` label above species lines.

## Notes

- Does **not** close #222. Next planned work: **§8** instrumentation/perf (#205), then **§10** documentation.
- Per-mode **camera memory** when switching Map view remains a future enhancement (not in this PR).
- Experimental spike branch cleanup is tracked outside #222.

## Issues

Refs #222


Made with [Cursor](https://cursor.com)