### PR TITLE
Centralize basemap config in shared YAML manifest

### DIFF
--- a/.cursor/commands/start-issue-work.md
+++ b/.cursor/commands/start-issue-work.md
@@ -1,0 +1,106 @@
+# Start issue work
+
+You are helping work on an issue in the `myebirdstuff` repository.
+
+## Inputs
+
+The user will provide a GitHub issue number, for example:
+
+- `#254`
+- `254`
+
+If no issue number is provided, ask for it before continuing.
+
+---
+
+## Repository workflow
+
+- `main` is the stable/release branch
+- `beta-next` is the integration branch
+- Development work must happen on a new issue branch created from `beta-next`
+- Do not work directly on `main` or `beta-next`
+
+---
+
+## Step 1 — Confirm starting state
+
+1. Confirm the current branch.
+2. If currently on `beta-next`, continue.
+3. If on another branch, check whether there are uncommitted changes.
+4. If there are uncommitted changes, stop and ask what to do.
+
+---
+
+## Step 2 — Read context
+
+Before coding:
+
+1. Read the GitHub issue.
+2. Explore the repository enough to understand the relevant area.
+3. Focus especially on the `explorer` app.
+4. Read relevant technical documentation, including repo guidance files and docs under `docs/explorer/`.
+
+Summarise briefly:
+
+- what the issue is asking for
+- likely files or areas involved
+- any assumptions or risks
+
+---
+
+## Step 3 — Create development branch
+
+Use the existing `/create-dev-branch` command for the issue.
+
+The branch should:
+
+- be based on `beta-next`
+- include the issue number as a prefix
+- use a short descriptive slug
+
+Example:
+
+`254-add-basemap-options`
+
+If `/create-dev-branch` cannot be invoked directly from this command, perform the same steps manually.
+
+---
+
+## Step 4 — Work the issue
+
+Proceed with implementation once the branch is created.
+
+Keep changes focused on the issue.
+
+Do not:
+- refactor unrelated code
+- change behaviour outside the issue scope unless required
+- commit secrets or local config files
+- push or open a PR unless asked
+
+---
+
+## Step 5 — Ask only when needed
+
+Only stop to ask questions if:
+
+- the issue is ambiguous
+- the implementation has meaningful design choices
+- the requested change conflicts with existing behaviour
+- there is risk of unintended regression
+
+Otherwise, make reasonable, conservative choices and continue.
+
+---
+
+## Step 6 — Before finishing
+
+Provide a summary of:
+
+- branch created
+- files changed
+- behaviour implemented
+- tests run
+- any follow-up concerns
+
+If tests were not run, say so clearly.

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -198,7 +198,8 @@ Do not duplicate HTML in UI code — use shared formatters.
 
 ### Defaults
 
