### PR TITLE
Add global species coverage against eBird taxonomy

### DIFF
--- a/docs/explorer/regression-checklist.md
+++ b/docs/explorer/regression-checklist.md
@@ -48,13 +48,15 @@ Run before merging refactor branches to `main`.
 
 ## Ranking & Lists
 - Ranking & Lists load (nested **Top Lists** / **Interesting Lists** only)
+- **Interesting Lists:** **Species: Coverage** is the first expander (#262); table shows species in eBird taxonomy, observed species, and observed %; footnote mentions extinct-species handling
 - Species tables (Most individuals, Most checklists, Subspecies occurrence, Seen only once) render correctly
 - Links work (locations and checklists)
 
 ## Bird Families
 - Bird Families tab loads (main tab, not under Ranking & Lists)
 - Family summary grid and overview / species detail behave as before
-- Taxonomy footnote and eBird species links work
+- **Family coverage overview** (no family selected): *Total species* under Taxonomy; *Observed species* and *Observed species (%)* under Coverage (#262)
+- Footnote covers eBird/Clements taxonomy and extinct-species inclusion/exclusion; eBird species links work in family detail
 
 ## Settings
 - **Tables & lists:** Country tab sorting dropdown (Alphabetically / By life birds / By total species) reorders Country accordions only

--- a/explorer/app/streamlit/bird_families_streamlit_html.py
+++ b/explorer/app/streamlit/bird_families_streamlit_html.py
@@ -12,6 +12,7 @@ Prep attaches coverage tables to the shared rankings session bundle via
 from __future__ import annotations
 
 import html
+import logging
 from typing import Any
 
 import pandas as pd
@@ -27,9 +28,14 @@ from explorer.core.species_logic import countable_species_vectorized
 from explorer.core.stats import safe_count
 
 from explorer.app.streamlit.app_constants import RANKING_LISTS_FAMILIES_BUNDLE_KEY
-from explorer.app.streamlit.defaults import RANKINGS_TABLE_LAYOUT_MAX_WIDTH_PX
+from explorer.app.streamlit.defaults import (
+    RANKINGS_TABLE_LAYOUT_MAX_WIDTH_PX,
+    TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE,
+)
 from explorer.app.streamlit.perf_instrumentation import perf_fragment
 from explorer.app.streamlit.streamlit_theme import inject_streamlit_checklist_css
+
+logger = logging.getLogger(__name__)
 
 _STREAMLIT_TABLE_SCOPE = "streamlit-checklist-html-ab"
 _RANKINGS_SCOPE_EXTRA = "streamlit-rankings-html"
@@ -46,8 +52,26 @@ _EBIRD_TAXONOMY_URL = "https://science.ebird.org/en/use-ebird-data/the-ebird-tax
 _FAMILY_COVERAGE_SUMMARY_DATAFRAME_HEIGHT_PX = 280
 
 
+def compute_world_species_coverage(detail: pd.DataFrame) -> tuple[int, int, float]:
+    """Return (observed_species, living_taxonomy_species, observed_percent) from merged coverage detail."""
+    if detail.empty:
+        return 0, 0, 0.0
+    total = int(detail["base_species"].nunique())
+    observed = int(detail.loc[detail["seen"], "base_species"].nunique())
+    pct = (observed / total * 100.0) if total else 0.0
+    return observed, total, pct
+
+
+def _filter_taxonomy_for_coverage(tax: pd.DataFrame) -> pd.DataFrame:
+    """Apply extinct-species filter per :data:`TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE`."""
+    if TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE or "is_extinct" not in tax.columns:
+        return tax
+    return tax[~tax["is_extinct"].fillna(False)].copy()
+
+
 def _family_coverage_summary_metrics_sections(
     summary: pd.DataFrame,
+    world_coverage: tuple[int, int, float] | None = None,
 ) -> list[tuple[str, list[tuple[str, str]]]]:
     """(section heading, [(metric label, formatted value), ...]) for overview HTML and tests."""
     if summary.empty:
@@ -68,8 +92,23 @@ def _family_coverage_summary_metrics_sections(
     n_ge_50 = int((pct_seen >= 50.0).sum())
     n_single_species_family = int((total_sp == 1).sum())
     n_zero_seen = int((seen == 0).sum())
-    return [
+    sections: list[tuple[str, list[tuple[str, str]]]] = [
         ("Taxonomy", [("Total families", f"{n_total:,}")]),
+    ]
+    if world_coverage is not None:
+        obs_sp, total_sp_world, pct_world = world_coverage
+        sections.append(
+            (
+                "World species coverage",
+                [
+                    ("Observed species", f"{obs_sp:,}"),
+                    ("Living species in eBird/Clements taxonomy", f"{total_sp_world:,}"),
+                    ("Observed species (%)", f"{pct_world:.1f}%"),
+                ],
+            )
+        )
+    sections.extend(
+        [
         (
             "Coverage",
             [
@@ -101,21 +140,29 @@ def _family_coverage_summary_metrics_sections(
                 ("Families with no species recorded", f"{n_zero_seen:,}"),
             ],
         ),
-    ]
+        ]
+    )
+    return sections
 
 
-def family_coverage_summary_metrics_df(summary: pd.DataFrame) -> pd.DataFrame:
+def family_coverage_summary_metrics_df(
+    summary: pd.DataFrame,
+    world_coverage: tuple[int, int, float] | None = None,
+) -> pd.DataFrame:
     """Flattened Section / Metric / Value (used by unit tests; mirrors overview rows)."""
     rows: list[dict[str, str]] = []
-    for section, pairs in _family_coverage_summary_metrics_sections(summary):
+    for section, pairs in _family_coverage_summary_metrics_sections(summary, world_coverage):
         for metric, value in pairs:
             rows.append({"Section": section, "Metric": metric, "Value": value})
     return pd.DataFrame(rows)
 
 
-def family_coverage_summary_metrics_html(summary: pd.DataFrame) -> str:
+def family_coverage_summary_metrics_html(
+    summary: pd.DataFrame,
+    world_coverage: tuple[int, int, float] | None = None,
+) -> str:
     """HTML overview table with group heading rows (same ``stats-tbl`` / ``rankings-tbl`` pattern as species detail)."""
-    sections = _family_coverage_summary_metrics_sections(summary)
+    sections = _family_coverage_summary_metrics_sections(summary, world_coverage)
     if not sections:
         return ""
     body_parts: list[str] = []
@@ -138,15 +185,19 @@ def family_coverage_summary_metrics_html(summary: pd.DataFrame) -> str:
     )
 
 
-def _family_coverage_taxonomy_note_html() -> str:
+def _family_coverage_taxonomy_note_html(include_world_coverage_note: bool = False) -> str:
     """Footnote below the overview table; same caption style as Yearly Summary protocol note (refs #85)."""
-    inner = (
-        f'<p style="{_YEARLY_STREAMLIT_CAPTION_STYLE}">'
+    parts = [
         "<strong>Taxonomy:</strong> "
         f'<a href="{html.escape(_EBIRD_TAXONOMY_URL)}" target="_blank" rel="noopener">eBird</a> '
         "— species and family groups follow the eBird taxonomy."
-        "</p>"
-    )
+    ]
+    if include_world_coverage_note:
+        parts.append(
+            "Coverage uses living species from the current eBird/Clements taxonomy. "
+            "Extinct species are excluded by default."
+        )
+    inner = "".join(f'<p style="{_YEARLY_STREAMLIT_CAPTION_STYLE}">{p}</p>' for p in parts)
     return f'<div class="{_STREAMLIT_TABLE_SCOPE} {_RANKINGS_SCOPE_EXTRA}">{inner}</div>'
 
 
@@ -179,6 +230,10 @@ def build_group_coverage_tables(df_full: pd.DataFrame, taxonomy_locale: str) -> 
     tax = _load_taxonomy_species_rows(taxonomy_locale)
     groups = _load_taxonomy_groups(taxonomy_locale)
     if tax.empty or not groups:
+        return pd.DataFrame(), pd.DataFrame()
+
+    tax = _filter_taxonomy_for_coverage(tax)
+    if tax.empty:
         return pd.DataFrame(), pd.DataFrame()
 
     tax = tax.copy()
@@ -233,6 +288,13 @@ def build_group_coverage_tables(df_full: pd.DataFrame, taxonomy_locale: str) -> 
         obs["individuals"] = obs["individuals"].fillna(0).astype(int)
         obs["first_sid"] = obs["first_sid"].fillna("").astype(str)
         obs["last_sid"] = obs["last_sid"].fillna("").astype(str)
+    tax_bases = set(tax["base_species"].astype(str))
+    unmatched = sorted(set(obs["base_species"].astype(str)) - tax_bases)
+    if unmatched:
+        logger.debug(
+            "Observed base species not in taxonomy (excluded from coverage): %s",
+            unmatched,
+        )
     merged = tax.merge(obs, how="left", on="base_species")
     merged["seen"] = merged["checklists"].notna()
     merged["checklists"] = merged["checklists"].fillna(0).astype(int)
@@ -384,11 +446,15 @@ def render_families_streamlit_tab_from_bundle(bundle: dict[str, Any]) -> None:
 
     if not selected_group:
         st.markdown("**Family coverage overview**")
-        _overview_html = family_coverage_summary_metrics_html(summary)
+        world_cov = compute_world_species_coverage(detail) if not detail.empty else None
+        _overview_html = family_coverage_summary_metrics_html(summary, world_cov)
         if _overview_html:
             st.markdown(_overview_html, unsafe_allow_html=True)
         st.markdown('<div style="height:1rem;" aria-hidden="true"></div>', unsafe_allow_html=True)
-        st.markdown(_family_coverage_taxonomy_note_html(), unsafe_allow_html=True)
+        st.markdown(
+            _family_coverage_taxonomy_note_html(include_world_coverage_note=world_cov is not None),
+            unsafe_allow_html=True,
+        )
         return
 
     selected = detail[detail["group_name"] == selected_group].copy()

--- a/explorer/app/streamlit/bird_families_streamlit_html.py
+++ b/explorer/app/streamlit/bird_families_streamlit_html.py
@@ -374,7 +374,7 @@ def attach_group_coverage_to_bundle(
     if world_metrics is not None:
         obs, total, pct = world_metrics
         bundle[WORLD_SPECIES_COVERAGE_SECTION_KEY] = (
-            "World species coverage",
+            "Species: Coverage",
             world_species_coverage_list_html(obs, total, pct),
         )
     else:

--- a/explorer/app/streamlit/bird_families_streamlit_html.py
+++ b/explorer/app/streamlit/bird_families_streamlit_html.py
@@ -71,16 +71,18 @@ def _filter_taxonomy_for_coverage(tax: pd.DataFrame) -> pd.DataFrame:
     return tax[~tax["is_extinct"].fillna(False)].copy()
 
 
-def world_species_coverage_extinct_footnote_text() -> str:
-    """Caption for world species coverage tables (refs #262)."""
+def _extinct_species_coverage_clause() -> str:
+    """Lowercase clause for footnotes; no trailing period (refs #262)."""
     if TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE:
-        return (
-            "Extinct species are included in the eBird/Clements taxonomy total and "
-            "coverage percentage."
-        )
+        return "extinct species are included in coverage totals"
+    return "extinct species are excluded from coverage totals"
+
+
+def taxonomy_coverage_footnote_text() -> str:
+    """Plain-text footnote for family/world coverage tables (refs #262)."""
     return (
-        "Extinct species are excluded from the eBird/Clements taxonomy total and "
-        "coverage percentage."
+        "Species and family groups follow the eBird/Clements taxonomy; "
+        f"{_extinct_species_coverage_clause()}."
     )
 
 
@@ -105,7 +107,7 @@ def world_species_coverage_list_html(observed: int, total: int, pct: float) -> s
     )
     footnote = (
         f'<p style="{_YEARLY_STREAMLIT_CAPTION_STYLE}">'
-        f"{html.escape(world_species_coverage_extinct_footnote_text())}"
+        f"{html.escape(taxonomy_coverage_footnote_text())}"
         "</p>"
     )
     return tbl + footnote
@@ -218,9 +220,10 @@ def _family_coverage_taxonomy_note_html() -> str:
     """Footnote below the overview table; same caption style as Yearly Summary protocol note (refs #85)."""
     inner = (
         f'<p style="{_YEARLY_STREAMLIT_CAPTION_STYLE}">'
-        "<strong>Taxonomy:</strong> "
-        f'<a href="{html.escape(_EBIRD_TAXONOMY_URL)}" target="_blank" rel="noopener">eBird</a> '
-        "— species and family groups follow the eBird taxonomy."
+        "Species and family groups follow the "
+        f'<a href="{html.escape(_EBIRD_TAXONOMY_URL)}" target="_blank" rel="noopener">eBird</a>'
+        "/Clements taxonomy; "
+        f"{html.escape(_extinct_species_coverage_clause())}."
         "</p>"
     )
     return f'<div class="{_STREAMLIT_TABLE_SCOPE} {_RANKINGS_SCOPE_EXTRA}">{inner}</div>'

--- a/explorer/app/streamlit/bird_families_streamlit_html.py
+++ b/explorer/app/streamlit/bird_families_streamlit_html.py
@@ -43,6 +43,8 @@ _RANKINGS_SCOPE_EXTRA = "streamlit-rankings-html"
 GROUP_COVERAGE_SUMMARY_KEY = "group_coverage_summary"
 GROUP_COVERAGE_DETAIL_KEY = "group_coverage_detail"
 GROUP_COVERAGE_ERROR_KEY = "group_coverage_error"
+WORLD_SPECIES_COVERAGE_METRICS_KEY = "world_species_coverage_metrics"
+WORLD_SPECIES_COVERAGE_SECTION_KEY = "world_species_coverage_section"
 _STREAMLIT_GROUP_COVERAGE_SELECTED_KEY = "streamlit_group_coverage_selected_group"
 _STREAMLIT_GROUP_COVERAGE_TABLE_KEY = "streamlit_group_coverage_summary_table"
 _STREAMLIT_GROUP_COVERAGE_FALLBACK_KEY = "streamlit_group_coverage_selected_group_fallback"
@@ -69,6 +71,46 @@ def _filter_taxonomy_for_coverage(tax: pd.DataFrame) -> pd.DataFrame:
     return tax[~tax["is_extinct"].fillna(False)].copy()
 
 
+def world_species_coverage_extinct_footnote_text() -> str:
+    """Caption for world species coverage tables (refs #262)."""
+    if TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE:
+        return (
+            "Extinct species are included in the eBird/Clements taxonomy total and "
+            "coverage percentage."
+        )
+    return (
+        "Extinct species are excluded from the eBird/Clements taxonomy total and "
+        "coverage percentage."
+    )
+
+
+def world_species_coverage_list_html(observed: int, total: int, pct: float) -> str:
+    """Simple metric table + footnote for Rankings **Interesting Lists** expander (refs #262)."""
+    rows = [
+        ("Species in eBird taxonomy", f"{total:,}"),
+        ("Observed species", f"{observed:,}"),
+        ("Observed species (%)", f"{pct:.1f}%"),
+    ]
+    body = "".join(
+        "<tr>"
+        f"<td>{html.escape(label)}</td>"
+        f'<td style="text-align:right">{html.escape(value)}</td>'
+        "</tr>"
+        for label, value in rows
+    )
+    tbl = (
+        "<table class='stats-tbl rankings-tbl'>"
+        "<thead><tr><th>Metric</th><th>Value</th></tr></thead>"
+        f"<tbody>{body}</tbody></table>"
+    )
+    footnote = (
+        f'<p style="{_YEARLY_STREAMLIT_CAPTION_STYLE}">'
+        f"{html.escape(world_species_coverage_extinct_footnote_text())}"
+        "</p>"
+    )
+    return tbl + footnote
+
+
 def _family_coverage_summary_metrics_sections(
     summary: pd.DataFrame,
     world_coverage: tuple[int, int, float] | None = None,
@@ -92,32 +134,21 @@ def _family_coverage_summary_metrics_sections(
     n_ge_50 = int((pct_seen >= 50.0).sum())
     n_single_species_family = int((total_sp == 1).sum())
     n_zero_seen = int((seen == 0).sum())
-    sections: list[tuple[str, list[tuple[str, str]]]] = [
-        ("Taxonomy", [("Total families", f"{n_total:,}")]),
+    taxonomy_pairs: list[tuple[str, str]] = [("Total families", f"{n_total:,}")]
+    coverage_pairs: list[tuple[str, str]] = [
+        ("Observed families (at least one species)", f"{n_with_any:,}"),
+        ("Observed families (%)", f"{pct_any:.1f}%"),
+        ("Fully recorded families (all species observed)", f"{n_complete:,}"),
+        ("Fully recorded families (%)", f"{pct_complete:.1f}%"),
     ]
     if world_coverage is not None:
         obs_sp, total_sp_world, pct_world = world_coverage
-        sections.append(
-            (
-                "World species coverage",
-                [
-                    ("Observed species", f"{obs_sp:,}"),
-                    ("Living species in eBird/Clements taxonomy", f"{total_sp_world:,}"),
-                    ("Observed species (%)", f"{pct_world:.1f}%"),
-                ],
-            )
-        )
-    sections.extend(
-        [
-        (
-            "Coverage",
-            [
-                ("Observed families (at least one species)", f"{n_with_any:,}"),
-                ("Observed families (%)", f"{pct_any:.1f}%"),
-                ("Fully recorded families (all species observed)", f"{n_complete:,}"),
-                ("Fully recorded families (%)", f"{pct_complete:.1f}%"),
-            ],
-        ),
+        taxonomy_pairs.append(("Total species", f"{total_sp_world:,}"))
+        coverage_pairs.insert(1, ("Observed species", f"{obs_sp:,}"))
+        coverage_pairs.insert(3, ("Observed species (%)", f"{pct_world:.1f}%"))
+    return [
+        ("Taxonomy", taxonomy_pairs),
+        ("Coverage", coverage_pairs),
         (
             "Progress",
             [
@@ -140,9 +171,7 @@ def _family_coverage_summary_metrics_sections(
                 ("Families with no species recorded", f"{n_zero_seen:,}"),
             ],
         ),
-        ]
-    )
-    return sections
+    ]
 
 
 def family_coverage_summary_metrics_df(
@@ -185,19 +214,15 @@ def family_coverage_summary_metrics_html(
     )
 
 
-def _family_coverage_taxonomy_note_html(include_world_coverage_note: bool = False) -> str:
+def _family_coverage_taxonomy_note_html() -> str:
     """Footnote below the overview table; same caption style as Yearly Summary protocol note (refs #85)."""
-    parts = [
+    inner = (
+        f'<p style="{_YEARLY_STREAMLIT_CAPTION_STYLE}">'
         "<strong>Taxonomy:</strong> "
         f'<a href="{html.escape(_EBIRD_TAXONOMY_URL)}" target="_blank" rel="noopener">eBird</a> '
         "— species and family groups follow the eBird taxonomy."
-    ]
-    if include_world_coverage_note:
-        parts.append(
-            "Coverage uses living species from the current eBird/Clements taxonomy. "
-            "Extinct species are excluded by default."
-        )
-    inner = "".join(f'<p style="{_YEARLY_STREAMLIT_CAPTION_STYLE}">{p}</p>' for p in parts)
+        "</p>"
+    )
     return f'<div class="{_STREAMLIT_TABLE_SCOPE} {_RANKINGS_SCOPE_EXTRA}">{inner}</div>'
 
 
@@ -342,6 +367,18 @@ def attach_group_coverage_to_bundle(
     bundle[GROUP_COVERAGE_SUMMARY_KEY] = summary_df
     bundle[GROUP_COVERAGE_DETAIL_KEY] = detail_df
     bundle[GROUP_COVERAGE_ERROR_KEY] = coverage_error
+    world_metrics: tuple[int, int, float] | None = None
+    if not detail_df.empty:
+        world_metrics = compute_world_species_coverage(detail_df)
+    bundle[WORLD_SPECIES_COVERAGE_METRICS_KEY] = world_metrics
+    if world_metrics is not None:
+        obs, total, pct = world_metrics
+        bundle[WORLD_SPECIES_COVERAGE_SECTION_KEY] = (
+            "World species coverage",
+            world_species_coverage_list_html(obs, total, pct),
+        )
+    else:
+        bundle[WORLD_SPECIES_COVERAGE_SECTION_KEY] = None
     return bundle
 
 
@@ -446,15 +483,12 @@ def render_families_streamlit_tab_from_bundle(bundle: dict[str, Any]) -> None:
 
     if not selected_group:
         st.markdown("**Family coverage overview**")
-        world_cov = compute_world_species_coverage(detail) if not detail.empty else None
+        world_cov = bundle.get(WORLD_SPECIES_COVERAGE_METRICS_KEY)
         _overview_html = family_coverage_summary_metrics_html(summary, world_cov)
         if _overview_html:
             st.markdown(_overview_html, unsafe_allow_html=True)
         st.markdown('<div style="height:1rem;" aria-hidden="true"></div>', unsafe_allow_html=True)
-        st.markdown(
-            _family_coverage_taxonomy_note_html(include_world_coverage_note=world_cov is not None),
-            unsafe_allow_html=True,
-        )
+        st.markdown(_family_coverage_taxonomy_note_html(), unsafe_allow_html=True)
         return
 
     selected = detail[detail["group_name"] == selected_group].copy()

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -403,6 +403,10 @@ SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v18"
 RANKINGS_TABLE_LAYOUT_MAX_WIDTH_PX = 1400
 RANKINGS_BUNDLE_SCROLL_HINT_DEFAULT = "shading"
 
+# Bird Families / taxonomy coverage: when False, extinct species are excluded from denominators
+# and family/world coverage tables (refs #262).
+TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE = False
+
 
 def debug_defaults_enabled() -> list[str]:
     """Return names of debug toggles in this module that are currently ``True``.

--- a/explorer/app/streamlit/rankings_streamlit_html.py
+++ b/explorer/app/streamlit/rankings_streamlit_html.py
@@ -96,6 +96,15 @@ def _rankings_expander_sections(sections: list[tuple[str, str]]) -> None:
             )
 
 
+def _rankings_bundle_has_content(bundle: dict[str, Any]) -> bool:
+    """True when the bundle includes Top Lists, Interesting Lists, or Species: Coverage sections."""
+    return bool(
+        bundle.get("rankings_sections_top_n")
+        or bundle.get("rankings_sections_other")
+        or bundle.get(WORLD_SPECIES_COVERAGE_SECTION_KEY)
+    )
+
+
 def render_rankings_streamlit_tab_from_bundle(bundle: dict[str, Any]) -> None:
     """Render Rankings HTML from a precomputed bundle (fragment-safe)."""
     inject_streamlit_checklist_css(_rankings_table_layout_inject_css())
@@ -118,7 +127,7 @@ def run_rankings_streamlit_tab_fragment() -> None:
     """Partial reruns when Rankings expanders/widgets change (same pattern as Country / Yearly)."""
     with perf_fragment("ranking_lists"):
         bundle = st.session_state.get(RANKING_LISTS_FAMILIES_BUNDLE_KEY) or {}
-        if not bundle.get("rankings_sections_top_n") and not bundle.get("rankings_sections_other"):
+        if not _rankings_bundle_has_content(bundle):
             st.info("Load checklist data to use Ranking & Lists.")
             return
         render_rankings_streamlit_tab_from_bundle(bundle)

--- a/explorer/app/streamlit/rankings_streamlit_html.py
+++ b/explorer/app/streamlit/rankings_streamlit_html.py
@@ -12,7 +12,8 @@ Species-group coverage lives on the **Bird Families** main tab
 
 **Top N** and **visible rows** are controlled from **Settings → Tables & lists** (session keys
 ``streamlit_rankings_top_n``, ``streamlit_rankings_visible_rows``; refs `#81`). **Top Lists** tables
-include a narrow leading **Rank** column with soft accent styling (refs `#83`). **Species: Not seen in
+include a narrow leading **Rank** column with soft accent styling (refs `#83`). **World species coverage**
+is the first expander under **Interesting Lists** (refs `#262`). **Species: Not seen in
 the past year** is the last expander under Interesting Lists; it lists countable species with no
 observation in the trailing twelve months on the **full export** and is not Top-N–capped (refs `#106`).
 A hint points to the **Country** tab for the in-country, working-set–scoped variant (refs `#108`).
@@ -30,7 +31,10 @@ from explorer.core.taxonomy import get_species_and_lifelist_urls, load_taxonomy
 
 from explorer.app.streamlit.app_caches import cached_full_export_checklist_stats_payload
 from explorer.app.streamlit.app_constants import RANKING_LISTS_FAMILIES_BUNDLE_KEY
-from explorer.app.streamlit.bird_families_streamlit_html import attach_group_coverage_to_bundle
+from explorer.app.streamlit.bird_families_streamlit_html import (
+    WORLD_SPECIES_COVERAGE_SECTION_KEY,
+    attach_group_coverage_to_bundle,
+)
 from explorer.app.streamlit.perf_instrumentation import perf_fragment
 from explorer.app.streamlit.defaults import RANKINGS_BUNDLE_SCROLL_HINT_DEFAULT, RANKINGS_TABLE_LAYOUT_MAX_WIDTH_PX
 from explorer.app.streamlit.streamlit_theme import inject_streamlit_checklist_css
@@ -102,7 +106,11 @@ def render_rankings_streamlit_tab_from_bundle(bundle: dict[str, Any]) -> None:
         _rankings_expander_sections(list(bundle.get("rankings_sections_top_n") or []))
 
     with tab_int:
-        _rankings_expander_sections(list(bundle.get("rankings_sections_other") or []))
+        sections = list(bundle.get("rankings_sections_other") or [])
+        world_section = bundle.get(WORLD_SPECIES_COVERAGE_SECTION_KEY)
+        if world_section:
+            sections = [world_section] + sections
+        _rankings_expander_sections(sections)
 
 
 @st.fragment

--- a/explorer/app/streamlit/rankings_streamlit_html.py
+++ b/explorer/app/streamlit/rankings_streamlit_html.py
@@ -12,7 +12,7 @@ Species-group coverage lives on the **Bird Families** main tab
 
 **Top N** and **visible rows** are controlled from **Settings → Tables & lists** (session keys
 ``streamlit_rankings_top_n``, ``streamlit_rankings_visible_rows``; refs `#81`). **Top Lists** tables
-include a narrow leading **Rank** column with soft accent styling (refs `#83`). **World species coverage**
+include a narrow leading **Rank** column with soft accent styling (refs `#83`). **Species: Coverage**
 is the first expander under **Interesting Lists** (refs `#262`). **Species: Not seen in
 the past year** is the last expander under Interesting Lists; it lists countable species with no
 observation in the trailing twelve months on the **full export** and is not Top-N–capped (refs `#106`).

--- a/explorer/core/taxonomy_bundle.py
+++ b/explorer/core/taxonomy_bundle.py
@@ -50,6 +50,16 @@ def _fetch_taxonomy_csv(url: str) -> str | None:
         return None
 
 
+def _taxonomy_row_is_extinct(extinct_raw: str, extinct_year_raw: str) -> bool:
+    """True when eBird marks a species extinct via ``EXTINCT`` or a non-empty ``EXTINCT_YEAR``.
+
+    The live taxonomy CSV usually sets ``EXTINCT=1``; some rows may only carry ``EXTINCT_YEAR``.
+    """
+    if extinct_raw in {"1", "true", "True", "yes", "Yes"}:
+        return True
+    return bool(extinct_year_raw)
+
+
 def _parse_taxonomy_csv(raw: str) -> tuple[pd.DataFrame, dict[str, str]]:
     """Parse one taxonomy CSV into species rows and common_name → species_code (species category only)."""
     reader = csv.DictReader(io.StringIO(raw))
@@ -101,7 +111,7 @@ def _parse_taxonomy_csv(raw: str) -> tuple[pd.DataFrame, dict[str, str]]:
             continue
         extinct_raw = str(row.get(extinct_key) or "").strip() if extinct_key else ""
         extinct_year_raw = str(row.get(extinct_year_key) or "").strip() if extinct_year_key else ""
-        is_extinct = extinct_raw in {"1", "true", "True", "yes", "Yes"}
+        is_extinct = _taxonomy_row_is_extinct(extinct_raw, extinct_year_raw)
         rows.append(
             {
                 "scientific_name": sci,

--- a/explorer/core/taxonomy_bundle.py
+++ b/explorer/core/taxonomy_bundle.py
@@ -65,6 +65,8 @@ def _parse_taxonomy_csv(raw: str) -> tuple[pd.DataFrame, dict[str, str]]:
         field_lower.get("scientific name"),
     )
     tax_order_key = field_lower.get("taxon_order") or field_lower.get("taxon order")
+    extinct_key = field_lower.get("extinct")
+    extinct_year_key = field_lower.get("extinct_year") or field_lower.get("extinct year")
 
     rows: list[dict[str, Any]] = []
     lookup: dict[str, str] = {}
@@ -97,6 +99,9 @@ def _parse_taxonomy_csv(raw: str) -> tuple[pd.DataFrame, dict[str, str]]:
             taxon_order = float(str(tax_raw).strip())
         except Exception:
             continue
+        extinct_raw = str(row.get(extinct_key) or "").strip() if extinct_key else ""
+        extinct_year_raw = str(row.get(extinct_year_key) or "").strip() if extinct_year_key else ""
+        is_extinct = extinct_raw in {"1", "true", "True", "yes", "Yes"}
         rows.append(
             {
                 "scientific_name": sci,
@@ -104,6 +109,9 @@ def _parse_taxonomy_csv(raw: str) -> tuple[pd.DataFrame, dict[str, str]]:
                 "species_code": code,
                 "taxon_order": taxon_order,
                 "base_species": " ".join(sci.lower().split()[:2]).strip(),
+                "extinct": extinct_raw,
+                "extinct_year": extinct_year_raw,
+                "is_extinct": is_extinct,
             }
         )
     return pd.DataFrame(rows), lookup

--- a/tests/explorer/test_rankings_family_summary.py
+++ b/tests/explorer/test_rankings_family_summary.py
@@ -211,5 +211,5 @@ def test_attach_group_coverage_stores_world_metrics_once(monkeypatch):
 
     bundle = bf.attach_group_coverage_to_bundle({}, df_full, "en_AU")
     assert bundle[bf.WORLD_SPECIES_COVERAGE_METRICS_KEY] == (1, 1, 100.0)
-    assert bundle[bf.WORLD_SPECIES_COVERAGE_SECTION_KEY][0] == "World species coverage"
+    assert bundle[bf.WORLD_SPECIES_COVERAGE_SECTION_KEY][0] == "Species: Coverage"
     assert calls == ["compute"]

--- a/tests/explorer/test_rankings_family_summary.py
+++ b/tests/explorer/test_rankings_family_summary.py
@@ -106,7 +106,8 @@ def test_world_species_coverage_list_html_footnote_excludes_extinct_by_default(m
     html_out = bf.world_species_coverage_list_html(10, 100, 10.0)
     assert "Species in eBird taxonomy" in html_out
     assert "Observed species (%)" in html_out
-    assert "excluded" in html_out.lower()
+    assert "eBird/Clements taxonomy" in html_out
+    assert "excluded from coverage totals" in html_out.lower()
 
 
 def test_world_species_coverage_list_html_footnote_includes_extinct_when_enabled(monkeypatch):
@@ -114,7 +115,21 @@ def test_world_species_coverage_list_html_footnote_includes_extinct_when_enabled
 
     monkeypatch.setattr(bf, "TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE", True)
     html_out = bf.world_species_coverage_list_html(10, 100, 10.0)
-    assert "included" in html_out.lower()
+    assert "included in coverage totals" in html_out.lower()
+
+
+def test_family_coverage_taxonomy_note_html_combined_footnote(monkeypatch):
+    from explorer.app.streamlit import bird_families_streamlit_html as bf
+
+    monkeypatch.setattr(bf, "TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE", False)
+    html_out = bf._family_coverage_taxonomy_note_html()
+    assert "eBird</a>/Clements taxonomy" in html_out
+    assert "excluded from coverage totals" in html_out.lower()
+    assert "<strong>Taxonomy:</strong>" not in html_out
+
+    monkeypatch.setattr(bf, "TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE", True)
+    html_out = bf._family_coverage_taxonomy_note_html()
+    assert "included in coverage totals" in html_out.lower()
 
 
 def test_compute_world_species_coverage_counts_seen_base_species():
@@ -213,3 +228,17 @@ def test_attach_group_coverage_stores_world_metrics_once(monkeypatch):
     assert bundle[bf.WORLD_SPECIES_COVERAGE_METRICS_KEY] == (1, 1, 100.0)
     assert bundle[bf.WORLD_SPECIES_COVERAGE_SECTION_KEY][0] == "Species: Coverage"
     assert calls == ["compute"]
+
+
+def test_rankings_bundle_has_content_includes_world_species_section():
+    from explorer.app.streamlit.rankings_streamlit_html import (
+        WORLD_SPECIES_COVERAGE_SECTION_KEY,
+        _rankings_bundle_has_content,
+    )
+
+    assert _rankings_bundle_has_content({}) is False
+    assert _rankings_bundle_has_content({"rankings_sections_top_n": [("t", "h")]}) is True
+    assert _rankings_bundle_has_content({"rankings_sections_other": [("t", "h")]}) is True
+    assert _rankings_bundle_has_content(
+        {WORLD_SPECIES_COVERAGE_SECTION_KEY: ("Species: Coverage", "<p>x</p>")}
+    ) is True

--- a/tests/explorer/test_rankings_family_summary.py
+++ b/tests/explorer/test_rankings_family_summary.py
@@ -70,7 +70,7 @@ def test_family_coverage_summary_metrics_html_group_rows():
     assert "<th colspan=\"2\">" in html_out
 
 
-def test_family_coverage_summary_metrics_includes_world_species_section():
+def test_family_coverage_summary_metrics_integrates_world_species_rows():
     from explorer.app.streamlit.bird_families_streamlit_html import family_coverage_summary_metrics_df
 
     summary = pd.DataFrame(
@@ -82,12 +82,39 @@ def test_family_coverage_summary_metrics_includes_world_species_section():
         }
     )
     out = family_coverage_summary_metrics_df(summary, world_coverage=(752, 11062, 6.8))
-    world_rows = out[out["Section"] == "World species coverage"]
-    assert len(world_rows) == 3
-    assert world_rows.iloc[0]["Metric"] == "Observed species"
-    assert world_rows.iloc[0]["Value"] == "752"
-    assert world_rows.iloc[1]["Value"] == "11,062"
-    assert world_rows.iloc[2]["Value"] == "6.8%"
+    assert "World species coverage" not in set(out["Section"])
+    taxonomy = out[out["Section"] == "Taxonomy"]
+    assert list(taxonomy["Metric"]) == ["Total families", "Total species"]
+    assert taxonomy.iloc[1]["Value"] == "11,062"
+    coverage = out[out["Section"] == "Coverage"]
+    assert list(coverage["Metric"]) == [
+        "Observed families (at least one species)",
+        "Observed species",
+        "Observed families (%)",
+        "Observed species (%)",
+        "Fully recorded families (all species observed)",
+        "Fully recorded families (%)",
+    ]
+    assert coverage.iloc[1]["Value"] == "752"
+    assert coverage.iloc[3]["Value"] == "6.8%"
+
+
+def test_world_species_coverage_list_html_footnote_excludes_extinct_by_default(monkeypatch):
+    from explorer.app.streamlit import bird_families_streamlit_html as bf
+
+    monkeypatch.setattr(bf, "TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE", False)
+    html_out = bf.world_species_coverage_list_html(10, 100, 10.0)
+    assert "Species in eBird taxonomy" in html_out
+    assert "Observed species (%)" in html_out
+    assert "excluded" in html_out.lower()
+
+
+def test_world_species_coverage_list_html_footnote_includes_extinct_when_enabled(monkeypatch):
+    from explorer.app.streamlit import bird_families_streamlit_html as bf
+
+    monkeypatch.setattr(bf, "TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE", True)
+    html_out = bf.world_species_coverage_list_html(10, 100, 10.0)
+    assert "included" in html_out.lower()
 
 
 def test_compute_world_species_coverage_counts_seen_base_species():
@@ -144,3 +171,45 @@ def test_build_group_coverage_tables_excludes_extinct_species_by_default(monkeyp
     assert summary.iloc[0]["total_species"] == 1
     assert len(detail) == 1
     assert bf.compute_world_species_coverage(detail) == (1, 1, 100.0)
+
+
+def test_attach_group_coverage_stores_world_metrics_once(monkeypatch):
+    from explorer.app.streamlit import bird_families_streamlit_html as bf
+
+    tax = pd.DataFrame(
+        [
+            {
+                "scientific_name": "Aves vivus",
+                "common_name": "Living Bird",
+                "species_code": "livbrd",
+                "taxon_order": 10.0,
+                "base_species": "aves vivus",
+                "is_extinct": False,
+            },
+        ]
+    )
+    groups = [{"group_name": "All Birds", "group_order": 1, "bounds": [(0.0, 100.0)]}]
+    df_full = pd.DataFrame(
+        {
+            "Scientific Name": ["Aves vivus"],
+            "Common Name": ["Living Bird"],
+            "Count": [1],
+            "Submission ID": ["s1"],
+            "Date": ["2020-01-01"],
+        }
+    )
+    calls: list[str] = []
+    original = bf.compute_world_species_coverage
+
+    def _counting_compute(detail):
+        calls.append("compute")
+        return original(detail)
+
+    monkeypatch.setattr(bf, "_load_taxonomy_species_rows", lambda _loc: tax)
+    monkeypatch.setattr(bf, "_load_taxonomy_groups", lambda _loc: groups)
+    monkeypatch.setattr(bf, "compute_world_species_coverage", _counting_compute)
+
+    bundle = bf.attach_group_coverage_to_bundle({}, df_full, "en_AU")
+    assert bundle[bf.WORLD_SPECIES_COVERAGE_METRICS_KEY] == (1, 1, 100.0)
+    assert bundle[bf.WORLD_SPECIES_COVERAGE_SECTION_KEY][0] == "World species coverage"
+    assert calls == ["compute"]

--- a/tests/explorer/test_rankings_family_summary.py
+++ b/tests/explorer/test_rankings_family_summary.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 
 def test_family_coverage_summary_metrics_df_counts():
@@ -67,3 +68,79 @@ def test_family_coverage_summary_metrics_html_group_rows():
     assert "Taxonomy" in html_out
     assert "Coverage" in html_out
     assert "<th colspan=\"2\">" in html_out
+
+
+def test_family_coverage_summary_metrics_includes_world_species_section():
+    from explorer.app.streamlit.bird_families_streamlit_html import family_coverage_summary_metrics_df
+
+    summary = pd.DataFrame(
+        {
+            "group_name": ["A"],
+            "seen_species": [1],
+            "total_species": [1],
+            "percent_seen": [100.0],
+        }
+    )
+    out = family_coverage_summary_metrics_df(summary, world_coverage=(752, 11062, 6.8))
+    world_rows = out[out["Section"] == "World species coverage"]
+    assert len(world_rows) == 3
+    assert world_rows.iloc[0]["Metric"] == "Observed species"
+    assert world_rows.iloc[0]["Value"] == "752"
+    assert world_rows.iloc[1]["Value"] == "11,062"
+    assert world_rows.iloc[2]["Value"] == "6.8%"
+
+
+def test_compute_world_species_coverage_counts_seen_base_species():
+    from explorer.app.streamlit.bird_families_streamlit_html import compute_world_species_coverage
+
+    detail = pd.DataFrame(
+        {
+            "base_species": ["anas gracilis", "corvus corax", "falco peregrinus"],
+            "seen": [True, True, False],
+        }
+    )
+    assert compute_world_species_coverage(detail) == (2, 3, pytest.approx(200 / 3))
+
+
+def test_build_group_coverage_tables_excludes_extinct_species_by_default(monkeypatch):
+    from explorer.app.streamlit import bird_families_streamlit_html as bf
+
+    tax = pd.DataFrame(
+        [
+            {
+                "scientific_name": "Aves vivus",
+                "common_name": "Living Bird",
+                "species_code": "livbrd",
+                "taxon_order": 10.0,
+                "base_species": "aves vivus",
+                "is_extinct": False,
+            },
+            {
+                "scientific_name": "Aves extinctus",
+                "common_name": "Extinct Bird",
+                "species_code": "extbrd",
+                "taxon_order": 11.0,
+                "base_species": "aves extinctus",
+                "is_extinct": True,
+            },
+        ]
+    )
+    groups = [{"group_name": "All Birds", "group_order": 1, "bounds": [(0.0, 100.0)]}]
+    df_full = pd.DataFrame(
+        {
+            "Scientific Name": ["Aves vivus", "Aves extinctus subsp."],
+            "Common Name": ["Living Bird", "Extinct Bird"],
+            "Count": [1, 1],
+            "Submission ID": ["s1", "s2"],
+            "Date": ["2020-01-01", "2020-01-02"],
+        }
+    )
+
+    monkeypatch.setattr(bf, "_load_taxonomy_species_rows", lambda _loc: tax)
+    monkeypatch.setattr(bf, "_load_taxonomy_groups", lambda _loc: groups)
+    monkeypatch.setattr(bf, "TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE", False)
+
+    summary, detail = bf.build_group_coverage_tables(df_full, "en_AU")
+    assert summary.iloc[0]["total_species"] == 1
+    assert len(detail) == 1
+    assert bf.compute_world_species_coverage(detail) == (1, 1, 100.0)

--- a/tests/explorer/test_taxonomy_bundle.py
+++ b/tests/explorer/test_taxonomy_bundle.py
@@ -118,3 +118,43 @@ def test_en_au_merges_us_csv_without_extra_species_row_fetch():
     assert m_urlopen.call_count == 3
     assert bundle.common_to_code["Gray Noddy"] == "grynod1"
     assert bundle.common_to_code["Grey Ternlet"] == "grynod1"
+
+
+def test_parse_taxonomy_csv_retains_extinct_fields():
+    csv_data = _make_csv(
+        [
+            {
+                "common_name": "Living Bird",
+                "species_code": "livbrd",
+                "category": "species",
+                "scientific_name": "Aves vivus",
+                "taxon_order": "100",
+                "extinct": "0",
+                "extinct_year": "",
+            },
+            {
+                "common_name": "Extinct Bird",
+                "species_code": "extbrd",
+                "category": "species",
+                "scientific_name": "Aves extinctus",
+                "taxon_order": "101",
+                "extinct": "1",
+                "extinct_year": "1900",
+            },
+        ],
+        fieldnames=(
+            "common_name",
+            "species_code",
+            "category",
+            "scientific_name",
+            "taxon_order",
+            "extinct",
+            "extinct_year",
+        ),
+    )
+    ctxs = _mock_urlopen_responses([csv_data])
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=ctxs):
+        bundle = load_taxonomy_bundle("en_US")
+    rows = bundle.species_rows.sort_values("taxon_order").reset_index(drop=True)
+    assert list(rows["is_extinct"]) == [False, True]
+    assert rows.loc[1, "extinct_year"] == "1900"

--- a/tests/explorer/test_taxonomy_bundle.py
+++ b/tests/explorer/test_taxonomy_bundle.py
@@ -158,3 +158,41 @@ def test_parse_taxonomy_csv_retains_extinct_fields():
     rows = bundle.species_rows.sort_values("taxon_order").reset_index(drop=True)
     assert list(rows["is_extinct"]) == [False, True]
     assert rows.loc[1, "extinct_year"] == "1900"
+
+
+def test_taxonomy_row_is_extinct_from_year_when_flag_unset():
+    from explorer.core.taxonomy_bundle import _taxonomy_row_is_extinct
+
+    assert _taxonomy_row_is_extinct("0", "1900") is True
+    assert _taxonomy_row_is_extinct("", "1938") is True
+    assert _taxonomy_row_is_extinct("0", "") is False
+    assert _taxonomy_row_is_extinct("1", "") is True
+
+
+def test_parse_taxonomy_csv_marks_extinct_from_extinct_year_only():
+    csv_data = _make_csv(
+        [
+            {
+                "common_name": "Year Only Extinct",
+                "species_code": "yrext",
+                "category": "species",
+                "scientific_name": "Aves antiquus",
+                "taxon_order": "102",
+                "extinct": "0",
+                "extinct_year": "1938",
+            },
+        ],
+        fieldnames=(
+            "common_name",
+            "species_code",
+            "category",
+            "scientific_name",
+            "taxon_order",
+            "extinct",
+            "extinct_year",
+        ),
+    )
+    ctxs = _mock_urlopen_responses([csv_data])
+    with patch("explorer.core.taxonomy_bundle.urlopen", side_effect=ctxs):
+        bundle = load_taxonomy_bundle("en_US")
+    assert bool(bundle.species_rows.iloc[0]["is_extinct"]) is True


### PR DESCRIPTION
## Summary

Adds world species coverage metrics so birders can see how their personal species list compares to the current eBird/Clements checklist. Metrics are computed once during rankings/families bundle prep and shared by both UI surfaces.

## Changes

- **Taxonomy bundle:** parse and retain `EXTINCT`, `EXTINCT_YEAR`, and `is_extinct` from the eBird taxonomy CSV
- **Configuration:** `TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE = False` in `defaults.py` (extinct species excluded from coverage by default)
- **Bird Families overview:** fold world species rows into existing sections — *Total species* under Taxonomy; *Observed species* and *Observed species (%)* under Coverage
- **Ranking & Lists → Interesting Lists:** new **Species: Coverage** expander (first on the tab) with taxonomy total, observed count, percentage, and extinct-species footnote
- **Performance:** store `world_species_coverage_metrics` on the shared bundle; Bird Families and Interesting Lists reuse the same precomputed values

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` — 631 passed, 7 skipped
- Manual: load Bird Families overview (no family selected) and Interesting Lists → **Species: Coverage**

## Notes

- User observations roll up to countable base species; unmatched taxonomy rows are excluded from the numerator (debug-logged only)
- Footnote wording reflects `TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE` (excluded by default; switches to “included” if the flag is enabled)

Refs #262

Made with [Cursor](https://cursor.com)