### PR TITLE
Fix family map highlight species links and share taxonomy load

### DIFF
--- a/explorer/app/streamlit/app_caches.py
+++ b/explorer/app/streamlit/app_caches.py
@@ -74,17 +74,16 @@ def cached_family_map_bundle(df_full: pd.DataFrame, taxonomy_locale: str) -> dic
         merge_taxonomy_detail_for_family_map,
         prepare_family_map_work_frame,
     )
-    from explorer.core.species_family import (
-        build_base_species_to_family_map,
-        load_taxonomy_groups,
-        load_taxonomy_species_rows,
-    )
+    from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
+    from explorer.core.species_family import build_base_species_to_family_map
+    from explorer.core.taxonomy_bundle import load_taxonomy_bundle, taxonomy_locale_key
 
-    loc = (taxonomy_locale or "").strip()
+    loc = taxonomy_locale_key(taxonomy_locale) or TAXONOMY_LOCALE_DEFAULT
     try:
+        bundle = load_taxonomy_bundle(loc)
+        tax = bundle.species_rows
+        groups = list(bundle.groups)
         base_to_family = build_base_species_to_family_map(loc)
-        tax = load_taxonomy_species_rows(loc)
-        groups = load_taxonomy_groups(loc)
         tax_merged = merge_taxonomy_detail_for_family_map(tax, groups)
     except Exception:
         return {

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -404,7 +404,9 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                     family_highlight_base = st.selectbox(
                         "Highlight species (optional)",
                         options=[""] + bases,
-                        format_func=lambda b: "— None —" if b == "" else (base_to_common.get(b) or b),
+                        format_func=lambda b: "— None —"
+                        if b == ""
+                        else (base_to_common.get(str(b).strip().lower()) or b),
                         key=STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY,
                     )
                 else:

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -121,6 +121,7 @@ from explorer.core.family_map_compute import (
     compute_family_map_banner_metrics,
     filter_work_to_family,
     selected_species_checklist_individual_counts,
+    species_url_for_base_species,
 )
 from explorer.app.streamlit.defaults import (
     MAP_ALL_LOCATIONS_CENTRE_OF_GRAVITY_ZOOM,
@@ -671,9 +672,33 @@ def render_prep_spinner_and_map_tab(
                                     else None
                                 )
                                 hl_species_url = None
-                                if hl and hl_label:
-                                    _u = species_url_fn(hl_label)
-                                    hl_species_url = _u if _u else None
+                                if hl:
+                                    hl_species_url = species_url_for_base_species(
+                                        hl,
+                                        tax_merged,
+                                        fallback_fn=species_url_fn,
+                                        fallback_common_name=hl_label or None,
+                                    )
+                                    if not hl_species_url and family_species_url_by_common:
+                                        _hl_rows = wf[
+                                            wf["_base"]
+                                            .astype(str)
+                                            .str.strip()
+                                            .str.lower()
+                                            == hl
+                                        ]
+                                        for _cn in (
+                                            _hl_rows["Common Name"]
+                                            .fillna("")
+                                            .astype(str)
+                                            .str.strip()
+                                            .unique()
+                                        ):
+                                            if _cn:
+                                                _u = family_species_url_by_common.get(_cn)
+                                                if _u:
+                                                    hl_species_url = _u
+                                                    break
                                 all_locations_leaflet_banner_html = (
                                     build_family_map_banner_overlay_html(
                                         metrics,

--- a/explorer/core/family_map_compute.py
+++ b/explorer/core/family_map_compute.py
@@ -197,7 +197,8 @@ def highlight_species_choices_alphabetical(
     bases = sorted(work_family["_base"].dropna().astype(str).str.strip().unique(), key=str.casefold)
 
     def label_for(b: str) -> str:
-        return (base_to_common.get(b) or b).strip() or b
+        key = str(b).strip().lower()
+        return (base_to_common.get(key) or b).strip() or b
 
     pairs = [(label_for(b), b) for b in bases]
     pairs.sort(key=lambda p: (p[0].casefold(), p[1].casefold()))
@@ -288,6 +289,35 @@ def merge_taxonomy_detail_for_family_map(
         lambda x: pd.Series(assign_group_for_taxon_order(float(x), glist))
     )
     return tax
+
+
+def species_url_for_base_species(
+    base_species: str,
+    taxonomy_merged: pd.DataFrame | None,
+    *,
+    fallback_fn: Callable[[str], str | None] | None = None,
+    fallback_common_name: str | None = None,
+) -> str | None:
+    """eBird species page URL for a base scientific name (banner/legend parity with map popups).
+
+    Popups resolve via ``_base`` → ``species_code`` in *taxonomy_merged*; the startup
+    :func:`~explorer.core.taxonomy.get_species_url` cache is only a fallback when that fails.
+    """
+    b = str(base_species or "").strip().lower()
+    if not b:
+        return None
+    tax = taxonomy_merged if taxonomy_merged is not None else pd.DataFrame()
+    if not tax.empty and {"base_species", "species_code"}.issubset(tax.columns):
+        sub = tax[tax["base_species"].astype(str).str.strip().str.lower() == b]
+        for _, row in sub.iterrows():
+            code = str(row.get("species_code") or "").strip()
+            if code:
+                return f"https://ebird.org/species/{code}"
+    if fallback_fn and fallback_common_name:
+        name = str(fallback_common_name).strip()
+        if name:
+            return fallback_fn(name)
+    return None
 
 
 def build_common_name_to_species_url(

--- a/explorer/core/species_family.py
+++ b/explorer/core/species_family.py
@@ -4,106 +4,29 @@ Fetches the same eBird taxonomy CSV and species-group JSON as the **Families** t
 (:func:`~explorer.app.streamlit.rankings_streamlit_html._build_group_coverage_tables`).
 Core code uses :func:`build_base_species_to_family_map` with ``functools.lru_cache``;
 Streamlit layers may add separate ``@st.cache_data`` around the loaders.
+
+Network loads are shared via :func:`~explorer.core.taxonomy_bundle.load_taxonomy_bundle`.
 """
 
 from __future__ import annotations
 
-import csv
 import functools
-import io
-import json
 from typing import Any
-
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
 
 import pandas as pd
 
 from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
-
-_TAXONOMY_EBIRD_URL = "https://api.ebird.org/v2/ref/taxonomy/ebird"
-_GROUPS_EBIRD_URL = "https://api.ebird.org/v2/ref/sppgroup/ebird"
+from explorer.core.taxonomy_bundle import load_taxonomy_bundle, taxonomy_locale_key
 
 
 def load_taxonomy_species_rows(locale: str) -> pd.DataFrame:
     """Load eBird taxonomy rows (species only) with taxon order and base species key."""
-    loc = (locale or "").strip()
-    url = _TAXONOMY_EBIRD_URL
-    if loc:
-        url = f"{url}?{urlencode({'locale': loc})}"
-    req = Request(url, headers={"Accept": "text/csv"})
-    with urlopen(req, timeout=30) as resp:
-        raw = resp.read().decode("utf-8", errors="replace")
-    reader = csv.DictReader(io.StringIO(raw))
-    rows: list[dict[str, Any]] = []
-    for row in reader:
-        cat = str(row.get("CATEGORY", row.get("category", ""))).strip().lower()
-        if cat != "species":
-            continue
-        sci = str(
-            row.get("SCIENTIFIC_NAME")
-            or row.get("SCI_NAME")
-            or row.get("scientific_name")
-            or row.get("sci_name")
-            or ""
-        ).strip()
-        common = str(
-            row.get("COMMON_NAME")
-            or row.get("PRIMARY_COM_NAME")
-            or row.get("common_name")
-            or ""
-        ).strip()
-        code = str(row.get("SPECIES_CODE") or row.get("species_code") or "").strip()
-        tax_raw = row.get("TAXON_ORDER") or row.get("taxon_order") or ""
-        try:
-            taxon_order = float(str(tax_raw).strip())
-        except Exception:
-            continue
-        if not sci or not common:
-            continue
-        rows.append(
-            {
-                "scientific_name": sci,
-                "common_name": common,
-                "species_code": code,
-                "taxon_order": taxon_order,
-                "base_species": " ".join(sci.lower().split()[:2]).strip(),
-            }
-        )
-    return pd.DataFrame(rows)
+    return load_taxonomy_bundle(taxonomy_locale_key(locale)).species_rows
 
 
 def load_taxonomy_groups(locale: str) -> list[dict[str, Any]]:
     """Load eBird species-group (family) ranges for taxon order."""
-    loc = (locale or "").strip()
-    url = _GROUPS_EBIRD_URL
-    if loc:
-        url = f"{url}?{urlencode({'locale': loc})}"
-    req = Request(url, headers={"Accept": "application/json"})
-    with urlopen(req, timeout=30) as resp:
-        raw = resp.read().decode("utf-8", errors="replace")
-    data = json.loads(raw)
-    out: list[dict[str, Any]] = []
-    for item in data:
-        bounds_in = item.get("taxonOrderBounds", []) or []
-        bounds: list[tuple[float, float]] = []
-        for pair in bounds_in:
-            if not isinstance(pair, list) or len(pair) != 2:
-                continue
-            try:
-                lo = float(pair[0])
-                hi = float(pair[1])
-            except Exception:
-                continue
-            bounds.append((lo, hi))
-        out.append(
-            {
-                "group_name": str(item.get("groupName", "")).strip(),
-                "group_order": int(item.get("groupOrder", 0) or 0),
-                "bounds": bounds,
-            }
-        )
-    return out
+    return list(load_taxonomy_bundle(taxonomy_locale_key(locale)).groups)
 
 
 def assign_group_for_taxon_order(taxon_order: float, groups: list[dict[str, Any]]) -> tuple[str, int]:
@@ -136,7 +59,7 @@ def build_base_species_to_family_map(locale: str) -> dict[str, str]:
     Uses the same assignment as Rankings **Families**. Returns ``{}`` if taxonomy
     cannot be loaded (network error, empty response).
     """
-    loc = (locale or "").strip() or TAXONOMY_LOCALE_DEFAULT
+    loc = taxonomy_locale_key(locale) or TAXONOMY_LOCALE_DEFAULT
     try:
         return dict(_base_species_family_items_cached(loc))
     except Exception:

--- a/explorer/core/taxonomy.py
+++ b/explorer/core/taxonomy.py
@@ -16,47 +16,12 @@ same species codes. eBird uses different English names in different regions (e.g
 API reference: https://documenter.getpostman.com/view/664302/S1ENwy59
 """
 
-import csv
-import io
 from urllib.error import URLError
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
 
-_TAXONOMY_BASE = "https://api.ebird.org/v2/ref/taxonomy/ebird"
+from explorer.core.taxonomy_bundle import load_taxonomy_bundle, taxonomy_locale_key
+
 # In-memory cache: common_name (strip) -> species_code. None if not loaded or load failed.
 _common_to_code: dict[str, str] | None = None
-
-
-def _taxonomy_csv_to_lookup(raw: str) -> dict[str, str] | None:
-    """Parse taxonomy CSV body into common_name -> species_code for category ``species`` only."""
-    reader = csv.DictReader(io.StringIO(raw))
-    if not reader.fieldnames:
-        return None
-    field_lower = {f.strip().lower(): f for f in reader.fieldnames}
-    common_key = field_lower.get("common_name") or field_lower.get("common name")
-    code_key = field_lower.get("species_code") or field_lower.get("species code")
-    category_key = field_lower.get("category")
-    if not common_key or not code_key or not category_key:
-        return None
-    lookup: dict[str, str] = {}
-    for row in reader:
-        cat = (row.get(category_key) or "").strip().lower()
-        if cat != "species":
-            continue
-        common = (row.get(common_key) or "").strip()
-        code = (row.get(code_key) or "").strip()
-        if common and code:
-            lookup[common] = code
-    return lookup
-
-
-def _fetch_taxonomy_csv(url: str) -> str | None:
-    try:
-        req = Request(url, headers={"Accept": "text/csv"})
-        with urlopen(req, timeout=30) as resp:
-            return resp.read().decode("utf-8", errors="replace")
-    except (URLError, OSError, TimeoutError):
-        return None
 
 
 def load_taxonomy(locale: str | None = None) -> bool:
@@ -65,6 +30,9 @@ def load_taxonomy(locale: str | None = None) -> bool:
     Call once at startup. On success returns True and
     get_species_url / get_species_lifelist_url will return URLs for species.
     On failure returns False; lookups return None and the UI does not break.
+
+    Uses :func:`~explorer.core.taxonomy_bundle.load_taxonomy_bundle` so the CSV is not
+    downloaded separately from the family map / Rankings loaders.
 
     Args:
         locale: Optional locale code so common names match your eBird export.
@@ -78,25 +46,13 @@ def load_taxonomy(locale: str | None = None) -> bool:
     """
     global _common_to_code
     _common_to_code = None
-    loc_clean = str(locale).strip() if locale else ""
-    primary_url = _TAXONOMY_BASE
-    if loc_clean:
-        primary_url = f"{_TAXONOMY_BASE}?{urlencode({'locale': loc_clean})}"
-    raw_primary = _fetch_taxonomy_csv(primary_url)
-    if raw_primary is None:
+    try:
+        bundle = load_taxonomy_bundle(taxonomy_locale_key(locale))
+    except (URLError, OSError, TimeoutError):
         return False
-    primary_lookup = _taxonomy_csv_to_lookup(raw_primary)
-    if primary_lookup is None:
+    if not bundle.common_to_code:
         return False
-    if loc_clean and loc_clean.lower() != "en_us":
-        us_url = f"{_TAXONOMY_BASE}?{urlencode({'locale': 'en_US'})}"
-        raw_us = _fetch_taxonomy_csv(us_url)
-        if raw_us:
-            us_lookup = _taxonomy_csv_to_lookup(raw_us)
-            if us_lookup:
-                _common_to_code = {**us_lookup, **primary_lookup}
-                return True
-    _common_to_code = primary_lookup
+    _common_to_code = bundle.common_to_code
     return True
 
 

--- a/explorer/core/taxonomy_bundle.py
+++ b/explorer/core/taxonomy_bundle.py
@@ -1,0 +1,177 @@
+"""Shared eBird taxonomy load: one CSV fetch/parse per locale for tables and species links.
+
+``load_taxonomy_bundle`` is the single entry point used by :mod:`explorer.core.species_family`
+(species rows + species groups) and :mod:`explorer.core.taxonomy` (common name → species code).
+Non-``en_US`` locales still merge **en_US** common names into the lookup dict (same rules as
+:func:`~explorer.core.taxonomy.load_taxonomy`).
+"""
+
+from __future__ import annotations
+
+import csv
+import functools
+import io
+import json
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+_TAXONOMY_EBIRD_URL = "https://api.ebird.org/v2/ref/taxonomy/ebird"
+_GROUPS_EBIRD_URL = "https://api.ebird.org/v2/ref/sppgroup/ebird"
+
+
+def taxonomy_locale_key(locale: str | None) -> str:
+    """Normalized locale string for bundle cache keys (empty = API default / en_US)."""
+    return (locale or "").strip()
+
+
+def _taxonomy_csv_url(locale_key: str) -> str:
+    if locale_key:
+        return f"{_TAXONOMY_EBIRD_URL}?{urlencode({'locale': locale_key})}"
+    return _TAXONOMY_EBIRD_URL
+
+
+def _groups_json_url(locale_key: str) -> str:
+    if locale_key:
+        return f"{_GROUPS_EBIRD_URL}?{urlencode({'locale': locale_key})}"
+    return _GROUPS_EBIRD_URL
+
+
+def _fetch_taxonomy_csv(url: str) -> str | None:
+    try:
+        req = Request(url, headers={"Accept": "text/csv"})
+        with urlopen(req, timeout=30) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except (URLError, OSError, TimeoutError):
+        return None
+
+
+def _parse_taxonomy_csv(raw: str) -> tuple[pd.DataFrame, dict[str, str]]:
+    """Parse one taxonomy CSV into species rows and common_name → species_code (species category only)."""
+    reader = csv.DictReader(io.StringIO(raw))
+    if not reader.fieldnames:
+        return pd.DataFrame(), {}
+    field_lower = {f.strip().lower(): f for f in reader.fieldnames}
+    common_key = field_lower.get("common_name") or field_lower.get("common name")
+    code_key = field_lower.get("species_code") or field_lower.get("species code")
+    category_key = field_lower.get("category")
+    sci_keys = (
+        field_lower.get("scientific_name"),
+        field_lower.get("sci_name"),
+        field_lower.get("scientific name"),
+    )
+    tax_order_key = field_lower.get("taxon_order") or field_lower.get("taxon order")
+
+    rows: list[dict[str, Any]] = []
+    lookup: dict[str, str] = {}
+    for row in reader:
+        cat = ""
+        if category_key:
+            cat = str(row.get(category_key) or "").strip().lower()
+        if cat != "species":
+            continue
+        sci = ""
+        for sk in sci_keys:
+            if sk:
+                sci = str(row.get(sk) or "").strip()
+                if sci:
+                    break
+        common = ""
+        if common_key:
+            common = str(row.get(common_key) or "").strip()
+        if not common and field_lower.get("primary_com_name"):
+            common = str(row.get(field_lower["primary_com_name"]) or "").strip()
+        code = ""
+        if code_key:
+            code = str(row.get(code_key) or "").strip()
+        if common and code:
+            lookup[common] = code
+        if not sci or not common:
+            continue
+        tax_raw = row.get(tax_order_key) if tax_order_key else ""
+        try:
+            taxon_order = float(str(tax_raw).strip())
+        except Exception:
+            continue
+        rows.append(
+            {
+                "scientific_name": sci,
+                "common_name": common,
+                "species_code": code,
+                "taxon_order": taxon_order,
+                "base_species": " ".join(sci.lower().split()[:2]).strip(),
+            }
+        )
+    return pd.DataFrame(rows), lookup
+
+
+def _fetch_taxonomy_groups(locale_key: str) -> list[dict[str, Any]]:
+    url = _groups_json_url(locale_key)
+    req = Request(url, headers={"Accept": "application/json"})
+    with urlopen(req, timeout=30) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+    data = json.loads(raw)
+    out: list[dict[str, Any]] = []
+    for item in data:
+        bounds_in = item.get("taxonOrderBounds", []) or []
+        bounds: list[tuple[float, float]] = []
+        for pair in bounds_in:
+            if not isinstance(pair, list) or len(pair) != 2:
+                continue
+            try:
+                lo = float(pair[0])
+                hi = float(pair[1])
+            except Exception:
+                continue
+            bounds.append((lo, hi))
+        out.append(
+            {
+                "group_name": str(item.get("groupName", "")).strip(),
+                "group_order": int(item.get("groupOrder", 0) or 0),
+                "bounds": bounds,
+            }
+        )
+    return out
+
+
+@dataclass(frozen=True)
+class TaxonomyBundle:
+    """One locale's taxonomy CSV (species rows), species groups, and link lookup dict."""
+
+    species_rows: pd.DataFrame
+    groups: tuple[dict[str, Any], ...]
+    common_to_code: dict[str, str]
+
+
+@functools.lru_cache(maxsize=16)
+def load_taxonomy_bundle(locale: str | None = None) -> TaxonomyBundle:
+    """Fetch and parse eBird taxonomy once per locale (cached in-process).
+
+    *locale* — same semantics as :func:`~explorer.core.taxonomy.load_taxonomy` (``None``/``""``
+    for API default). Uses :data:`~explorer.core.settings_schema_defaults.TAXONOMY_LOCALE_DEFAULT`
+    only when callers pass that explicitly via :mod:`species_family`.
+    """
+    loc = taxonomy_locale_key(locale)
+    raw_primary = _fetch_taxonomy_csv(_taxonomy_csv_url(loc))
+    if raw_primary is None:
+        return TaxonomyBundle(pd.DataFrame(), (), {})
+
+    species_rows, common = _parse_taxonomy_csv(raw_primary)
+    if loc and loc.lower() != "en_us":
+        raw_us = _fetch_taxonomy_csv(_taxonomy_csv_url("en_US"))
+        if raw_us:
+            _, us_lookup = _parse_taxonomy_csv(raw_us)
+            if us_lookup:
+                common = {**us_lookup, **common}
+
+    groups = tuple(_fetch_taxonomy_groups(loc))
+    return TaxonomyBundle(species_rows, groups, common)
+
+
+def clear_taxonomy_bundle_cache() -> None:
+    """Clear the in-process bundle cache (tests)."""
+    load_taxonomy_bundle.cache_clear()

--- a/tests/explorer/test_family_map_compute.py
+++ b/tests/explorer/test_family_map_compute.py
@@ -20,7 +20,12 @@ from explorer.core.family_map_compute import (
     merge_taxonomy_detail_for_family_map,
     prepare_family_map_work_frame,
     selected_species_checklist_individual_counts,
+    species_url_for_base_species,
     taxonomy_species_count_for_family,
+)
+from explorer.core.family_map_overlays import (
+    build_family_map_banner_overlay_html,
+    build_family_map_legend_overlay_html_for_pins,
 )
 
 
@@ -242,6 +247,61 @@ def test_base_species_to_common_from_taxonomy():
     d = base_species_to_common_from_taxonomy(tax)
     assert d["aa bb"] == "A"
     assert d["cc dd"] == "C"
+
+
+def test_species_url_for_base_species_uses_species_code_not_common_name_lookup():
+    """Banner/legend must resolve via base → code (popup parity), not common-name cache only."""
+    tax = pd.DataFrame(
+        {
+            "base_species": ["hemipus hirundinaceus"],
+            "species_code": ["bwfshr2"],
+            "common_name": ["Black-winged Flycatcher-shrike"],
+        }
+    )
+    url = species_url_for_base_species(
+        "hemipus hirundinaceus",
+        tax,
+        fallback_fn=lambda _: None,
+    )
+    assert url == "https://ebird.org/species/bwfshr2"
+
+
+def test_species_url_for_base_species_falls_back_to_common_name_fn():
+    tax = pd.DataFrame(
+        {"base_species": ["other sp"], "species_code": [""], "common_name": ["Other"]}
+    )
+    url = species_url_for_base_species(
+        "unknownus species",
+        tax,
+        fallback_fn=lambda n: "https://ebird.org/species/fallback"
+        if n == "Mystery Bird"
+        else None,
+        fallback_common_name="Mystery Bird",
+    )
+    assert url == "https://ebird.org/species/fallback"
+
+
+def test_family_map_banner_and_legend_include_highlight_species_link():
+    metrics = FamilyMapBannerMetrics(
+        family_name="Vangas, Helmetshrikes, and Allies",
+        total_species_taxonomy=10,
+        species_recorded_user=2,
+        locations_with_records=3,
+    )
+    banner = build_family_map_banner_overlay_html(
+        metrics,
+        selected_species_n_checklists=2,
+        selected_species_n_individuals=5,
+        selected_species_display_name="Black-winged Flycatcher-shrike",
+        selected_species_url="https://ebird.org/species/bwfshr2",
+    )
+    legend = build_family_map_legend_overlay_html_for_pins(
+        (),
+        highlight_label="Black-winged Flycatcher-shrike",
+        highlight_species_url="https://ebird.org/species/bwfshr2",
+    )
+    assert 'href="https://ebird.org/species/bwfshr2"' in banner
+    assert 'href="https://ebird.org/species/bwfshr2"' in legend
 
 
 def test_build_common_name_to_species_url_via_base_not_taxonomy_common_name():

--- a/tests/explorer/test_species_family.py
+++ b/tests/explorer/test_species_family.py
@@ -10,14 +10,17 @@ import pytest
 
 from explorer.core import species_family
 from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
+from explorer.core.taxonomy_bundle import clear_taxonomy_bundle_cache
 
 
 @pytest.fixture(autouse=True)
 def _clear_species_family_cache():
     """Clear memoized family map cache between tests."""
     species_family._base_species_family_items_cached.cache_clear()
+    clear_taxonomy_bundle_cache()
     yield
     species_family._base_species_family_items_cached.cache_clear()
+    clear_taxonomy_bundle_cache()
 
 
 def _mock_urlopen_payload(payload: str) -> MagicMock:
@@ -38,12 +41,16 @@ species,Missing Order Bird,No Order,misord,
 species,No Common, ,nocomm,400
 """
     with patch(
-        "explorer.core.species_family.urlopen",
-        return_value=_mock_urlopen_payload(csv_data),
+        "explorer.core.taxonomy_bundle.urlopen",
+        side_effect=[
+            _mock_urlopen_payload(csv_data),
+            _mock_urlopen_payload(csv_data),
+            _mock_urlopen_payload("[]"),
+        ],
     ) as m_urlopen:
         out = species_family.load_taxonomy_species_rows("en_AU")
 
-    req = m_urlopen.call_args[0][0]
+    req = m_urlopen.call_args_list[0][0][0]
     assert "locale=en_AU" in req.full_url
     assert list(out["common_name"]) == ["Common Raven", "Grey Teal"]
     assert list(out["base_species"]) == ["corvus corax", "anas gracilis"]
@@ -61,13 +68,20 @@ def test_load_taxonomy_groups_parses_bounds_and_skips_invalid_entries():
             {"groupName": "Ravens", "groupOrder": 3, "taxonOrderBounds": []},
         ]
     )
+    csv_data = """CATEGORY,SCIENTIFIC_NAME,COMMON_NAME,SPECIES_CODE,TAXON_ORDER
+species,Anas gracilis,Grey Teal,grtea,200
+"""
     with patch(
-        "explorer.core.species_family.urlopen",
-        return_value=_mock_urlopen_payload(payload),
+        "explorer.core.taxonomy_bundle.urlopen",
+        side_effect=[
+            _mock_urlopen_payload(csv_data),
+            _mock_urlopen_payload(csv_data),
+            _mock_urlopen_payload(payload),
+        ],
     ) as m_urlopen:
         out = species_family.load_taxonomy_groups("en_AU")
 
-    req = m_urlopen.call_args[0][0]
+    req = m_urlopen.call_args_list[2][0][0]
     assert "locale=en_AU" in req.full_url
     assert out[0]["group_name"] == "Ducks"
     assert out[0]["bounds"] == [(10.0, 20.0), (40.0, 50.0)]

--- a/tests/explorer/test_taxonomy.py
+++ b/tests/explorer/test_taxonomy.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from explorer.core import taxonomy
+from explorer.core.taxonomy_bundle import clear_taxonomy_bundle_cache
 
 
 def _make_csv(rows, fieldnames=("common_name", "species_code", "category")):
@@ -18,11 +19,24 @@ def _make_csv(rows, fieldnames=("common_name", "species_code", "category")):
     return buf.getvalue()
 
 
+def _mock_urlopen_ctxs(*payloads: str) -> list[MagicMock]:
+    ctxs: list[MagicMock] = []
+    for payload in payloads:
+        resp = MagicMock()
+        resp.read.return_value = payload.encode("utf-8")
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=resp)
+        cm.__exit__ = MagicMock(return_value=False)
+        ctxs.append(cm)
+    return ctxs
+
+
 @pytest.fixture(autouse=True)
 def _reset_taxonomy_after_each():
     """Reset taxonomy module state after each test so tests don't affect each other."""
     yield
     taxonomy._common_to_code = None
+    clear_taxonomy_bundle_cache()
 
 
 def test_load_taxonomy_success_builds_lookup():
@@ -32,17 +46,13 @@ def test_load_taxonomy_success_builds_lookup():
         {"common_name": "Grey Teal", "species_code": "grtea", "category": "species"},
         {"common_name": "Some spuh", "species_code": "spuh1", "category": "spuh"},
     ])
-    resp = MagicMock()
-    resp.read.return_value = csv_data.encode("utf-8")
-    cm = MagicMock()
-    cm.__enter__ = MagicMock(return_value=resp)
-    cm.__exit__ = MagicMock(return_value=False)
-    with patch("explorer.core.taxonomy.urlopen", return_value=cm) as m_urlopen:
+    ctxs = _mock_urlopen_ctxs(csv_data, "[]")
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=ctxs) as m_urlopen:
         ok = taxonomy.load_taxonomy()
     assert ok is True
-    m_urlopen.assert_called_once()
-    call_args = m_urlopen.call_args[0][0]
-    assert call_args.full_url == "https://api.ebird.org/v2/ref/taxonomy/ebird"
+    assert m_urlopen.call_count == 2
+    first_url = m_urlopen.call_args_list[0][0][0].full_url
+    assert first_url == "https://api.ebird.org/v2/ref/taxonomy/ebird"
     assert taxonomy.get_species_url("Sulphur-crested Cockatoo") == "https://ebird.org/species/succoc"
     assert taxonomy.get_species_url("Grey Teal") == "https://ebird.org/species/grtea"
     assert taxonomy.get_species_lifelist_url("Grey Teal") == "https://ebird.org/lifelist?spp=grtea"
@@ -52,14 +62,10 @@ def test_load_taxonomy_success_builds_lookup():
 def test_load_taxonomy_with_locale_requests_url_with_param():
     """When a non-en_US locale is passed, we fetch that locale and en_US, then merge."""
     csv_data = _make_csv([{"common_name": "Grey Teal", "species_code": "grtea", "category": "species"}])
-    resp = MagicMock()
-    resp.read.return_value = csv_data.encode("utf-8")
-    cm = MagicMock()
-    cm.__enter__ = MagicMock(return_value=resp)
-    cm.__exit__ = MagicMock(return_value=False)
-    with patch("explorer.core.taxonomy.urlopen", return_value=cm) as m_urlopen:
+    ctxs = _mock_urlopen_ctxs(csv_data, csv_data, "[]")
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=ctxs) as m_urlopen:
         taxonomy.load_taxonomy(locale="en_AU")
-    assert m_urlopen.call_count == 2
+    assert m_urlopen.call_count == 3
     urls = [c[0][0].full_url for c in m_urlopen.call_args_list]
     assert any("locale=en_AU" in u for u in urls)
     assert any("locale=en_US" in u for u in urls)
@@ -69,21 +75,17 @@ def test_load_taxonomy_with_locale_requests_url_with_param():
 def test_load_taxonomy_en_us_fetches_once():
     """en_US is the merge source; loading it directly only needs one request."""
     csv_data = _make_csv([{"common_name": "Gray Teal", "species_code": "gretea1", "category": "species"}])
-    resp = MagicMock()
-    resp.read.return_value = csv_data.encode("utf-8")
-    cm = MagicMock()
-    cm.__enter__ = MagicMock(return_value=resp)
-    cm.__exit__ = MagicMock(return_value=False)
-    with patch("explorer.core.taxonomy.urlopen", return_value=cm) as m_urlopen:
+    ctxs = _mock_urlopen_ctxs(csv_data, "[]")
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=ctxs) as m_urlopen:
         taxonomy.load_taxonomy(locale="en_US")
-    assert m_urlopen.call_count == 1
+    assert m_urlopen.call_count == 2
     assert "locale=en_US" in m_urlopen.call_args[0][0].full_url
 
 
 def test_load_taxonomy_network_failure_returns_false():
     """When the API is unavailable, load_taxonomy returns False and lookups return None."""
     from urllib.error import URLError
-    with patch("explorer.core.taxonomy.urlopen", side_effect=URLError("offline")):
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=URLError("offline")):
         ok = taxonomy.load_taxonomy()
     assert ok is False
     assert taxonomy.get_species_url("Grey Teal") is None
@@ -131,18 +133,11 @@ def test_load_taxonomy_en_au_merges_en_us_alternate_names():
     us_csv = _make_csv(
         [{"common_name": "Gray Noddy", "species_code": "grynod1", "category": "species"}]
     )
-    ctxs = []
-    for body in (au_csv, us_csv):
-        r = MagicMock()
-        r.read.return_value = body.encode("utf-8")
-        c = MagicMock()
-        c.__enter__ = MagicMock(return_value=r)
-        c.__exit__ = MagicMock(return_value=False)
-        ctxs.append(c)
-    with patch("explorer.core.taxonomy.urlopen", side_effect=ctxs) as m_urlopen:
+    ctxs = _mock_urlopen_ctxs(au_csv, us_csv, "[]")
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=ctxs) as m_urlopen:
         ok = taxonomy.load_taxonomy(locale="en_AU")
     assert ok is True
