### PR TITLE
fix: Species map banner links via base species code

### DIFF
--- a/explorer/app/streamlit/app_prep_map_leaflet_modes.py
+++ b/explorer/app/streamlit/app_prep_map_leaflet_modes.py
@@ -859,10 +859,11 @@ def prep_standard_map_leaflet_modes(
                         lifer_lookup_df=ctx["lifer_lookup_df"],
                         base_species_fn=base_species_for_lifer,
                     )
+                    _base_sp = base_species_for_lifer(overlay_sci)
                     _tax_loc = taxonomy_locale_key(tax_locale_effective) or TAXONOMY_LOCALE_DEFAULT
                     _tax_rows = load_taxonomy_bundle(_tax_loc).species_rows
                     _sp_url = species_url_for_base_species(
-                        base_species_for_lifer(overlay_sci),
+                        _base_sp,
                         _tax_rows,
                         fallback_fn=species_url_fn,
                         fallback_common_name=_banner_fields["display_name"],

--- a/explorer/app/streamlit/app_prep_map_leaflet_modes.py
+++ b/explorer/app/streamlit/app_prep_map_leaflet_modes.py
@@ -84,7 +84,11 @@ from explorer.core.map_marker_colour_resolve import (
     resolve_lifer_overlay_pin_params,
     resolve_species_visit_pin,
 )
-from explorer.core.settings_schema_defaults import MAP_CLUSTER_ALL_LOCATIONS_DEFAULT
+from explorer.core.settings_schema_defaults import (
+    MAP_CLUSTER_ALL_LOCATIONS_DEFAULT,
+    TAXONOMY_LOCALE_DEFAULT,
+)
+from explorer.core.taxonomy_bundle import load_taxonomy_bundle, taxonomy_locale_key
 from explorer.core.species_locations_geojson import (
     build_species_locations_geojson_payload,
     compute_species_map_banner_fields,
@@ -855,7 +859,14 @@ def prep_standard_map_leaflet_modes(
                         lifer_lookup_df=ctx["lifer_lookup_df"],
                         base_species_fn=base_species_for_lifer,
                     )
-                    _sp_url = species_url_fn(_banner_fields["display_name"])
+                    _tax_loc = taxonomy_locale_key(tax_locale_effective) or TAXONOMY_LOCALE_DEFAULT
+                    _tax_rows = load_taxonomy_bundle(_tax_loc).species_rows
+                    _sp_url = species_url_for_base_species(
+                        base_species_for_lifer(overlay_sci),
+                        _tax_rows,
+                        fallback_fn=species_url_fn,
+                        fallback_common_name=_banner_fields["display_name"],
+                    )
                     all_locations_leaflet_banner_html = build_species_banner_html(
                         species_url=_sp_url if _sp_url else None,
                         date_filter_status="",

--- a/tests/explorer/test_family_map_compute.py
+++ b/tests/explorer/test_family_map_compute.py
@@ -265,6 +265,24 @@ def test_species_url_for_base_species_uses_species_code_not_common_name_lookup()
     assert url == "https://ebird.org/species/bwfshr2"
 
 
+def test_species_url_for_base_species_common_starling_en_us_taxonomy():
+    """Export says Common Starling; en_US taxonomy CSV says European Starling — link via base (refs #251)."""
+    tax = pd.DataFrame(
+        {
+            "base_species": ["sturnus vulgaris"],
+            "species_code": ["eursta"],
+            "common_name": ["European Starling"],
+        }
+    )
+    url = species_url_for_base_species(
+        "sturnus vulgaris",
+        tax,
+        fallback_fn=lambda name: None,
+        fallback_common_name="Common Starling",
+    )
+    assert url == "https://ebird.org/species/eursta"
+
+
 def test_species_url_for_base_species_falls_back_to_common_name_fn():
     tax = pd.DataFrame(
         {"base_species": ["other sp"], "species_code": [""], "common_name": ["Other"]}

--- a/tests/explorer/test_family_map_compute.py
+++ b/tests/explorer/test_family_map_compute.py
@@ -266,7 +266,7 @@ def test_species_url_for_base_species_uses_species_code_not_common_name_lookup()
 
 
 def test_species_url_for_base_species_common_starling_en_us_taxonomy():
-    """Export says Common Starling; en_US taxonomy CSV says European Starling — link via base (refs #251)."""
+    """Export says Common Starling; en_US taxonomy CSV says European Starling — link via base."""
     tax = pd.DataFrame(
         {
             "base_species": ["sturnus vulgaris"],


### PR DESCRIPTION
## Summary

On the **Species locations** map, the banner title link could fail when the export common name did not match the loaded taxonomy locale (e.g. **Common Starling** in the export vs **European Starling** in `en_US` taxonomy). The title still rendered in green but without an `<a>` tag, so it looked like a link but was not clickable.

This aligns species-map banner URL resolution with the family map: resolve via `base_species → species_code`, with common-name lookup as fallback.

## Changes

- Resolve species banner URLs through `species_url_for_base_species()` and taxonomy species rows instead of common-name lookup alone
- Add unit test for Common Starling / European Starling locale mismatch (`eursta`)

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q -m "not e2e"` — 612 passed

Manual: Map → Species locations → select Common Starling → banner title should link to `https://ebird.org/species/eursta`.

Fixes #251


Made with [Cursor](https://cursor.com)