### PR TITLE
Fix E2E tests overwriting local config_secret.yaml

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -359,7 +359,7 @@ regressions can be diagnosed quickly without re-adding scaffolding.
 
 ### Explorer E2E (Playwright) and perf guardrails
 
-- **Smoke + journeys** (fixture CSV via temp `config`): `pip install playwright` ·
+- **Smoke + journeys** (fixture CSV via temp `config` under pytest `tmp_path`; `EXPLORER_CONFIG_DIR` — never touches repo `config/config_secret.yaml`): `pip install playwright` ·
   `python -m playwright install chromium` ·  
   `pytest tests/explorer/test_streamlit_map_e2e.py tests/explorer/test_streamlit_journeys_e2e.py -m e2e -v`
 - **Opt-in perf + JSONL capture** (sets ``EXPLORER_PERF_LOG_FILE`` in the test fixture):  

--- a/explorer/app/streamlit/README.md
+++ b/explorer/app/streamlit/README.md
@@ -98,7 +98,7 @@ Disk search is **first folder that contains the CSV**, in this order:
 | **Config `data_folder`** | As above (`config_secret.yaml` → `config.yaml`). |
 | **Working directory** | Put `MyEBirdData.csv` (or override basename with env **`STREAMLIT_EBIRD_DATA_FILE`**) in the directory you start Streamlit from. |
 
-There is **no** `STREAMLIT_EBIRD_DATA_FOLDER` or Streamlit-secret data-folder override; use config files, CWD, or upload.
+There is **no** `STREAMLIT_EBIRD_DATA_FOLDER` or Streamlit-secret data-folder override; use config files, CWD, or upload. **`EXPLORER_CONFIG_DIR`** (environment only) redirects config YAML lookup for automated E2E tests; normal local runs leave it unset.
 
 **Precedence (load):** A new pick from the landing uploader → **disk** (config paths + CWD) → **cached upload**. Stale upload cache is cleared when disk wins.
 

--- a/explorer/app/streamlit/explorer_update_notice.py
+++ b/explorer/app/streamlit/explorer_update_notice.py
@@ -18,7 +18,7 @@ import streamlit as st
 
 from explorer.app.streamlit.explorer_build_version import EXPLORER_BUILD_VERSION
 from explorer.app.streamlit.streamlit_ui_constants import SIDEBAR_FOOTER_LINK_HEX