-    assert m_urlopen.call_count == 2
+    assert m_urlopen.call_count == 3
     assert taxonomy.get_species_url("Gray Noddy") == "https://ebird.org/species/grynod1"
     assert taxonomy.get_species_url("Grey Ternlet") == "https://ebird.org/species/grynod1"
 

--- a/tests/explorer/test_taxonomy_bundle.py
+++ b/tests/explorer/test_taxonomy_bundle.py
@@ -1,0 +1,120 @@
+"""Tests for shared eBird taxonomy bundle (single fetch per locale)."""
+
+import csv
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from explorer.core import species_family, taxonomy
+from explorer.core.taxonomy_bundle import clear_taxonomy_bundle_cache, load_taxonomy_bundle
+
+
+def _make_csv(rows, fieldnames=("common_name", "species_code", "category", "scientific_name", "taxon_order")):
+    buf = io.StringIO()
+    w = csv.DictWriter(buf, fieldnames=fieldnames)
+    w.writeheader()
+    for r in rows:
+        w.writerow(r)
+    return buf.getvalue()
+
+
+def _mock_urlopen_responses(csv_bodies: list[str], groups_body: str = "[]"):
+    """Build urlopen side_effect: taxonomy CSV URL(s) then species-group JSON."""
+    ctxs: list[MagicMock] = []
+    for body in csv_bodies:
+        r = MagicMock()
+        r.read.return_value = body.encode("utf-8")
+        c = MagicMock()
+        c.__enter__ = MagicMock(return_value=r)
+        c.__exit__ = MagicMock(return_value=False)
+        ctxs.append(c)
+    gr = MagicMock()
+    gr.read.return_value = groups_body.encode("utf-8")
+    gc = MagicMock()
+    gc.__enter__ = MagicMock(return_value=gr)
+    gc.__exit__ = MagicMock(return_value=False)
+    ctxs.append(gc)
+    return ctxs
+
+
+@pytest.fixture(autouse=True)
+def _clear_bundle_cache():
+    yield
+    taxonomy._common_to_code = None
+    clear_taxonomy_bundle_cache()
+
+
+def test_load_taxonomy_bundle_fetches_csv_and_groups_once_per_locale():
+    csv_data = _make_csv(
+        [
+            {
+                "common_name": "Grey Teal",
+                "species_code": "grtea",
+                "category": "species",
+                "scientific_name": "Anas gracilis",
+                "taxon_order": "100",
+            }
+        ]
+    )
+    ctxs = _mock_urlopen_responses([csv_data, csv_data])
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=ctxs) as m_urlopen:
+        b1 = load_taxonomy_bundle("en_AU")
+        b2 = load_taxonomy_bundle("en_AU")
+    assert m_urlopen.call_count == 3
+    assert b1 is b2
+    assert len(b1.species_rows) == 1
+    assert b1.common_to_code["Grey Teal"] == "grtea"
+
+
+def test_species_family_and_load_taxonomy_share_one_csv_fetch():
+    csv_data = _make_csv(
+        [
+            {
+                "common_name": "Grey Teal",
+                "species_code": "grtea",
+                "category": "species",
+                "scientific_name": "Anas gracilis",
+                "taxon_order": "100",
+            }
+        ]
+    )
+    ctxs = _mock_urlopen_responses([csv_data, csv_data])
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=ctxs) as m_urlopen:
+        assert taxonomy.load_taxonomy(locale="en_AU") is True
+        rows = species_family.load_taxonomy_species_rows("en_AU")
+    assert m_urlopen.call_count == 3
+    assert len(rows) == 1
+    assert taxonomy.get_species_url("Grey Teal") == "https://ebird.org/species/grtea"
+
+
+def test_en_au_merges_us_csv_without_extra_species_row_fetch():
+    au_csv = _make_csv(
+        [
+            {
+                "common_name": "Grey Ternlet",
+                "species_code": "grynod1",
+                "category": "species",
+                "scientific_name": "Procelerna cerulea",
+                "taxon_order": "200",
+            }
+        ]
+    )
+    us_csv = _make_csv(
+        [
+            {
+                "common_name": "Gray Noddy",
+                "species_code": "grynod1",
+                "category": "species",
+                "scientific_name": "Procelerna cerulea",
+                "taxon_order": "200",
+            }
+        ]
+    )
+    ctxs = _mock_urlopen_responses([au_csv, us_csv])
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=ctxs) as m_urlopen:
+        bundle = load_taxonomy_bundle("en_AU")
+    assert m_urlopen.call_count == 3
+    assert bundle.common_to_code["Gray Noddy"] == "grynod1"
+    assert bundle.common_to_code["Grey Ternlet"] == "grynod1"


