### PR TITLE
Speed up tab and table prep after map improvements

### DIFF
--- a/benchmarks/map_perf/README.md
+++ b/benchmarks/map_perf/README.md
@@ -16,8 +16,9 @@ notes) and these **guardrail ceilings**.
 ## Feasibility / relevance
 
 - **Feasible:** small JSON blobs, no binary logs.
-- **Relevant:** keeps `prep.*` / `dataset.load` / `map.*.leaflet.*` instrumentation honest when refactoring
-  embeds (#190) or payload cache keys.
+- **Relevant:** keeps `prep.*` / `dataset.load` / `map.*.leaflet.*` / tab-prep (`prep.cache_checklist_stats.*`,
+  `prep.cache_rankings_bundle`, `perf_fragment` tab bodies) instrumentation honest when refactoring
+  embeds (#190), payload cache keys, or checklist/rankings compute.
 - **Worth doing:** lightweight; complements human-reported timings. Replace or tighten ceilings when
   you intentionally improve hotspots.
 
@@ -64,3 +65,12 @@ python scripts/aggregate_perf_jsonl.py benchmarks/map_perf/snapshots \
 Treat rows where `payload_cache_hit` is false (or absent on older logs) as payload **misses**;
 ignore true hits when comparing build regressions. One-shot fixture journey:
 `./scripts/run_post_leaflet_perf_baseline.sh`.
+
+**Tab/table prep journey** (fixture, opt-in):
+
+```bash
+pytest tests/explorer/test_tab_perf_e2e.py --perf -v
+```
+
+Expect `prep.cache_checklist_stats.working`, `.full_export`, `prep.cache_rankings_bundle`, and
+`prep.tab_session_sync` in the JSONL after the Checklist Statistics → Overview tabs are visible.

--- a/benchmarks/map_perf/stage_ceilings.json
+++ b/benchmarks/map_perf/stage_ceilings.json
@@ -25,6 +25,7 @@
     "ranking_lists": 120000,
     "yearly_summary": 120000,
     "country": 120000,
-    "maintenance": 120000
+    "maintenance": 120000,
+    "maintenance.map_duplicate_scan": 120000
   }
 }

--- a/benchmarks/map_perf/stage_ceilings.json
+++ b/benchmarks/map_perf/stage_ceilings.json
@@ -15,6 +15,16 @@
     "map.species_leaflet.component_embed": 120000,
     "map.family_leaflet.payload": 240000,
     "map.family_leaflet.component_embed": 120000,
-    "taxonomy.cached_species_url_fn": 60000
+    "taxonomy.cached_species_url_fn": 60000,
+    "prep.cache_checklist_stats.working": 180000,
+    "prep.cache_checklist_stats.full_export": 180000,
+    "prep.cache_rankings_bundle": 180000,
+    "prep.cache_sex_notation_by_year": 60000,
+    "prep.tab_session_sync": 60000,
+    "checklist_statistics": 120000,
+    "ranking_lists": 120000,
+    "yearly_summary": 120000,
+    "country": 120000,
+    "maintenance": 120000
   }
 }

--- a/explorer/app/streamlit/app_caches.py
+++ b/explorer/app/streamlit/app_caches.py
@@ -74,6 +74,21 @@ def cached_sex_notation_by_year(df: pd.DataFrame) -> dict:
     return get_sex_notation_by_year(df)
 
 
+@st.cache_data(show_spinner=False)
+def cached_map_maintenance_data(
+    loc_df: pd.DataFrame,
+    threshold_m: int,
+) -> tuple[list, list]:
+    """Exact- and near-duplicate location scan for the Maintenance tab (refs #79).
+
+    Cached on *loc_df* + *threshold_m* so fragment reruns do not repeat BallTree work.
+    """
+    from explorer.core.duplicate_checks import get_map_maintenance_data
+
+    exact_rows, near_pairs = get_map_maintenance_data(loc_df, threshold_m)
+    return exact_rows, near_pairs
+
+
 def full_location_data_for_maintenance(df: pd.DataFrame) -> pd.DataFrame:
     """Unique locations for map maintenance (same columns as ``full_location_data``)."""
     cols = ["Location ID", "Location", "Latitude", "Longitude"]

