### PR TITLE
Shared helper for map species banner URL resolution

### DIFF
--- a/explorer/app/streamlit/app_prep_map_leaflet_modes.py
+++ b/explorer/app/streamlit/app_prep_map_leaflet_modes.py
@@ -62,7 +62,6 @@ from explorer.core.family_map_compute import (
     compute_family_map_banner_metrics,
     filter_work_to_family,
     selected_species_checklist_individual_counts,
-    species_url_for_base_species,
 )
 from explorer.core.family_map_overlays import (
     build_family_map_banner_overlay_html,
@@ -84,11 +83,8 @@ from explorer.core.map_marker_colour_resolve import (
     resolve_lifer_overlay_pin_params,
     resolve_species_visit_pin,
 )
-from explorer.core.settings_schema_defaults import (
-    MAP_CLUSTER_ALL_LOCATIONS_DEFAULT,
-    TAXONOMY_LOCALE_DEFAULT,
-)
-from explorer.core.taxonomy_bundle import load_taxonomy_bundle, taxonomy_locale_key
+from explorer.core.settings_schema_defaults import MAP_CLUSTER_ALL_LOCATIONS_DEFAULT
+from explorer.core.species_link_urls import species_banner_url
 from explorer.core.species_locations_geojson import (
     build_species_locations_geojson_payload,
     compute_species_map_banner_fields,
@@ -271,11 +267,11 @@ def prep_family_leaflet_mode(
                 )
                 hl_species_url = None
                 if hl:
-                    hl_species_url = species_url_for_base_species(
-                        hl,
-                        tax_merged,
-                        fallback_fn=species_url_fn,
-                        fallback_common_name=hl_label or None,
+                    hl_species_url = species_banner_url(
+                        base_species=hl,
+                        taxonomy_locale=tax_locale_effective,
+                        display_name=hl_label or "",
+                        species_url_fn=species_url_fn,
                     )
                     if not hl_species_url and family_species_url_by_common:
                         _hl_rows = wf[
@@ -859,14 +855,11 @@ def prep_standard_map_leaflet_modes(
                         lifer_lookup_df=ctx["lifer_lookup_df"],
                         base_species_fn=base_species_for_lifer,
                     )
-                    _base_sp = base_species_for_lifer(overlay_sci)
-                    _tax_loc = taxonomy_locale_key(tax_locale_effective) or TAXONOMY_LOCALE_DEFAULT
-                    _tax_rows = load_taxonomy_bundle(_tax_loc).species_rows
-                    _sp_url = species_url_for_base_species(
-                        _base_sp,
-                        _tax_rows,
-                        fallback_fn=species_url_fn,
-                        fallback_common_name=_banner_fields["display_name"],
+                    _sp_url = species_banner_url(
+                        base_species=base_species_for_lifer(overlay_sci),
+                        taxonomy_locale=tax_locale_effective,
+                        display_name=_banner_fields["display_name"],
+                        species_url_fn=species_url_fn,
                     )
                     all_locations_leaflet_banner_html = build_species_banner_html(
                         species_url=_sp_url if _sp_url else None,

--- a/explorer/core/species_link_urls.py
+++ b/explorer/core/species_link_urls.py
@@ -1,0 +1,34 @@
+"""Shared eBird species page URL resolution for map banners."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from explorer.core.family_map_compute import species_url_for_base_species
+from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
+from explorer.core.taxonomy_bundle import load_taxonomy_bundle, taxonomy_locale_key
+
+
+def species_banner_url(
+    *,
+    base_species: str | None,
+    taxonomy_locale: str,
+    display_name: str,
+    species_url_fn: Callable[[str], str | None],
+) -> str | None:
+    """Resolve a map banner link: base scientific name → ``species_code`` → URL.
+
+    Uses taxonomy rows for the given locale; falls back to *species_url_fn* with
+    *display_name* when base → code lookup fails (same rules as map popups).
+    """
+    base = (base_species or "").strip()
+    if not base:
+        return None
+    tax_loc = taxonomy_locale_key(taxonomy_locale) or TAXONOMY_LOCALE_DEFAULT
+    tax_rows = load_taxonomy_bundle(tax_loc).species_rows
+    return species_url_for_base_species(
+        base,
+        tax_rows,
+        fallback_fn=species_url_fn,
+        fallback_common_name=(display_name or "").strip() or None,
+    )

--- a/tests/explorer/test_map_banner_species_url_integration.py
+++ b/tests/explorer/test_map_banner_species_url_integration.py
@@ -1,0 +1,169 @@
+"""Integration: map prep wires ``species_banner_url`` into banner HTML (#253)."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from explorer.core.family_map_compute import (
+    base_species_to_common_from_taxonomy,
+    families_recorded_alphabetically,
+    prepare_family_map_work_frame,
+)
+from explorer.core.map_prep import prepare_all_locations_map_context
+from tests.explorer.test_family_map_compute import (
+    _base_to_family_stub,
+    _tiny_export_rows,
+)
+from tests.explorer.test_streamlit_map_prep import _tiny_df
+from tests.explorer.test_streamlit_ui_helpers import _drop_submodule, _install_streamlit_stub
+
+
+@pytest.fixture
+def streamlit_stub(monkeypatch: pytest.MonkeyPatch):
+    _install_streamlit_stub(monkeypatch)
+    import streamlit as st
+
+    st.session_state.clear()
+    _drop_submodule("explorer.app.streamlit.app_prep_map_ui")
+    _drop_submodule("explorer.app.streamlit.app_prep_map_leaflet_modes")
+    return st
+
+
+@pytest.fixture
+def mock_species_banner_taxonomy(monkeypatch: pytest.MonkeyPatch):
+    rows = pd.DataFrame(
+        {
+            "base_species": ["anas gracilis", "pachycephala rufiventris"],
+            "species_code": ["grtea", "rufwhi1"],
+            "common_name": ["Grey Teal", "Rufous Whistler"],
+        }
+    )
+    bundle = MagicMock(species_rows=rows, groups=[])
+    monkeypatch.setattr(
+        "explorer.core.species_link_urls.load_taxonomy_bundle",
+        lambda _locale: bundle,
+    )
+    return rows
+
+
+@pytest.fixture
+def noop_perf_span(monkeypatch: pytest.MonkeyPatch):
+    import explorer.app.streamlit.app_prep_map_ui as app_prep_map_ui
+
+    @contextmanager
+    def _noop(*_a, **_k):
+        yield
+
+    monkeypatch.setattr(app_prep_map_ui, "perf_span", _noop)
+
+
+def _mock_family_map_bundle(_df_full: pd.DataFrame, _taxonomy_locale: str) -> dict:
+    df = _tiny_export_rows()
+    work = prepare_family_map_work_frame(df, _base_to_family_stub())
+    tax_merged = pd.DataFrame(
+        {
+            "base_species": [
+                "pachycephala olivacea",
+                "pachycephala pectoralis",
+                "pachycephala rufiventris",
+                "anas gracilis",
+            ],
+            "species_code": ["oliwhi1", "golwhi1", "rufwhi1", "grtea"],
+            "common_name": [
+                "Olive Whistler",
+                "Golden Whistler",
+                "Rufous Whistler",
+                "Grey Teal",
+            ],
+            "group_name": [
+                "Whistlers and Allies",
+                "Whistlers and Allies",
+                "Whistlers and Allies",
+                "Ducks, Geese, and Swans",
+            ],
+        }
+    )
+    return {
+        "work": work,
+        "tax_merged": tax_merged,
+        "base_to_common": base_species_to_common_from_taxonomy(tax_merged),
+        "families": families_recorded_alphabetically(work),
+    }
+
+
+def test_species_map_prep_banner_includes_ebird_species_link(
+    streamlit_stub,
+    mock_species_banner_taxonomy,
+    noop_perf_span,
+) -> None:
+    from explorer.app.streamlit.app_prep_map_leaflet_modes import (
+        prep_standard_map_leaflet_modes,
+    )
+
+    df = _tiny_df()
+    ctx = prepare_all_locations_map_context(df)
+    bundle, hint = prep_standard_map_leaflet_modes(
+        ctx=ctx,
+        work_df=df,
+        tax_locale_effective="en_AU",
+        map_view_mode="species",
+        date_filter_banner="",
+        map_style="default",
+        map_height=400,
+        species_pick_common="Grey Teal",
+        species_pick_sci="Anas gracilis",
+        hide_non_matching_locations=False,
+        popup_sort_order="date_desc",
+        popup_scroll_hint="",
+        mark_lifer=False,
+        mark_last_seen=False,
+        family_colour_scheme=0,
+        blank_viewport_recipe={},
+        species_url_fn=lambda _name: None,
+    )
+
+    assert hint is None
+    assert bundle.use_species_leaflet is True
+    assert 'href="https://ebird.org/species/grtea"' in (
+        bundle.all_locations_leaflet_banner_html or ""
+    )
+
+
+def test_family_map_prep_highlight_banner_includes_ebird_species_link(
+    streamlit_stub,
+    mock_species_banner_taxonomy,
+    noop_perf_span,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import explorer.app.streamlit.app_prep_map_leaflet_modes as leaflet_modes
+
+    monkeypatch.setattr(
+        leaflet_modes,
+        "cached_family_map_bundle",
+        _mock_family_map_bundle,
+    )
+
+    df = _tiny_export_rows()
+    bundle, hint = leaflet_modes.prep_family_leaflet_mode(
+        work_df=df,
+        df_full=df,
+        tax_locale_effective="en_AU",
+        date_filter_banner="",
+        map_style="default",
+        map_height=400,
+        map_view_mode="families",
+        family_name="Whistlers and Allies",
+        family_highlight_base="pachycephala rufiventris",
+        family_colour_scheme=0,
+        blank_viewport_recipe={},
+        species_url_fn=lambda _name: None,
+    )
+
+    assert hint is None
+    assert bundle.use_family_leaflet is True
+    banner = bundle.all_locations_leaflet_banner_html or ""
+    assert 'href="https://ebird.org/species/rufwhi1"' in banner

--- a/tests/explorer/test_species_link_urls.py
+++ b/tests/explorer/test_species_link_urls.py
@@ -1,0 +1,64 @@
+"""Tests for explorer.core.species_link_urls."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from explorer.core.species_link_urls import species_banner_url
+
+
+def test_species_banner_url_empty_base_returns_none():
+    assert (
+        species_banner_url(
+            base_species="",
+            taxonomy_locale="en_AU",
+            display_name="Test Bird",
+            species_url_fn=lambda _: "https://ebird.org/species/x",
+        )
+        is None
+    )
+
+
+@patch("explorer.core.species_link_urls.load_taxonomy_bundle")
+def test_species_banner_url_resolves_via_taxonomy_base_to_code(mock_load: MagicMock):
+    mock_load.return_value = MagicMock(
+        species_rows=pd.DataFrame(
+            {
+                "base_species": ["sturnus vulgaris"],
+                "species_code": ["eursta"],
+                "common_name": ["European Starling"],
+            }
+        )
+    )
+    url = species_banner_url(
+        base_species="sturnus vulgaris",
+        taxonomy_locale="en_US",
+        display_name="Common Starling",
+        species_url_fn=lambda _: None,
+    )
+    assert url == "https://ebird.org/species/eursta"
+    mock_load.assert_called_once_with("en_US")
+
+
+@patch("explorer.core.species_link_urls.load_taxonomy_bundle")
+def test_species_banner_url_falls_back_to_common_name_fn(mock_load: MagicMock):
+    mock_load.return_value = MagicMock(
+        species_rows=pd.DataFrame(
+            {
+                "base_species": ["other sp"],
+                "species_code": [""],
+                "common_name": ["Other"],
+            }
+        )
+    )
+    url = species_banner_url(
+        base_species="unknownus species",
+        taxonomy_locale="en_AU",
+        display_name="Mystery Bird",
+        species_url_fn=lambda n: "https://ebird.org/species/fallback"
+        if n == "Mystery Bird"
+        else None,
+    )
+    assert url == "https://ebird.org/species/fallback"


### PR DESCRIPTION
## Summary

Extracts a shared `species_banner_url()` helper so species and family map banners use one code path for base scientific name → taxonomy `species_code` → eBird URL, with common-name fallback. Follow-up from #251 / PR #252.

## Changes

- Add `explorer/core/species_link_urls.py` with `species_banner_url()`
- Update species and family map banner call sites in `app_prep_map_leaflet_modes.py`
- Add unit tests in `tests/explorer/test_species_link_urls.py`
- Family map retains its extra fallback via observed common names in checklist data (unchanged)

## Testing

- `python3 -m ruff check explorer/` — passed
- `python3 -m pytest tests/ -q -m "not e2e"` — 615 passed, 7 e2e deselected

Manual: quick smoke on species + family map banner links recommended (automated tests do not assert end-to-end banner URLs through map prep).

## Notes

`species_url_for_base_species()` remains in `family_map_compute.py` for popup/common-name maps; the new helper wraps taxonomy load + that function for banner use only.

Fixes #253

Made with [Cursor](https://cursor.com)