### PR DESCRIPTION
## Summary

Fixes missing eBird hyperlinks on the **Family locations** map banner and legend when a species is highlighted (e.g. Black-winged Flycatcher-shrike). Popups already linked via base species → `species_code`; banner/legend used common-name lookup only and could miss.

Also consolidates eBird taxonomy loading into a single cached bundle per locale so the taxonomy CSV and species groups are not fetched separately by family map prep and `get_species_url`.

## Changes

- Resolve highlight URLs via `species_url_for_base_species()` (base → `species_code` from merged taxonomy), with fallbacks to checklist common names and `get_species_url`
- Add `explorer/core/taxonomy_bundle.py`: one in-process load per locale (primary CSV, optional en_US CSV merge for link failsafe, species groups JSON)
- Wire `species_family`, `taxonomy.load_taxonomy`, and `cached_family_map_bundle` through the bundle
- Unit tests for highlight link HTML, bundle caching, and shared fetch behaviour

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/explorer/ -q` — 581 passed, 7 skipped
- Manual: Family locations highlight — banner + legend links; smoke on other link surfaces

## Notes

- Non-`en_US` locales still fetch a second taxonomy CSV (`en_US`) to merge US English common names into the link lookup (existing failsafe for mixed export wording).
- Cold start per locale remains 2 taxonomy HTTP calls + 1 species-groups call; the win is avoiding duplicate CSV downloads across code paths.

Fixes #227

Made with [Cursor](https://cursor.com)