-from explorer.core.explorer_paths import _safe_load_yaml_mapping
+from explorer.core.explorer_paths import _safe_load_yaml_mapping, explorer_config_dir
 from explorer.core.explorer_release_version import remote_release_is_newer_than_embedded
 
 GITHUB_RELEASES_LATEST_API = (
@@ -56,7 +56,7 @@ def _hostname_from_context_url(url: Any) -> str:
 
 def _config_files_opt_out_update_check(repo_root: str) -> bool:
     """True if ``check_for_updates: false`` appears in either YAML config."""
-    config_dir = os.path.join(repo_root, "config")
+    config_dir = explorer_config_dir(repo_root)
     for name in ("config_secret.yaml", "config.yaml"):
         raw = _safe_load_yaml_mapping(os.path.join(config_dir, name))
         v = raw.get("check_for_updates")

--- a/explorer/core/explorer_paths.py
+++ b/explorer/core/explorer_paths.py
@@ -9,7 +9,9 @@ Search order (first folder that contains the filename wins):
 
 ``config/config_template.yaml`` is a tracked template; secret configs are gitignored.
 
-No env-based data folder: use config files, CWD, or Streamlit **file upload**. Streamlit Cloud: upload on the landing page.
+Config directory defaults to ``{repo_root}/config``. Set ``EXPLORER_CONFIG_DIR`` to an
+absolute path (E2E tests use an isolated temp dir) so personal ``config_secret.yaml`` is
+never read or written. Streamlit Cloud: upload on the landing page.
 """
 
 from __future__ import annotations
@@ -18,6 +20,16 @@ import os
 from typing import List, Optional, Tuple
 
 from explorer.core.path_resolution import find_data_file
+
+EXPLORER_CONFIG_DIR_ENV = "EXPLORER_CONFIG_DIR"
+
+
+def explorer_config_dir(repo_root: str) -> str:
+    """Directory containing ``config.yaml`` / ``config_secret.yaml`` for path resolution."""
+    override = os.environ.get(EXPLORER_CONFIG_DIR_ENV, "").strip()
+    if override:
+        return os.path.normpath(override)
+    return os.path.join(repo_root, "config")
 
 
 def _safe_load_yaml_mapping(path: str) -> dict:
@@ -53,7 +65,7 @@ def build_explorer_candidate_dirs(
     """Return ``(folders, source_labels)`` for :func:`resolve_ebird_data_file`."""
     folders: List[str] = []
     sources: List[str] = []
-    config_dir = os.path.join(repo_root, "config")
+    config_dir = explorer_config_dir(repo_root)
 
     for label, name in (
         ("config_secret", "config_secret.yaml"),
@@ -106,7 +118,7 @@ def resolve_ebird_data_file(
 def settings_yaml_path_for_source(repo_root: str, source_label: str) -> Optional[str]:
     """Active config path for a resolved source (or ``None``)."""
     src = (source_label or "").strip().lower()
-    config_dir = os.path.join(repo_root, "config")
+    config_dir = explorer_config_dir(repo_root)
     if src == "config_secret":
         return os.path.join(config_dir, "config_secret.yaml")
     if src == "config":

--- a/explorer/core/explorer_paths.py
+++ b/explorer/core/explorer_paths.py
@@ -25,7 +25,10 @@ EXPLORER_CONFIG_DIR_ENV = "EXPLORER_CONFIG_DIR"
 
 
 def explorer_config_dir(repo_root: str) -> str:
-    """Directory containing ``config.yaml`` / ``config_secret.yaml`` for path resolution."""
+    """Directory containing ``config.yaml`` / ``config_secret.yaml`` for path resolution.
+
+    ``EXPLORER_CONFIG_DIR`` overrides the default ``{repo_root}/config`` (E2E tests only).
+    """
     override = os.environ.get(EXPLORER_CONFIG_DIR_ENV, "").strip()
     if override:
         return os.path.normpath(override)

--- a/tests/README.md
+++ b/tests/README.md
@@ -61,6 +61,8 @@ python -m playwright install chromium
 
 If Playwright is not installed, E2E modules skip by design.
 
+**Local secrets:** E2E tests write config only under pytest’s temp directory (`EXPLORER_CONFIG_DIR`). Your gitignored `config/config_secret.yaml` and `config/config.yaml` are never read or modified by pytest.
+
 ## Map / Leaflet tests (Python, no browser)
 
 | Module | What it covers |

--- a/tests/explorer/conftest.py
+++ b/tests/explorer/conftest.py
@@ -37,8 +37,8 @@ def streamlit_app_url(tmp_path):
     port = free_tcp_port()
     url = f"http://127.0.0.1:{port}"
     csv_src = resolve_e2e_dataset_csv_source()
-    with temporary_ebird_csv_config(REPO_ROOT, tmp_path, csv_src):
-        with streamlit_http_server(cwd=REPO_ROOT, port=port, env_extra={}, capture_stdio=False) as (_proc, _logs):
+    with temporary_ebird_csv_config(tmp_path, csv_src) as config_env:
+        with streamlit_http_server(cwd=REPO_ROOT, port=port, env_extra=config_env, capture_stdio=False) as (_proc, _logs):
             wait_for_http_ready(url, timeout_s=e2e_http_ready_timeout_s())
             yield url
 
@@ -54,7 +54,8 @@ def streamlit_perf_url_and_logfile(tmp_path):
         "EXPLORER_PERF_LOG_FILE": str(log_file),
     }
     csv_src = resolve_e2e_dataset_csv_source()
-    with temporary_ebird_csv_config(REPO_ROOT, tmp_path, csv_src):
+    with temporary_ebird_csv_config(tmp_path, csv_src) as config_env:
+        env_extra = {**config_env, **env_extra}
         with streamlit_http_server(cwd=REPO_ROOT, port=port, env_extra=env_extra, capture_stdio=False) as (_proc, _logs):
             wait_for_http_ready(url, timeout_s=e2e_http_ready_timeout_s())
             try:

--- a/tests/explorer/e2e_support.py
+++ b/tests/explorer/e2e_support.py
@@ -415,57 +415,27 @@ def max_elapsed_ms_by_stage(events: Iterable[dict[str, Any]]) -> dict[str, float
 
 
 @contextlib.contextmanager
-def temporary_ebird_csv_config(repo_root: Path, tmp_path: Path, csv_source: Path) -> Iterator[None]:
-    """Point config at *tmp_path* with *csv_source* copied as ``MyEBirdData.csv``.
+def temporary_ebird_csv_config(tmp_path: Path, csv_source: Path) -> Iterator[dict[str, str]]:
+    """Point the Streamlit app at *csv_source* via an isolated temp config directory.
 
-    Does **not** overwrite ``config_secret.yaml`` in place (avoids clobbering local secrets if a
-    run is interrupted). Instead, renames the live secret aside for the test and restores it in
-    ``finally`` (and via ``atexit`` as a safety net).
+    Writes ``config.yaml`` under ``tmp_path/config/`` only. Returns env overrides
+    (``EXPLORER_CONFIG_DIR``) for the Streamlit subprocess — the repo ``config/`` tree
+    (including ``config_secret.yaml``) is never read or written.
     """
-    import atexit
     import shutil
+
+    from explorer.core.explorer_paths import EXPLORER_CONFIG_DIR_ENV
 
     data_dir = tmp_path / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
     dataset_path = data_dir / "MyEBirdData.csv"
     shutil.copyfile(csv_source, dataset_path)
 
-    config_dir = repo_root / "config"
+    config_dir = tmp_path / "config"
     config_dir.mkdir(parents=True, exist_ok=True)
     config_yaml = config_dir / "config.yaml"
-    config_secret_yaml = config_dir / "config_secret.yaml"
-    secret_e2e_bak = config_dir / "config_secret.yaml.e2e-bak"
-    original_cfg = config_yaml.read_text(encoding="utf-8") if config_yaml.exists() else None
-    had_secret = config_secret_yaml.is_file()
-    if had_secret:
-        if secret_e2e_bak.exists():
-            secret_e2e_bak.unlink()
-        config_secret_yaml.rename(secret_e2e_bak)
     config_payload = f"data_folder: {data_dir.as_posix()}\n"
     config_yaml.write_text(config_payload, encoding="utf-8")
-    config_secret_yaml.write_text(config_payload, encoding="utf-8")
 
-    restored = False
-
-    def _restore() -> None:
-        nonlocal restored
-        if restored:
-            return
-        restored = True
-        if original_cfg is None:
-            with contextlib.suppress(FileNotFoundError):
-                config_yaml.unlink()
-        else:
-            config_yaml.write_text(original_cfg, encoding="utf-8")
-        with contextlib.suppress(FileNotFoundError):
-            config_secret_yaml.unlink()
-        if secret_e2e_bak.is_file():
-            secret_e2e_bak.rename(config_secret_yaml)
-
-    atexit.register(_restore)
-    try:
-        yield
-    finally:
-        atexit.unregister(_restore)
-        _restore()
+    yield {EXPLORER_CONFIG_DIR_ENV: str(config_dir)}
 

--- a/tests/explorer/test_e2e_config_isolation.py
+++ b/tests/explorer/test_e2e_config_isolation.py
@@ -1,11 +1,9 @@
-"""Regression: E2E helpers must not read or write repo ``config/config_secret.yaml`` (#247)."""
+"""Regression: E2E helpers must not read or write repo ``config/config_secret.yaml``."""
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
-
-import pytest
 
 from tests.explorer.e2e_support import INTEGRATION_FIXTURE_CSV, temporary_ebird_csv_config
 

--- a/tests/explorer/test_e2e_config_isolation.py
+++ b/tests/explorer/test_e2e_config_isolation.py
@@ -1,0 +1,74 @@
+"""Regression: E2E helpers must not read or write repo ``config/config_secret.yaml`` (#247)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.explorer.e2e_support import INTEGRATION_FIXTURE_CSV, temporary_ebird_csv_config
+
+
+def test_temporary_ebird_csv_config_leaves_repo_config_untouched(tmp_path):
+    """Repo ``config/`` files stay byte-identical; no ``.e2e-bak`` sidecar."""
+    repo = tmp_path / "repo"
+    config_dir = repo / "config"
+    config_dir.mkdir(parents=True)
+    secret = config_dir / "config_secret.yaml"
+    secret.write_text(
+        "data_folder: /home/me/ebird\n"
+        "google_api_key: test-key-should-survive\n"
+        "explorer_settings:\n  map_height_px: 640\n",
+        encoding="utf-8",
+    )
+    config_yaml = config_dir / "config.yaml"
+    config_yaml.write_text("data_folder: /home/me/ebird\n", encoding="utf-8")
+    secret_before = secret.read_bytes()
+    config_before = config_yaml.read_bytes()
+
+    pytest_tmp = tmp_path / "pytest_tmp"
+    pytest_tmp.mkdir()
+    with temporary_ebird_csv_config(pytest_tmp, INTEGRATION_FIXTURE_CSV) as env:
+        assert "EXPLORER_CONFIG_DIR" in env
+        isolated = Path(env["EXPLORER_CONFIG_DIR"])
+        assert isolated.is_dir()
+        assert (isolated / "config.yaml").is_file()
+        assert not (isolated / "config_secret.yaml").exists()
+
+    assert secret.read_bytes() == secret_before
+    assert config_yaml.read_bytes() == config_before
+    assert not (config_dir / "config_secret.yaml.e2e-bak").exists()
+
+
+def test_build_explorer_candidate_dirs_honours_explorer_config_dir(tmp_path, monkeypatch):
+    """``EXPLORER_CONFIG_DIR`` redirects YAML lookup away from ``repo/config``."""
+    from explorer.core.explorer_paths import (
+        EXPLORER_CONFIG_DIR_ENV,
+        build_explorer_candidate_dirs,
+        resolve_ebird_data_file,
+    )
+
+    repo = tmp_path / "repo"
+    (repo / "config").mkdir(parents=True)
+    isolated_config = tmp_path / "isolated_config"
+    isolated_config.mkdir()
+    data_dir = tmp_path / "isolated_data"
+    data_dir.mkdir()
+    (data_dir / "MyEBirdData.csv").write_text("Date,Time\n", encoding="utf-8")
+
+    (isolated_config / "config.yaml").write_text(
+        f"data_folder: {data_dir.as_posix()}\n",
+        encoding="utf-8",
+    )
+    # Repo config would point elsewhere if accidentally read.
+    (repo / "config" / "config.yaml").write_text(
+        "data_folder: /wrong/path\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv(EXPLORER_CONFIG_DIR_ENV, str(isolated_config))
+    folders, sources = build_explorer_candidate_dirs(repo_root=str(repo), cwd=str(tmp_path / "cwd"))
+    path, folder, src = resolve_ebird_data_file("MyEBirdData.csv", folders, sources)
+    assert os.path.normpath(folder) == os.path.normpath(str(data_dir))
+    assert src == "config"

--- a/tests/explorer/test_explorer_paths.py
+++ b/tests/explorer/test_explorer_paths.py
@@ -88,6 +88,19 @@ def test_settings_yaml_path_for_source(tmp_path):
     assert p3 is None
 
 
+def test_settings_yaml_path_honours_explorer_config_dir(tmp_path, monkeypatch):
+    from explorer.core.explorer_paths import EXPLORER_CONFIG_DIR_ENV, settings_yaml_path_for_source
+
+    repo = tmp_path / "repo"
+    (repo / "config").mkdir(parents=True)
+    isolated_config = tmp_path / "isolated_config"
+    isolated_config.mkdir()
+
+    monkeypatch.setenv(EXPLORER_CONFIG_DIR_ENV, str(isolated_config))
+    p = settings_yaml_path_for_source(str(repo), "config")
+    assert p == os.path.join(str(isolated_config), "config.yaml")
+
+
 def test_config_yaml_wins_over_cwd_when_both_have_csv(tmp_path):
     from explorer.core.explorer_paths import (
         build_explorer_candidate_dirs,


### PR DESCRIPTION
## Summary

Streamlit Playwright E2E tests could rename and overwrite a developer's gitignored `config/config_secret.yaml`, especially when pytest was interrupted or run back-to-back. This PR isolates E2E config under pytest's temp directory via `EXPLORER_CONFIG_DIR`, so personal secrets are never read or written during tests.

## Changes

- Add `EXPLORER_CONFIG_DIR` env override in `explorer_paths.py` for config YAML resolution
- Refactor `temporary_ebird_csv_config()` to write only under `tmp_path/config/` and pass env to the Streamlit subprocess
- Remove the `.e2e-bak` rename/restore dance from E2E fixtures
- Add regression tests in `test_e2e_config_isolation.py`
- Document that E2E never modifies local secrets in `tests/README.md` and `docs/development.md`

## Testing

- `python3 -m ruff check explorer/` — passed
- `python3 -m pytest tests/ -q` — 610 passed, 7 skipped
- `pytest tests/explorer/test_e2e_config_isolation.py tests/explorer/test_explorer_paths.py -v` — passed

## Notes

Normal app usage is unchanged: without `EXPLORER_CONFIG_DIR`, config resolution still uses `{repo_root}/config` as before.

Fixes #247

Made with [Cursor](https://cursor.com)