-- **`explorer/app/streamlit/defaults.py`** — **Developer tweakables**: map cluster options, pin **size / stroke / opacity**, legend dot sizes, theme hex, basemap list, map height slider bounds, layout widths, temporary map debug (live zoom). Edit here to change look/behaviour without hunting core modules.
+- **`explorer/data/basemaps.yaml`** — **Map basemaps** (keys, labels, tile URLs); loaded by `explorer/core/basemap_manifest.py`. Regenerate React assets with `python3 scripts/generate_basemap_assets.py`.
+- **`explorer/app/streamlit/defaults.py`** — **Developer tweakables**: map cluster options, pin **size / stroke / opacity**, legend dot sizes, theme hex, map height slider bounds, layout widths, temporary map debug (live zoom). Edit here to change look/behaviour without hunting core modules.
 
 - **Map marker design utility** — separate Streamlit app (not user-facing): `streamlit run explorer/app/streamlit/design_map_app.py`. Previews roles and exports scheme dicts; see [development.md](development.md#map-marker-colour-design-utility-developers).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -78,7 +78,7 @@ All four **Map view** modes use the same Streamlit custom component (`explorer/c
 | Client | `frontend/src/AllLocationsMap.tsx` (+ `AllLocationsMapLeaflet.ts`, `AllLocationsMapPopupHtml.ts`, `AllLocationsMapPopupSizing.ts`, `allLocationsMapTypes.ts`) | Leaflet map, MarkerCluster, popup templates (`AllLocationsMapPopup.css`) |
 | Export | `explorer/presentation/leaflet_map_html_export.py` | Standalone HTML (CDN Leaflet) from cached recipe (`LEAFLET_EXPORT_*` keys) |
 
-**Basemaps:** allowlisted keys in `explorer/core/settings_schema_defaults.py` (`MAP_BASEMAP_OPTIONS`); UI labels in `explorer/app/streamlit/defaults.py` (`MAP_BASEMAP_LABELS`). Tile URLs must stay aligned in `AllLocationsMapLeaflet.ts` and `presentation/static/leaflet_map_export.js`. Order: Default (OSM), CARTO Voyager, CartoDB Positron, Esri World Topo, Google Hybrid.
+**Basemaps:** single manifest at `explorer/data/basemaps.yaml` (keys, labels, tile URLs). Python loads it via `explorer/core/basemap_manifest.py` (`MAP_BASEMAP_OPTIONS`, `MAP_BASEMAP_LABELS`). Regenerate the React tile config with `python3 scripts/generate_basemap_assets.py` (also run from `scripts/build_all_locations_map_frontend.py`). HTML export embeds tile defs from the same manifest at export time (`leaflet_map_html_export.py` → `leaflet_map_export.js`).
 
 **Historical performance notes** (#222): [`issue-222-plain-summary.md`](explorer/issue-222-plain-summary.md) (plain language), [`issue-222-section-8-baseline.md`](explorer/issue-222-section-8-baseline.md) (tables + re-run), [`issue-222-section-8-prior-art.md`](explorer/issue-222-section-8-prior-art.md) (Folium-era context). Re-run: `./scripts/run_post_leaflet_perf_baseline.sh`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,7 +64,7 @@ npm run build
 
 `npm audit` without `--omit=dev` may report dev-toolchain issues from `react-scripts` (e.g. `webpack-dev-server`); CI does **not** fail on those. Review `package-lock.json` updates like Python `requirements.txt`.
 
-**Map HTML export (sidebar):** Lazy build on user action; one-click download via Streamlit + optional auto-click. If users report failed exports, see [map-html-export-ux-alternative.md](explorer/map-html-export-ux-alternative.md) for a two-button fallback design and browser-risk notes.
+**Map HTML export (sidebar):** Lazy build on user action; one-click download via Streamlit + optional auto-click. If users report failed exports, see [map-html-export-ux-alternative.md](explorer/map-html-export-ux-alternative.md) for a two-button fallback design and browser-risk notes. Export is infrequent and not on the live map hot path — a larger self-contained HTML file (e.g. full basemap defs in the embedded config) is an intentional tradeoff; optimise Streamlit map perf first.
 
 ### Map architecture (production)
 

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -5,7 +5,7 @@ you may edit in one place without hunting through core modules.
 **What belongs here**
 
 - Marker cluster options, pin **radius / stroke / opacities**, legend dot sizes, popup width
-- Map UI: basemap list/labels, height slider bounds, view labels, date-filter default; **debug-only map toggles** registered in :func:`debug_defaults_enabled` for CI
+- Map UI: basemap list/labels (from ``explorer/data/basemaps.yaml``), height slider bounds, view labels, date-filter default; **debug-only map toggles** registered in :func:`debug_defaults_enabled` for CI
 - Theme hex values aligned with ``.streamlit/config.toml``, settings panel width cap
 - Rankings HTML layout width / scroll hint default; spinner CSS cache key suffix when theme CSS changes
 
@@ -30,6 +30,7 @@ from explorer.core.map_marker_scheme_model import (
     MapMarkerSpeciesLocationsStyle,
     MapMarkerSpeciesMapBackgroundStyle,
 )
+from explorer.core.basemap_manifest import MAP_BASEMAP_LABELS  # noqa: F401 — re-export for Streamlit UI
 from explorer.core.settings_schema_defaults import (  # noqa: F401 — re-export for Streamlit UI
     MAP_BASEMAP_DEFAULT,
     MAP_BASEMAP_OPTIONS,
@@ -109,14 +110,6 @@ MAP_POPUP_MACAULAY_LINK_SYMBOL = "↗"
 # ---------------------------------------------------------------------------
 # Map UI — sidebar / Settings controls (basemap default is persisted in YAML)
 # ---------------------------------------------------------------------------
-
-MAP_BASEMAP_LABELS: dict[str, str] = {
-    "default": "Default (OpenStreetMap)",
-    "voyager": "CARTO Voyager",
-    "carto": "CartoDB Positron",
-    "esri_topo": "Esri World Topo",
-    "google": "Google Hybrid",
-}
 
 MAP_HEIGHT_PX_DEFAULT = 720
 MAP_HEIGHT_PX_MIN = 440

--- a/explorer/components/all_locations_map/__init__.py
+++ b/explorer/components/all_locations_map/__init__.py
@@ -55,7 +55,7 @@ def render_all_locations_map_component(
 
     *viewport* — camera recipe from :func:`~explorer.core.map_leaflet_viewport.all_locations_leaflet_viewport_recipe`. Omit or empty dict to fall back to GeoJSON-bounds padding in the iframe.
 
-    *map_style* — basemap key from ``MAP_BASEMAP_OPTIONS`` in ``explorer.app.streamlit.defaults``
+    *map_style* — basemap key from ``MAP_BASEMAP_OPTIONS`` (``explorer/data/basemaps.yaml`` via ``explorer.core.basemap_manifest``)
     (e.g. ``default``, ``voyager``, ``carto``, ``esri_topo``, ``google``). Passed from the Prep map
     tab sidebar; unknown values behave as ``default``.
 

--- a/explorer/components/all_locations_map/frontend/src/AllLocationsMapLeaflet.test.ts
+++ b/explorer/components/all_locations_map/frontend/src/AllLocationsMapLeaflet.test.ts
@@ -1,8 +1,9 @@
 import { normalizeBasemapId } from "./AllLocationsMapLeaflet";
+import { BASEMAP_IDS } from "./basemaps.generated";
 
 describe("normalizeBasemapId", () => {
   it("accepts all production basemap keys", () => {
-    for (const key of ["default", "voyager", "carto", "esri_topo", "google"]) {
+    for (const key of BASEMAP_IDS) {
       expect(normalizeBasemapId(key)).toBe(key);
     }
   });

--- a/explorer/components/all_locations_map/frontend/src/AllLocationsMapLeaflet.ts
+++ b/explorer/components/all_locations_map/frontend/src/AllLocationsMapLeaflet.ts
@@ -16,61 +16,18 @@ import {
   GO_TO_GPS_POPUP_HTML,
   POPUP_BIND_OPTIONS,
 } from "./AllLocationsMapPopupSizing";
-
-
-/** Must stay aligned with ``MAP_BASEMAP_OPTIONS`` in ``explorer/core/settings_schema_defaults.py``. */
-type BasemapId = "default" | "voyager" | "carto" | "esri_topo" | "google";
-
-const CARTO_ATTRIBUTION =
-  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>';
-
-const ALL_LOCATIONS_BASEMAPS: Record<BasemapId, { url: string; opts: L.TileLayerOptions }> = {
-  default: {
-    url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-    opts: {
-      maxZoom: 19,
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-    },
-  },
-  voyager: {
-    url: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png",
-    opts: {
-      maxZoom: 20,
-      subdomains: "abcd",
-      attribution: CARTO_ATTRIBUTION,
-    },
-  },
-  carto: {
-    url: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
-    opts: {
-      maxZoom: 20,
-      subdomains: "abcd",
-      attribution: CARTO_ATTRIBUTION,
-    },
-  },
-  esri_topo: {
-    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
-    opts: {
-      maxZoom: 19,
-      attribution:
-        "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
-    },
-  },
-  google: {
-    url: "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
-    opts: {
-      maxZoom: 22,
-      attribution: "Google",
-    },
-  },
-};
+import {
+  ALL_LOCATIONS_BASEMAPS,
+  BASEMAP_DEFAULT,
+  type BasemapId,
+} from "./basemaps.generated";
 
 export function normalizeBasemapId(raw: string | undefined): BasemapId {
-  const s = String(raw ?? "default").trim().toLowerCase();
+  const s = String(raw ?? BASEMAP_DEFAULT).trim().toLowerCase();
   if (s in ALL_LOCATIONS_BASEMAPS) {
     return s as BasemapId;
   }
-  return "default";
+  return BASEMAP_DEFAULT;
 }
 
 export function applyBasemapToMap(

--- a/explorer/components/all_locations_map/frontend/src/basemaps.generated.ts
+++ b/explorer/components/all_locations_map/frontend/src/basemaps.generated.ts
@@ -1,0 +1,35 @@
+/** AUTO-GENERATED from explorer/data/basemaps.yaml — do not edit. */
+/** Regenerate: python3 scripts/generate_basemap_assets.py */
+
+import type { TileLayerOptions } from "leaflet";
+
+export type BasemapId = "default" | "voyager" | "carto" | "esri_topo" | "google";
+
+export const BASEMAP_IDS = ["default", "voyager", "carto", "esri_topo", "google"] as const;
+
+export const BASEMAP_DEFAULT: BasemapId = "default";
+
+export type BasemapTileConfig = { url: string; opts: TileLayerOptions };
+
+export const ALL_LOCATIONS_BASEMAPS: Record<BasemapId, BasemapTileConfig> = {
+  "default": {
+    url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    opts: { maxZoom: 19, attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a>" },
+  },
+  "voyager": {
+    url: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png",
+    opts: { maxZoom: 20, subdomains: "abcd", attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/attributions\">CARTO</a>" },
+  },
+  "carto": {
+    url: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+    opts: { maxZoom: 20, subdomains: "abcd", attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/attributions\">CARTO</a>" },
+  },
+  "esri_topo": {
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
+    opts: { maxZoom: 19, attribution: "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community" },
+  },
+  "google": {
+    url: "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
+    opts: { maxZoom: 22, attribution: "Google" },
+  },
+};

--- a/explorer/core/basemap_manifest.py
+++ b/explorer/core/basemap_manifest.py
@@ -1,0 +1,118 @@
+"""
+Load the shared basemap manifest (``explorer/data/basemaps.yaml``).
+
+Single source of truth for allowlisted basemap keys, UI labels, and tile layer config.
+Used by settings validation, Streamlit UI, HTML export, and generated frontend assets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_MANIFEST_PATH = Path(__file__).resolve().parents[1] / "data" / "basemaps.yaml"
+
+
+@dataclass(frozen=True)
+class BasemapEntry:
+    key: str
+    label: str
+    url: str
+    max_zoom: int
+    attribution: str
+    attribution_export: str
+    subdomains: str | None = None
+
+
+def _parse_entry(raw: dict[str, Any]) -> BasemapEntry:
+    key = str(raw["key"])
+    attribution = str(raw["attribution"])
+    return BasemapEntry(
+        key=key,
+        label=str(raw["label"]),
+        url=str(raw["url"]),
+        max_zoom=int(raw["max_zoom"]),
+        attribution=attribution,
+        attribution_export=str(raw.get("attribution_export", attribution)),
+        subdomains=str(raw["subdomains"]) if raw.get("subdomains") is not None else None,
+    )
+
+
+@lru_cache(maxsize=1)
+def load_basemap_manifest() -> dict[str, Any]:
+    """Parse and cache ``basemaps.yaml``."""
+    data = yaml.safe_load(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid basemap manifest: expected mapping at {_MANIFEST_PATH}")
+    return data
+
+
+@lru_cache(maxsize=1)
+def get_basemap_entries() -> tuple[BasemapEntry, ...]:
+    data = load_basemap_manifest()
+    raw_list = data.get("basemaps")
+    if not isinstance(raw_list, list) or not raw_list:
+        raise ValueError("basemaps.yaml must define a non-empty basemaps list")
+    entries = tuple(_parse_entry(item) for item in raw_list)
+    keys = [e.key for e in entries]
+    if len(keys) != len(set(keys)):
+        raise ValueError("basemaps.yaml contains duplicate basemap keys")
+    return entries
+
+
+def get_basemap_default_key() -> str:
+    data = load_basemap_manifest()
+    default_key = str(data.get("default_key", "default"))
+    keys = {e.key for e in get_basemap_entries()}
+    if default_key not in keys:
+        raise ValueError(f"default_key {default_key!r} is not in basemaps list")
+    return default_key
+
+
+MAP_BASEMAP_OPTIONS: tuple[str, ...] = tuple(e.key for e in get_basemap_entries())
+MAP_BASEMAP_DEFAULT: str = get_basemap_default_key()
+MAP_BASEMAP_LABELS: dict[str, str] = {e.key: e.label for e in get_basemap_entries()}
+
+
+def basemap_tile_layer_for_component(entry: BasemapEntry) -> dict[str, Any]:
+    """Leaflet tile layer payload for the React map component."""
+    opts: dict[str, Any] = {
+        "maxZoom": entry.max_zoom,
+        "attribution": entry.attribution,
+    }
+    if entry.subdomains is not None:
+        opts["subdomains"] = entry.subdomains
+    return {"url": entry.url, "opts": opts}
+
+
+def basemap_tile_layer_for_export(entry: BasemapEntry) -> dict[str, Any]:
+    """Leaflet tile layer payload for standalone HTML export (plain attribution)."""
+    opts: dict[str, Any] = {
+        "maxZoom": entry.max_zoom,
+        "attribution": entry.attribution_export,
+    }
+    if entry.subdomains is not None:
+        opts["subdomains"] = entry.subdomains
+    return {"url": entry.url, "opts": opts}
+
+
+def basemap_tile_layers_for_component() -> dict[str, dict[str, Any]]:
+    return {e.key: basemap_tile_layer_for_component(e) for e in get_basemap_entries()}
+
+
+def basemap_tile_layers_for_export() -> dict[str, dict[str, Any]]:
+    return {e.key: basemap_tile_layer_for_export(e) for e in get_basemap_entries()}
+
+
+def basemap_tile_url_fragment(entry: BasemapEntry) -> str:
+    """Stable substring used in tests to verify export HTML embeds the correct tiles."""
+    url = entry.url
+    for token in ("https://{s}.", "https://", "http://"):
+        if url.startswith(token):
+            url = url[len(token) :]
+            break
+    return url.split("/")[0].split("{")[0].rstrip(".")

--- a/explorer/core/settings_schema_defaults.py
+++ b/explorer/core/settings_schema_defaults.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from explorer.core.basemap_manifest import (  # noqa: F401 — re-export for settings_config
+    MAP_BASEMAP_DEFAULT,
+    MAP_BASEMAP_OPTIONS,
+)
 from explorer.core.constants import COUNTRY_TAB_SORT_ALPHABETICAL
 
 SETTINGS_SCHEMA_VERSION = 1
@@ -17,17 +21,6 @@ MAP_POPUP_SORT_ORDER_DEFAULT = "ascending"
 MAP_POPUP_SCROLL_HINT_DEFAULT = "shading"
 MAP_MARK_LIFER_DEFAULT = True
 MAP_MARK_LAST_SEEN_DEFAULT = True
-# Basemap: stored in persisted settings as a simple key (not a tile-layer object).
-# Order matches the Map sidebar / Settings dropdown. Labels live in
-# ``explorer.app.streamlit.defaults.MAP_BASEMAP_LABELS``.
-MAP_BASEMAP_OPTIONS: tuple[str, ...] = (
-    "default",
-    "voyager",
-    "carto",
-    "esri_topo",
-    "google",
-)
-MAP_BASEMAP_DEFAULT = "default"
 MAP_HEIGHT_PX_DEFAULT = 720
 MAP_HEIGHT_PX_MIN = 440
 MAP_HEIGHT_PX_MAX = 1200

--- a/explorer/data/basemaps.yaml
+++ b/explorer/data/basemaps.yaml
@@ -1,0 +1,44 @@
+# Single source of truth for Explorer map basemap keys, labels, and tile layers.
+# Edit here only; regenerate frontend assets with:
+#   python3 scripts/generate_basemap_assets.py
+# (also runs automatically from scripts/build_all_locations_map_frontend.py)
+
+default_key: default
+
+basemaps:
+  - key: default
+    label: Default (OpenStreetMap)
+    url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+    max_zoom: 19
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+    attribution_export: "&copy; OpenStreetMap contributors"
+
+  - key: voyager
+    label: CARTO Voyager
+    url: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+    max_zoom: 20
+    subdomains: abcd
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+    attribution_export: "&copy; OpenStreetMap &copy; CARTO"
+
+  - key: carto
+    label: CartoDB Positron
+    url: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+    max_zoom: 20
+    subdomains: abcd
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+    attribution_export: "&copy; OpenStreetMap &copy; CARTO"
+
+  - key: esri_topo
+    label: Esri World Topo
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}"
+    max_zoom: 19
+    attribution: "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community"
+    attribution_export: "Tiles &copy; Esri"
+
+  - key: google
+    label: Google Hybrid
+    url: "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}"
+    max_zoom: 22
+    attribution: Google
+    attribution_export: Google

--- a/explorer/presentation/leaflet_map_html_export.py
+++ b/explorer/presentation/leaflet_map_html_export.py
@@ -12,7 +12,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from explorer.core.basemap_manifest import basemap_tile_layers_for_export
+from explorer.core.basemap_manifest import MAP_BASEMAP_DEFAULT, basemap_tile_layers_for_export
 from explorer.presentation.popup_v1_export_html import enrich_geojson_for_export
 
 _STATIC = Path(__file__).resolve().parent / "static"
@@ -52,7 +52,7 @@ def leaflet_map_to_html_bytes(
     *,
     geojson: dict[str, Any],
     height: int,
-    map_style: str = "default",
+    map_style: str = MAP_BASEMAP_DEFAULT,
     cluster_options: dict[str, Any] | None = None,
     circle_marker_style: dict[str, Any] | None = None,
     cluster_icon_style: dict[str, Any] | None = None,
@@ -67,7 +67,8 @@ def leaflet_map_to_html_bytes(
     config = {
         "geojson": enriched,
         "height": int(height),
-        "map_style": str(map_style or "default"),
+        "map_style": str(map_style or MAP_BASEMAP_DEFAULT),
+        "basemap_default": MAP_BASEMAP_DEFAULT,
         "basemaps": basemap_tile_layers_for_export(),
         "cluster_options": cluster_options if cluster_options is not None else {},
         "circle_marker_style": circle_marker_style if circle_marker_style is not None else {},

--- a/explorer/presentation/leaflet_map_html_export.py
+++ b/explorer/presentation/leaflet_map_html_export.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from explorer.core.basemap_manifest import basemap_tile_layers_for_export
 from explorer.presentation.popup_v1_export_html import enrich_geojson_for_export
 
 _STATIC = Path(__file__).resolve().parent / "static"
@@ -67,6 +68,7 @@ def leaflet_map_to_html_bytes(
         "geojson": enriched,
         "height": int(height),
         "map_style": str(map_style or "default"),
+        "basemaps": basemap_tile_layers_for_export(),
         "cluster_options": cluster_options if cluster_options is not None else {},
         "circle_marker_style": circle_marker_style if circle_marker_style is not None else {},
         "cluster_icon_style": cluster_icon_style if cluster_icon_style is not None else {},

--- a/explorer/presentation/leaflet_map_html_export.py
+++ b/explorer/presentation/leaflet_map_html_export.py
@@ -2,6 +2,10 @@
 
 Single-stack: uses the same GeoJSON + theme CSS as production, with a small vanilla JS viewer
 (``static/leaflet_map_export.js``). No Folium build at export time.
+
+Export is a low-frequency sidebar action. A slightly larger self-contained HTML file — for
+example the full basemap manifest embedded in the export config — is an acceptable tradeoff
+for maintainability. Live Streamlit map performance is the priority, not export file size.
 """
 
 from __future__ import annotations

--- a/explorer/presentation/static/leaflet_map_export.js
+++ b/explorer/presentation/static/leaflet_map_export.js
@@ -153,40 +153,11 @@
     spiderfy_on_max_zoom: false,
     remove_outside_visible_bounds: false,
   };
-  var BASEMAPS = {
-    default: {
-      url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-      opts: { maxZoom: 19, attribution: "&copy; OpenStreetMap contributors" },
-    },
-    voyager: {
-      url: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png",
-      opts: {
-        maxZoom: 20,
-        subdomains: "abcd",
-        attribution: "&copy; OpenStreetMap &copy; CARTO",
-      },
-    },
-    carto: {
-      url: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
-      opts: {
-        maxZoom: 20,
-        subdomains: "abcd",
-        attribution: "&copy; OpenStreetMap &copy; CARTO",
-      },
-    },
-    esri_topo: {
-      url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
-      opts: { maxZoom: 19, attribution: "Tiles &copy; Esri" },
-    },
-    google: {
-      url: "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
-      opts: { maxZoom: 22, attribution: "Google" },
-    },
-  };
 
-  function basemap(style) {
+  function basemap(style, basemaps) {
     var s = String(style || "default").toLowerCase();
-    return BASEMAPS[s] || BASEMAPS.default;
+    var maps = basemaps || {};
+    return maps[s] || maps.default || { url: "", opts: {} };
   }
 
   function mergeCluster(raw) {
@@ -301,7 +272,7 @@
         delete nodes[i].dataset.pebirdShrinkTarget;
       }
     });
-    var bm = basemap(cfg.map_style);
+    var bm = basemap(cfg.map_style, cfg.basemaps);
     L.tileLayer(bm.url, bm.opts).addTo(map);
     var clusterCfg = mergeCluster(cfg.cluster_options);
     var overlay;

--- a/explorer/presentation/static/leaflet_map_export.js
+++ b/explorer/presentation/static/leaflet_map_export.js
@@ -154,10 +154,11 @@
     remove_outside_visible_bounds: false,
   };
 
-  function basemap(style, basemaps) {
-    var s = String(style || "default").toLowerCase();
+  function basemap(style, basemaps, defaultKey) {
+    var fallback = String(defaultKey || "default").toLowerCase();
+    var s = String(style || fallback).toLowerCase();
     var maps = basemaps || {};
-    return maps[s] || maps.default || { url: "", opts: {} };
+    return maps[s] || maps[fallback] || { url: "", opts: {} };
   }
 
   function mergeCluster(raw) {
@@ -272,7 +273,7 @@
         delete nodes[i].dataset.pebirdShrinkTarget;
       }
     });
-    var bm = basemap(cfg.map_style, cfg.basemaps);
+    var bm = basemap(cfg.map_style, cfg.basemaps, cfg.basemap_default);
     L.tileLayer(bm.url, bm.opts).addTo(map);
     var clusterCfg = mergeCluster(cfg.cluster_options);
     var overlay;

--- a/scripts/build_all_locations_map_frontend.py
+++ b/scripts/build_all_locations_map_frontend.py
@@ -117,6 +117,12 @@ def main() -> None:
     args = parser.parse_args()
 
     if not args.check_only:
+        print("Generating basemap assets from explorer/data/basemaps.yaml …")
+        subprocess.run(
+            [sys.executable, str(_REPO_ROOT / "scripts/generate_basemap_assets.py")],
+            cwd=_REPO_ROOT,
+            check=True,
+        )
         print(f"Building {_FRONTEND.relative_to(_REPO_ROOT)} …")
         _run_npm_build(skip_install=args.skip_install)
 

--- a/scripts/build_all_locations_map_frontend.py
+++ b/scripts/build_all_locations_map_frontend.py
@@ -9,6 +9,10 @@ The committed ``frontend/build/`` tree is what Explorer loads at runtime (see co
 This script runs ``npm ci`` + ``npm run build``, then reports expected vs stray files so you know
 what to ``git add`` and what to delete (e.g. macOS Finder duplicates like ``static/css 4/``).
 
+With ``--check-only``, validates committed ``frontend/build/`` **and** that
+``basemaps.generated.ts`` matches ``explorer/data/basemaps.yaml`` (via
+``scripts/generate_basemap_assets.py --check``).
+
 Exit 1 if junk or unexpected files remain under ``build/`` (use ``--prune-junk`` to remove known junk only).
 """
 
@@ -28,6 +32,16 @@ _BUILD = _FRONTEND / "build"
 
 # macOS Finder "copy N" folders — never produced by Create React App.
 _JUNK_DIR_RE = re.compile(r"^(css|js) \d+$")
+
+
+def _run_basemap_assets(*, check: bool) -> None:
+    cmd = [sys.executable, str(_REPO_ROOT / "scripts/generate_basemap_assets.py")]
+    if check:
+        print("Checking basemap assets against explorer/data/basemaps.yaml …")
+        cmd.append("--check")
+    else:
+        print("Generating basemap assets from explorer/data/basemaps.yaml …")
+    subprocess.run(cmd, cwd=_REPO_ROOT, check=True)
 
 
 def _run_npm_build(*, skip_install: bool) -> None:
@@ -116,13 +130,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    _run_basemap_assets(check=args.check_only)
+
     if not args.check_only:
-        print("Generating basemap assets from explorer/data/basemaps.yaml …")
-        subprocess.run(
-            [sys.executable, str(_REPO_ROOT / "scripts/generate_basemap_assets.py")],
-            cwd=_REPO_ROOT,
-            check=True,
-        )
         print(f"Building {_FRONTEND.relative_to(_REPO_ROOT)} …")
         _run_npm_build(skip_install=args.skip_install)
 

--- a/scripts/generate_basemap_assets.py
+++ b/scripts/generate_basemap_assets.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Generate frontend basemap assets from ``explorer/data/basemaps.yaml``.
+
+Writes ``explorer/components/all_locations_map/frontend/src/basemaps.generated.ts``.
+
+Run from repo root (also invoked by ``scripts/build_all_locations_map_frontend.py``):
+
+    python3 scripts/generate_basemap_assets.py
+
+Use ``--check`` in CI to fail when generated output is stale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TS_OUT = (
+    _REPO_ROOT
+    / "explorer/components/all_locations_map/frontend/src/basemaps.generated.ts"
+)
+
+
+def _json_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def render_basemaps_ts() -> str:
+    # Import after repo root is on path when run as script.
+    sys.path.insert(0, str(_REPO_ROOT))
+    from explorer.core.basemap_manifest import (  # noqa: PLC0415
+        MAP_BASEMAP_DEFAULT,
+        basemap_tile_layers_for_component,
+        get_basemap_entries,
+    )
+
+    keys = [e.key for e in get_basemap_entries()]
+    basemaps = basemap_tile_layers_for_component()
+    union = " | ".join(_json_string(k) for k in keys)
+    lines = [
+        "/** AUTO-GENERATED from explorer/data/basemaps.yaml — do not edit. */",
+        "/** Regenerate: python3 scripts/generate_basemap_assets.py */",
+        "",
+        "import type { TileLayerOptions } from \"leaflet\";",
+        "",
+        f"export type BasemapId = {union};",
+        "",
+        f"export const BASEMAP_IDS = [{', '.join(_json_string(k) for k in keys)}] as const;",
+    ]
+    lines.extend(
+        [
+            "",
+            f"export const BASEMAP_DEFAULT: BasemapId = {_json_string(MAP_BASEMAP_DEFAULT)};",
+            "",
+            "export type BasemapTileConfig = { url: string; opts: TileLayerOptions };",
+            "",
+            "export const ALL_LOCATIONS_BASEMAPS: Record<BasemapId, BasemapTileConfig> = {",
+        ]
+    )
+    for key in keys:
+        layer = basemaps[key]
+        opts_parts = [f"maxZoom: {layer['opts']['maxZoom']}"]
+        if "subdomains" in layer["opts"]:
+            opts_parts.append(f"subdomains: {_json_string(layer['opts']['subdomains'])}")
+        opts_parts.append(f"attribution: {_json_string(layer['opts']['attribution'])}")
+        opts_body = ", ".join(opts_parts)
+        lines.append(f"  {_json_string(key)}: {{")
+        lines.append(f"    url: {_json_string(layer['url'])},")
+        lines.append(f"    opts: {{ {opts_body} }},")
+        lines.append("  },")
+    lines.append("};")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if generated TS is out of date (do not write).",
+    )
+    args = parser.parse_args()
+
+    rendered = render_basemaps_ts()
+    if args.check:
+        if not _TS_OUT.is_file():
+            print(f"error: missing {_TS_OUT.relative_to(_REPO_ROOT)}", file=sys.stderr)
+            sys.exit(1)
+        existing = _TS_OUT.read_text(encoding="utf-8")
+        if existing != rendered:
+            print(
+                f"error: {_TS_OUT.relative_to(_REPO_ROOT)} is stale; "
+                "run python3 scripts/generate_basemap_assets.py",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"OK: {_TS_OUT.relative_to(_REPO_ROOT)} matches basemaps.yaml")
+        return
+
+    _TS_OUT.write_text(rendered, encoding="utf-8")
+    print(f"wrote {_TS_OUT.relative_to(_REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/explorer/test_basemap_manifest.py
+++ b/tests/explorer/test_basemap_manifest.py
@@ -1,0 +1,44 @@
+"""Tests for the shared basemap manifest (``explorer/data/basemaps.yaml``)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_basemap_manifest_options_labels_and_tiles():
+    from explorer.core.basemap_manifest import (
+        MAP_BASEMAP_DEFAULT,
+        MAP_BASEMAP_LABELS,
+        MAP_BASEMAP_OPTIONS,
+        basemap_tile_layers_for_component,
+        basemap_tile_layers_for_export,
+        get_basemap_entries,
+    )
+
+    entries = get_basemap_entries()
+    assert len(entries) >= 5
+    assert MAP_BASEMAP_OPTIONS == tuple(e.key for e in entries)
+    assert MAP_BASEMAP_DEFAULT in MAP_BASEMAP_OPTIONS
+    assert list(MAP_BASEMAP_LABELS) == list(MAP_BASEMAP_OPTIONS)
+
+    component = basemap_tile_layers_for_component()
+    export = basemap_tile_layers_for_export()
+    for key in MAP_BASEMAP_OPTIONS:
+        assert key in component
+        assert key in export
+        assert component[key]["url"] == export[key]["url"]
+        assert component[key]["opts"]["maxZoom"] == export[key]["opts"]["maxZoom"]
+
+
+def test_generated_basemap_ts_is_fresh():
+    result = subprocess.run(
+        [sys.executable, str(_REPO_ROOT / "scripts/generate_basemap_assets.py"), "--check"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from explorer.core.basemap_manifest import basemap_tile_url_fragment, get_basemap_entries
 from explorer.presentation.leaflet_map_html_export import leaflet_map_to_html_bytes
 from explorer.presentation.popup_v1_export_html import popup_export_html_from_properties
 
@@ -158,13 +159,7 @@ def test_popup_export_html_species_popup_v1():
 
 @pytest.mark.parametrize(
     ("map_style", "tile_fragment"),
-    [
-        ("default", "tile.openstreetmap.org"),
-        ("voyager", "basemaps.cartocdn.com/rastertiles/voyager"),
-        ("carto", "basemaps.cartocdn.com/light_all"),
-        ("esri_topo", "World_Topo_Map"),
-        ("google", "mt1.google.com/vt/lyrs=y"),
-    ],
+    [(e.key, basemap_tile_url_fragment(e)) for e in get_basemap_entries()],
 )
 def test_leaflet_map_to_html_bytes_basemap_tile_urls(map_style: str, tile_fragment: str):
     geojson = {

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+import json
+import re
+
 import pytest
 
-from explorer.core.basemap_manifest import basemap_tile_url_fragment, get_basemap_entries
+from explorer.core.basemap_manifest import (
+    MAP_BASEMAP_OPTIONS,
+    basemap_tile_layers_for_export,
+    basemap_tile_url_fragment,
+    get_basemap_entries,
+)
 from explorer.presentation.leaflet_map_html_export import leaflet_map_to_html_bytes
 from explorer.presentation.popup_v1_export_html import popup_export_html_from_properties
 
@@ -157,12 +165,8 @@ def test_popup_export_html_species_popup_v1():
     assert "pebird-map-popup__all-visits" in html
 
 
-@pytest.mark.parametrize(
-    ("map_style", "tile_fragment"),
-    [(e.key, basemap_tile_url_fragment(e)) for e in get_basemap_entries()],
-)
-def test_leaflet_map_to_html_bytes_basemap_tile_urls(map_style: str, tile_fragment: str):
-    geojson = {
+def _minimal_export_geojson() -> dict:
+    return {
         "type": "FeatureCollection",
         "features": [
             {
@@ -172,8 +176,40 @@ def test_leaflet_map_to_html_bytes_basemap_tile_urls(map_style: str, tile_fragme
             }
         ],
     }
+
+
+def _parse_export_config_html(text: str) -> dict:
+    match = re.search(
+        r'<script type="application/json" id="pebird-map-export-config">(.*?)</script>',
+        text,
+        flags=re.DOTALL,
+    )
+    assert match is not None, "export config script tag missing"
+    return json.loads(match.group(1))
+
+
+def test_leaflet_map_to_html_bytes_embeds_basemap_manifest_in_config():
     raw = leaflet_map_to_html_bytes(
-        geojson=geojson,
+        geojson=_minimal_export_geojson(),
+        height=400,
+        map_style="default",
+        cluster_options={"enabled": False},
+        circle_marker_style={"fill_hex": "#3388ff", "stroke_hex": "#1c2630", "radius_px": 7},
+        viewport={"v": 1, "mode": "center_zoom", "center": [-37.0, 145.0], "zoom": 10},
+    )
+    config = _parse_export_config_html(raw.decode("utf-8"))
+    assert "basemaps" in config
+    assert set(config["basemaps"]) == set(MAP_BASEMAP_OPTIONS)
+    assert config["basemaps"] == basemap_tile_layers_for_export()
+
+
+@pytest.mark.parametrize(
+    ("map_style", "tile_fragment"),
+    [(e.key, basemap_tile_url_fragment(e)) for e in get_basemap_entries()],
+)
+def test_leaflet_map_to_html_bytes_basemap_tile_urls(map_style: str, tile_fragment: str):
+    raw = leaflet_map_to_html_bytes(
+        geojson=_minimal_export_geojson(),
         height=400,
         map_style=map_style,
         cluster_options={"enabled": False},
@@ -183,6 +219,7 @@ def test_leaflet_map_to_html_bytes_basemap_tile_urls(map_style: str, tile_fragme
     text = raw.decode("utf-8")
     assert f'"map_style":"{map_style}"' in text
     assert tile_fragment in text
+    assert "basemaps" in _parse_export_config_html(text)
 
 
 def test_leaflet_map_to_html_bytes_includes_viewer_and_geojson():

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -8,6 +8,7 @@ import re
 import pytest
 
 from explorer.core.basemap_manifest import (
+    MAP_BASEMAP_DEFAULT,
     MAP_BASEMAP_OPTIONS,
     basemap_tile_layers_for_export,
     basemap_tile_url_fragment,
@@ -198,6 +199,7 @@ def test_leaflet_map_to_html_bytes_embeds_basemap_manifest_in_config():
         viewport={"v": 1, "mode": "center_zoom", "center": [-37.0, 145.0], "zoom": 10},
     )
     config = _parse_export_config_html(raw.decode("utf-8"))
+    assert config["basemap_default"] == MAP_BASEMAP_DEFAULT
     assert "basemaps" in config
     assert set(config["basemaps"]) == set(MAP_BASEMAP_OPTIONS)
     assert config["basemaps"] == basemap_tile_layers_for_export()

--- a/tests/explorer/test_streamlit_settings_config.py
+++ b/tests/explorer/test_streamlit_settings_config.py
@@ -129,10 +129,11 @@ def test_load_yaml_settings_accepts_basemap_keys(tmp_path, basemap_key: str):
 
 def test_map_basemap_options_match_settings_schema():
     from explorer.app.streamlit.defaults import MAP_BASEMAP_LABELS, MAP_BASEMAP_OPTIONS
+    from explorer.core.basemap_manifest import get_basemap_entries
     from explorer.core.settings_schema_defaults import MAP_BASEMAP_OPTIONS as SCHEMA_OPTIONS
 
     assert MAP_BASEMAP_OPTIONS == SCHEMA_OPTIONS
-    assert len(MAP_BASEMAP_OPTIONS) == 5
+    assert len(MAP_BASEMAP_OPTIONS) == len(get_basemap_entries())
     assert list(MAP_BASEMAP_LABELS) == list(MAP_BASEMAP_OPTIONS)
 
 


### PR DESCRIPTION
## Summary

Introduces a single shared basemap manifest so tile URLs, labels, and options are no longer maintained in three separate places. No user-facing behaviour change — same five basemaps in the dropdown.

Includes PR review follow-ups (export config tests, `basemap_default` in export, `--check-only` basemap freshness) and one out-of-scope chore: a new `/start-issue-work` Cursor command.

## Changes

### Basemap manifest (#249)

- Add `explorer/data/basemaps.yaml` as the single source of truth for basemap keys, labels, and tile layer config
- Add `explorer/core/basemap_manifest.py` to load the manifest for Python (settings allowlist, UI labels, export tile defs)
- Generate `basemaps.generated.ts` for the React Leaflet component via `scripts/generate_basemap_assets.py`
- Wire generation into `scripts/build_all_locations_map_frontend.py` (full build writes; `--check-only` runs `--check`)
- HTML export embeds tile defs + `basemap_default` from the manifest at export time (`leaflet_map_html_export.py` → `leaflet_map_export.js`)
- Remove duplicated basemap constants from `settings_schema_defaults.py`, `defaults.py`, `AllLocationsMapLeaflet.ts`, and inline export JS
- Add tests for manifest integrity, generated-TS freshness, and explicit `basemaps` / `basemap_default` in export HTML config
- Update `docs/development.md` and `docs/AI_CONTEXT.md`
- Document that map HTML export file size is not a performance priority (low-frequency sidebar feature; live Streamlit map perf matters more)

### Out of scope (chore)

- Add `.cursor/commands/start-issue-work.md` — workflow command for starting issue work from `beta-next` (same pattern as other repo Cursor commands)

## Testing

- `python3 -m ruff check explorer/ scripts/generate_basemap_assets.py`
- `python3 -m pytest tests/ -q -m "not e2e and not perf"`
- `python3 scripts/build_all_locations_map_frontend.py --check-only`
- `npm run test:ci -- --testPathPattern=AllLocationsMapLeaflet`

## Notes

- To add or change a basemap: edit `explorer/data/basemaps.yaml`, then run `python3 scripts/generate_basemap_assets.py` (or the full frontend build script)
- Export JS uses plain-text attribution variants where they differ from the live component (same as before)

Fixes #249