--- a/explorer/app/streamlit/app_caches.py
+++ b/explorer/app/streamlit/app_caches.py
@@ -13,19 +13,37 @@ from explorer.app.streamlit.streamlit_ui_constants import CHECKLIST_STATS_TOP_N_
 
 
 @st.cache_data(show_spinner=False)
+def _cached_checklist_stats_payload_impl(
+    df: pd.DataFrame,
+    top_n_limit: int,
+    high_count_sort: str,
+    high_count_tie_break: str,
+    taxonomy_locale: str,
+) -> ChecklistStatsPayload | None:
+    """Single Streamlit cache for all checklist-stats payload builds (working + full export)."""
+    return compute_checklist_stats_payload(
+        df,
+        top_n_limit,
+        high_count_sort=high_count_sort,
+        high_count_tie_break=high_count_tie_break,
+        taxonomy_locale=taxonomy_locale,
+    )
+
+
 def cached_checklist_stats_payload(
     df: pd.DataFrame,
     taxonomy_locale: str,
 ) -> ChecklistStatsPayload | None:
     """Structured checklist stats for the Checklist Statistics tab (refs #68)."""
-    return compute_checklist_stats_payload(
+    return _cached_checklist_stats_payload_impl(
         df,
         CHECKLIST_STATS_TOP_N_TABLE_LIMIT,
-        taxonomy_locale=taxonomy_locale,
+        "total_count",
+        "last",
+        taxonomy_locale,
     )
 
 
-@st.cache_data(show_spinner=False)
 def cached_full_export_checklist_stats_payload(
     df: pd.DataFrame,
     top_n_limit: int,
@@ -36,13 +54,15 @@ def cached_full_export_checklist_stats_payload(
     """Full-export stats payload shared by Maintenance + Rankings (one compute per cache key).
 
     *top_n_limit* and high-count options match **Settings → Tables & lists** and Rankings.
+    When arguments match :func:`cached_checklist_stats_payload` on the same *df*, Streamlit
+    reuses the same cached result (no duplicate ~compute_rankings pass).
     """
-    return compute_checklist_stats_payload(
+    return _cached_checklist_stats_payload_impl(
         df,
         top_n_limit,
-        high_count_sort=high_count_sort,
-        high_count_tie_break=high_count_tie_break,
-        taxonomy_locale=taxonomy_locale,
+        high_count_sort,
+        high_count_tie_break,
+        taxonomy_locale,
     )
 
 

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -1406,16 +1406,17 @@ def render_prep_spinner_and_map_tab(
                         )
 
         with st.spinner(TAB_PREP_SPINNER_TEXT):
-            with perf_span("prep.cache_checklist_stats"):
+            with perf_span("prep.cache_checklist_stats.working"):
                 checklist_payload = cached_checklist_stats_payload(work_df, tax_locale_effective)
-            with perf_span("prep.cache_maint_rankings_sex_notation"):
-                top_n = int(st.session_state.get(STREAMLIT_RANKINGS_TOP_N_KEY))
-                hc_sort = str(st.session_state.get(STREAMLIT_HIGH_COUNT_SORT_KEY))
-                hc_tb = str(st.session_state.get(STREAMLIT_HIGH_COUNT_TIE_BREAK_KEY))
-                if df_full is not None and not df_full.empty:
+            top_n = int(st.session_state.get(STREAMLIT_RANKINGS_TOP_N_KEY))
+            hc_sort = str(st.session_state.get(STREAMLIT_HIGH_COUNT_SORT_KEY))
+            hc_tb = str(st.session_state.get(STREAMLIT_HIGH_COUNT_TIE_BREAK_KEY))
+            if df_full is not None and not df_full.empty:
+                with perf_span("prep.cache_checklist_stats.full_export"):
                     maint_full_payload = cached_full_export_checklist_stats_payload(
                         df_full, top_n, hc_sort, hc_tb, tax_locale_effective
                     )
+                with perf_span("prep.cache_rankings_bundle"):
                     rankings_bundle = build_rankings_tab_bundle(
                         df_full,
                         country_sort=st.session_state.get(STREAMLIT_COUNTRY_TAB_SORT_KEY),
@@ -1423,12 +1424,12 @@ def render_prep_spinner_and_map_tab(
                         high_count_sort=hc_sort,
                         high_count_tie_break=hc_tb,
                     )
-                else:
-                    maint_full_payload = None
-                    rankings_bundle = {}
-                sex_notation_by_year: dict = (
-                    {} if df_full.empty else cached_sex_notation_by_year(df_full)
-                )
+                with perf_span("prep.cache_sex_notation_by_year"):
+                    sex_notation_by_year: dict = cached_sex_notation_by_year(df_full)
+            else:
+                maint_full_payload = None
+                rankings_bundle = {}
+                sex_notation_by_year = {}
 
             with perf_span("prep.tab_session_sync"):
                 sync_checklist_stats_tab_session_inputs(checklist_payload)

--- a/explorer/app/streamlit/maintenance_streamlit_html.py
+++ b/explorer/app/streamlit/maintenance_streamlit_html.py
@@ -17,17 +17,17 @@ from explorer.presentation.maintenance_display import (
     incomplete_checklists_year_table_html,
     iter_incomplete_checklists_years_desc,
     iter_sex_notation_years_desc,
-    map_maintenance_table_sections_html,
+    map_maintenance_table_sections_from_data,
     sex_notation_intro_html,
     sex_notation_year_table_html,
 )
-from explorer.app.streamlit.app_caches import cached_species_url_fn
+from explorer.app.streamlit.app_caches import cached_map_maintenance_data, cached_species_url_fn
 from explorer.app.streamlit.app_constants import (
     DEFAULT_TAXONOMY_LOCALE,
     MAINTENANCE_TAB_SYNC_KEY,
     STREAMLIT_TAXONOMY_LOCALE_KEY,
 )
-from explorer.app.streamlit.perf_instrumentation import perf_fragment
+from explorer.app.streamlit.perf_instrumentation import perf_fragment, perf_span
 from explorer.app.streamlit.streamlit_theme import inject_streamlit_checklist_css
 
 # Same wrapper class as Checklist Statistics + Country HTML tabs (typography, tables, links).
@@ -123,8 +123,10 @@ def render_maintenance_streamlit_tab(
                     _md(_WRAPPER_OPEN + table + _WRAPPER_CLOSE)
 
     with tab_loc:
-        intro, exact_body, close_body = map_maintenance_table_sections_html(
-            loc_df, close_location_meters
+        with perf_span("maintenance.map_duplicate_scan"):
+            exact_rows, near_pairs = cached_map_maintenance_data(loc_df, close_location_meters)
+        intro, exact_body, close_body = map_maintenance_table_sections_from_data(
+            exact_rows, near_pairs, close_location_meters
         )
         _md(_WRAPPER_OPEN + intro + _WRAPPER_CLOSE)
         with st.expander("Exact duplicates", expanded=False):

--- a/explorer/core/stats.py
+++ b/explorer/core/stats.py
@@ -239,6 +239,30 @@ def longest_streak(unique_dates, cl):
 # Ranking helpers
 # ---------------------------------------------------------------------------
 
+def _countable_species_nunique_by_group(df_obs: pd.DataFrame, group_col: str, value_name: str) -> pd.DataFrame:
+    """Distinct countable base species per *group_col* (vectorized; replaces per-group ``apply``)."""
+    empty = pd.DataFrame(columns=[group_col, value_name])
+    if df_obs.empty or group_col not in df_obs.columns:
+        return empty
+    work = df_obs[[group_col, "Scientific Name", "Common Name"]].copy()
+    work["_base"] = countable_species_vectorized(work)
+    counted = work.dropna(subset=["_base"])
+    if counted.empty:
+        return empty
+    out = counted.groupby(group_col, sort=False)["_base"].nunique().reset_index(name=value_name)
+    return out
+
+
+def _individuals_sum_by_group(df_obs: pd.DataFrame, group_col: str, value_name: str) -> pd.DataFrame:
+    """Sum of parsed ``Count`` values per *group_col* (vectorized)."""
+    empty = pd.DataFrame(columns=[group_col, value_name])
+    if df_obs.empty or group_col not in df_obs.columns:
+        return empty
+    work = df_obs[[group_col, "Count"]].copy()
+    work["_nind"] = work["Count"].apply(safe_count)
+    return work.groupby(group_col, sort=False)["_nind"].sum().reset_index(name=value_name)
+
+
 def rankings_by_value(df_sub, value_col, date_col, loc_col, loc_id_col, sid_col, fmt, limit):
     """Top N by value desc, date asc; ties show oldest.
 
@@ -283,15 +307,9 @@ def rankings_by_location(df_obs, cl_sub, mode, fmt, limit):
     if df_obs.empty or cl_sub.empty:
         return []
     if mode == "species":
-        agg = df_obs.groupby("Location ID", group_keys=False).apply(
-            lambda g: countable_species_vectorized(g).dropna().nunique(),
-            include_groups=False,
-        ).reset_index(name="_val")
+        agg = _countable_species_nunique_by_group(df_obs, "Location ID", "_val")
     else:
-        agg = df_obs.groupby("Location ID", group_keys=False).apply(
-            lambda g: g["Count"].apply(safe_count).sum(),
-            include_groups=False,
-        ).reset_index(name="_val")
+        agg = _individuals_sum_by_group(df_obs, "Location ID", "_val")
     dt_col = "datetime" if "datetime" in cl_sub.columns else "Date"
     loc_info = cl_sub.groupby("Location ID").agg(
         Location=("Location", "first"),
@@ -808,14 +826,8 @@ def compute_rankings(
                                  "species_loc", "individuals_loc", "visited",
                                  "species_individuals", "species_checklists",
                                  "species_high_counts", "seen_once", "subspecies", "not_seen_recently")}
-    species_per_cl = df.groupby("Submission ID", group_keys=False).apply(
-        lambda g: countable_species_vectorized(g).dropna().nunique(),
-        include_groups=False,
-    ).reset_index(name="_nsp")
-    ind_per_cl = df.groupby("Submission ID", group_keys=False).apply(
-        lambda g: g["Count"].apply(safe_count).sum(),
-        include_groups=False,
-    ).reset_index(name="_nind")
+    species_per_cl = _countable_species_nunique_by_group(df, "Submission ID", "_nsp")
+    ind_per_cl = _individuals_sum_by_group(df, "Submission ID", "_nind")
     cl_species = cl.merge(species_per_cl, on="Submission ID", how="inner")
     cl_individuals = cl.merge(ind_per_cl, on="Submission ID", how="inner")
 

--- a/explorer/presentation/maintenance_display.py
+++ b/explorer/presentation/maintenance_display.py
@@ -196,16 +196,25 @@ def map_maintenance_close_locations_body_html(near_pairs: List[Any], threshold_m
   </div>"""
 
 
+def map_maintenance_table_sections_from_data(
+    exact_rows: List[Tuple[Any, ...]],
+    near_pairs: List[Any],
+    threshold_m: int,
+) -> Tuple[str, str, str]:
+    """Location maintenance HTML from precomputed duplicate/near-duplicate results (refs #79)."""
+    intro = map_maintenance_intro_html()
+    exact = map_maintenance_exact_duplicates_body_html(exact_rows)
+    close_ = map_maintenance_close_locations_body_html(near_pairs, threshold_m)
+    return intro, exact, close_
+
+
 def map_maintenance_table_sections_html(loc_df: pd.DataFrame, threshold_m: int) -> Tuple[str, str, str]:
     """Location maintenance: intro + exact-duplicates block + close-locations block (inner HTML only).
 
     Single call to :func:`get_map_maintenance_data` (refs #79).
     """
     exact_rows, near_pairs = get_map_maintenance_data(loc_df, threshold_m)
-    intro = map_maintenance_intro_html()
-    exact = map_maintenance_exact_duplicates_body_html(exact_rows)
-    close_ = map_maintenance_close_locations_body_html(near_pairs, threshold_m)
-    return intro, exact, close_
+    return map_maintenance_table_sections_from_data(exact_rows, near_pairs, threshold_m)
 
 
 def format_map_maintenance_html(loc_df: pd.DataFrame, threshold_m: int) -> str:

--- a/tests/explorer/test_app_caches_checklist_stats.py
+++ b/tests/explorer/test_app_caches_checklist_stats.py
@@ -1,0 +1,122 @@
+"""Checklist stats Streamlit cache: single impl, no duplicate compute on matching keys."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from explorer.app.streamlit import app_caches
+from explorer.app.streamlit.streamlit_ui_constants import CHECKLIST_STATS_TOP_N_TABLE_LIMIT
+from explorer.core.checklist_stats_compute import ChecklistStatsPayload
+
+
+def _minimal_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Submission ID": ["S1", "S1"],
+            "Date": pd.to_datetime(["2025-01-01", "2025-01-01"]),
+            "Time": ["08:00", "08:00"],
+            "Scientific Name": ["Anas gracilis", "Anas castanea"],
+            "Common Name": ["Grey Teal", "Chestnut Teal"],
+            "Count": [2, 1],
+            "Location ID": ["L1", "L1"],
+            "Location": ["Wetland", "Wetland"],
+            "Latitude": [-35.0, -35.0],
+            "Longitude": [149.0, 149.0],
+            "Protocol": ["Traveling", "Traveling"],
+            "Duration (Min)": [30, 30],
+            "Distance Traveled (km)": [1.0, 1.0],
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_checklist_stats_cache() -> None:
+    app_caches._cached_checklist_stats_payload_impl.clear()
+    yield
+    app_caches._cached_checklist_stats_payload_impl.clear()
+
+
+def test_working_and_full_export_share_one_compute_when_args_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default settings: full export uses same top_n/high-count defaults as the Checklist tab."""
+    compute_calls = 0
+
+    def counting_compute(
+        df: pd.DataFrame,
+        top_n_limit: int,
+        *,
+        high_count_sort: str = "total_count",
+        high_count_tie_break: str = "last",
+        taxonomy_locale: str | None = None,
+    ) -> ChecklistStatsPayload | None:
+        nonlocal compute_calls
+        compute_calls += 1
+        return ChecklistStatsPayload(
+            n_checklists=1,
+            n_species=1,
+            n_individuals=1,
+            n_completed_display="1",
+            protocol_rows=[],
+            total_minutes=0.0,
+            total_hours=0.0,
+            total_days_dec=0.0,
+            total_months=0.0,
+            total_years=0.0,
+            n_days_with_checklist=1,
+            n_shared=0,
+            shared_minutes=0.0,
+            shared_hours=0.0,
+            n_days_birding_with_others=0,
+            total_km=0.0,
+            parkruns=0.0,
+            marathons=0.0,
+            times_equator=0.0,
+            times_godwit=0.0,
+            streak=0,
+            streak_start_date="",
+            streak_start_loc="",
+            streak_start_sid="",
+            streak_start_lid="",
+            streak_end_date="",
+            streak_end_loc="",
+            streak_end_sid="",
+            streak_end_lid="",
+            rankings={},
+            years_list=[],
+            yearly_rows=[],
+            incomplete_by_year={},
+            country_sections=[],
+        )
+
+    monkeypatch.setattr(app_caches, "compute_checklist_stats_payload", counting_compute)
+    df = _minimal_df()
+    locale = "en_AU"
+
+    app_caches.cached_checklist_stats_payload(df, locale)
+    app_caches.cached_full_export_checklist_stats_payload(
+        df,
+        CHECKLIST_STATS_TOP_N_TABLE_LIMIT,
+        "total_count",
+        "last",
+        locale,
+    )
+
+    assert compute_calls == 1
+
+
+def test_full_export_recomputes_when_top_n_differs(monkeypatch: pytest.MonkeyPatch) -> None:
+    compute_calls = 0
+
+    def counting_compute(*_a, **_k) -> ChecklistStatsPayload | None:
+        nonlocal compute_calls
+        compute_calls += 1
+        return None
+
+    monkeypatch.setattr(app_caches, "compute_checklist_stats_payload", counting_compute)
+    df = _minimal_df()
+    locale = "en_AU"
+
+    app_caches.cached_checklist_stats_payload(df, locale)
+    app_caches.cached_full_export_checklist_stats_payload(df, 50, "total_count", "last", locale)
+
+    assert compute_calls == 2

--- a/tests/explorer/test_cached_map_maintenance.py
+++ b/tests/explorer/test_cached_map_maintenance.py
@@ -1,0 +1,35 @@
+"""Streamlit cache for location duplicate maintenance scan."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from explorer.app.streamlit import app_caches
+from explorer.core.duplicate_checks import get_map_maintenance_data
+
+
+@pytest.fixture(autouse=True)
+def _clear_map_maintenance_cache() -> None:
+    app_caches.cached_map_maintenance_data.clear()
+    yield
+    app_caches.cached_map_maintenance_data.clear()
+
+
+def test_cached_map_maintenance_matches_direct_call() -> None:
+    loc_df = pd.DataFrame(
+        {
+            "Location ID": ["L1", "L2", "L3"],
+            "Location": ["A", "B", "C"],
+            "Latitude": [-35.0, -35.0000001, -36.0],
+            "Longitude": [149.0, 149.0000001, 150.0],
+        }
+    )
+    threshold_m = 10
+
+    expected = get_map_maintenance_data(loc_df, threshold_m)
+    first = app_caches.cached_map_maintenance_data(loc_df, threshold_m)
+    second = app_caches.cached_map_maintenance_data(loc_df, threshold_m)
+
+    assert first == expected
+    assert second == first

--- a/tests/explorer/test_compute_rankings_vectorized.py
+++ b/tests/explorer/test_compute_rankings_vectorized.py
@@ -1,0 +1,44 @@
+"""Regression: vectorized ranking groupbys on the integration fixture."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from explorer.core.data_loader import load_dataset
+from explorer.core.stats import compute_rankings, rankings_by_location
+
+_INTEGRATION_CSV = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "ebird_integration_fixture.csv"
+)
+
+
+@pytest.fixture
+def _fixture_tables():
+    df = load_dataset(_INTEGRATION_CSV)
+    cl = df.drop_duplicates(subset=["Submission ID"]).copy()
+    dur_col = "Duration (Min)" if "Duration (Min)" in df.columns else None
+    dist_col = "Distance Traveled (km)" if "Distance Traveled (km)" in df.columns else None
+    return df, cl, dur_col, dist_col
+
+
+def test_compute_rankings_returns_nonempty_core_sections(_fixture_tables) -> None:
+    df, cl, dur_col, dist_col = _fixture_tables
+    result = compute_rankings(df, cl, limit=200, dur_col=dur_col, dist_col=dist_col)
+    assert len(result["species"]) > 0
+    assert len(result["species_loc"]) > 0
+    assert len(result["visited"]) > 0
+
+
+def test_rankings_by_location_species_respects_limit(_fixture_tables) -> None:
+    df, cl, _dur, _dist = _fixture_tables
+    rows = rankings_by_location(df, cl, "species", lambda x: f"{int(x):,}", limit=5)
+    assert 1 <= len(rows) <= 5
+
+
+def test_compute_rankings_all_sections_bounded(_fixture_tables) -> None:
+    df, cl, dur_col, dist_col = _fixture_tables
+    result = compute_rankings(df, cl, limit=10, dur_col=dur_col, dist_col=dist_col)
+    for key in ("species", "individuals", "species_loc", "individuals_loc", "visited"):
+        assert len(result[key]) <= 10

--- a/tests/explorer/test_tab_perf_e2e.py
+++ b/tests/explorer/test_tab_perf_e2e.py
@@ -1,0 +1,95 @@
+"""Opt-in tab/table prep performance E2E (JSONL via ``EXPLORER_PERF_LOG_FILE``).
+
+Run::
+
+    pytest tests/explorer/test_tab_perf_e2e.py --perf -v
+
+Complements ``test_map_perf_e2e.py``: asserts tab-prep ``prep.cache_*`` stages after cold load.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+
+from tests.explorer.e2e_support import (
+    append_e2e_first_paint_record,
+    launch_chromium_or_skip,
+    max_elapsed_ms_by_stage,
+    measure_first_paint_ms,
+    parse_perf_json_objects_from_log_lines,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.perf]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CEILINGS_PATH = _REPO_ROOT / "benchmarks" / "map_perf" / "stage_ceilings.json"
+
+
+def _load_stage_ceilings() -> dict[str, float]:
+    raw = json.loads(_CEILINGS_PATH.read_text(encoding="utf-8"))
+    caps = raw.get("max_elapsed_ms")
+    if not isinstance(caps, dict):
+        raise AssertionError(f"Invalid ceilings file: {_CEILINGS_PATH}")
+    return {str(k): float(v) for k, v in caps.items()}
+
+
+def test_tab_prep_stages_emitted_after_cold_load(
+    streamlit_perf_url_and_logfile: tuple[str, Path],
+) -> None:
+    """Cold load logs map + tab prep stages; checklist nested tab ``Overview`` becomes visible."""
+    url, log_file = streamlit_perf_url_and_logfile
+    ceilings = _load_stage_ceilings()
+    dataset_label = "real" if os.environ.get("EXPLORER_E2E_DATASET_CSV") else "fixture"
+
+    with launch_chromium_or_skip() as browser:
+        page = browser.new_page()
+        first_paint = measure_first_paint_ms(
+            page,
+            url,
+            must_contain=['class="pebird-map-banner__title">All locations</span>'],
+        )
+        page.get_by_text("Personal eBird Explorer").wait_for(timeout=20000)
+        append_e2e_first_paint_record(
+            log_file,
+            {
+                "elapsed_ms": first_paint["banner_ms"],
+                "goto_ms": first_paint["goto_ms"],
+                "banner_ms": first_paint["banner_ms"],
+                "dataset_label": dataset_label,
+                "journey": "tab_prep_cold_load",
+            },
+        )
+        page.get_by_role("tab", name="Checklist Statistics").wait_for(timeout=120_000)
+        page.get_by_role("tab", name="Overview").wait_for(timeout=120_000)
+
+    time.sleep(0.5)
+    raw_lines = log_file.read_text(encoding="utf-8").splitlines() if log_file.exists() else []
+    events = parse_perf_json_objects_from_log_lines(raw_lines)
+    assert len(events) >= 3, f"expected perf JSON events, got {len(events)}"
+
+    stages_seen = {str(e.get("stage")) for e in events if isinstance(e.get("stage"), str)}
+    must = {
+        "prep.cache_checklist_stats.working",
+        "prep.cache_checklist_stats.full_export",
+        "prep.cache_rankings_bundle",
+        "prep.tab_session_sync",
+    }
+    missing = must - stages_seen
+    assert not missing, f"missing tab prep stages {missing!r} in {sorted(stages_seen)!r}"
+
+    highs = max_elapsed_ms_by_stage(events)
+    failures: list[str] = []
+    for stage, cap in ceilings.items():
+        obs = highs.get(stage)
+        if obs is None:
+            continue
+        if obs > cap:
+            failures.append(f"{stage}: {obs:.1f}ms > ceiling {cap:.1f}ms")
+    assert not failures, "Perf ceilings exceeded:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary

After the Leaflet map work on `beta-next`, the default **Map** tab felt much faster, but cold load and refresh still spent a long time in the second sidebar spinner (“Preparing checklist, rankings, and other tabs…”). Profiling on a full personal export (~46k rows, ~5.6k locations) showed the bottleneck was not HTML rendering or the spinner itself, but **duplicate checklist-stats computation** and **slow per-checklist `groupby().apply()` loops** inside `compute_rankings`.

This PR cuts that tab-prep path from roughly **tens of seconds to a few seconds** on first load, and makes repeat visits much snappier via Streamlit cache hits. It also caches the Maintenance tab’s location-duplicate BallTree scan so fragment reruns do not repeat ~1s of work on large exports.

There is no linked GitHub issue; this branch was opened for pre-release experimentation.

## Changes

### Checklist / rankings prep (main win)

- **Unified Streamlit cache** (`_cached_checklist_stats_payload_impl`): `cached_checklist_stats_payload` (working set, Checklist Statistics tab) and `cached_full_export_checklist_stats_payload` (full export, Rankings + Maintenance incomplete lists) now share one `@st.cache_data` function. With default settings (top_n=200, same high-count options) and the same dataframe, cold load performs **one** `compute_checklist_stats_payload` instead of two identical ~25s passes.
- **Vectorized ranking groupbys** in `explorer/core/stats.py`: replaced per-group `groupby().apply(countable_species_vectorized…)` for species-per-checklist and species-per-location with vectorized `_base` + `groupby().nunique()`. On the real export fixture, `compute_rankings` dropped from ~24s to ~3s; full payload from ~25s to ~4s (dev machine).

### Maintenance tab (smaller follow-up)

- **`cached_map_maintenance_data`**: wraps `get_map_maintenance_data` so the Location Maintenance sub-tab does not rerun the BallTree scan on every `@st.fragment` rerun when data and threshold are unchanged.
- **`map_maintenance_table_sections_from_data`**: presentation helper so Streamlit can pass precomputed rows without importing cache into `maintenance_display`.

### Instrumentation and guardrails

- Split tab-prep perf spans: `prep.cache_checklist_stats.working`, `prep.cache_checklist_stats.full_export`, `prep.cache_rankings_bundle`, `prep.cache_sex_notation_by_year`, plus `maintenance.map_duplicate_scan`.
- Extended `benchmarks/map_perf/stage_ceilings.json` with tab-prep and fragment stage ceilings (loose, for opt-in `--perf` tests).
- New opt-in E2E: `tests/explorer/test_tab_perf_e2e.py` asserts tab-prep stages appear in JSONL after cold load.

## Testing

```bash
python3 -m ruff check explorer/
python3 -m pytest tests/ -q -m "not e2e"
```

Targeted new tests:

- `tests/explorer/test_app_caches_checklist_stats.py` — shared cache deduplication
- `tests/explorer/test_compute_rankings_vectorized.py` — integration fixture rankings regression
- `tests/explorer/test_cached_map_maintenance.py` — maintenance scan cache parity
- `tests/explorer/test_tab_perf_e2e.py` — opt-in: `pytest tests/explorer/test_tab_perf_e2e.py --perf -v`

**Manual:** cold launch + refresh on full `MyEBirdData.csv`; tab spinner should finish quickly after map; Checklist Statistics / Rankings tabs usable without a long second wait.

## Notes

- **Lazy tab render** was considered but is intentionally out of scope: with prep time reduced this dramatically, deferring `@st.fragment` execution is unnecessary complexity.
- **Date-filtered working set** still triggers a separate stats compute when `work_df` differs from `df_full` or settings diverge — by design.
- Remaining smaller opportunities (not in this PR): `rankings_high_counts` tuning, cold taxonomy fetch on first paint (#222), first-visit Lifer map payload build.

## Issues

None (experimental perf branch).

Made with [Cursor](https://cursor.com)