### PR TITLE
Unify MAP_POPUP_MAX_WIDTH_PX via codegen from defaults.py

### DIFF
--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -65,7 +65,7 @@ MAP_PIN_FILL_OPACITY_ALL_LOCATIONS = 1.0
 MAP_PIN_FILL_OPACITY_EMPHASIS = 0.9
 MAP_LEGEND_PIN_DOT_PX = 8
 MAP_LEGEND_PIN_BORDER_PX = 2
-MAP_POPUP_MAX_WIDTH_PX = 420  # Leaflet popup maxWidth; card-like popups (refs #145).
+MAP_POPUP_MAX_WIDTH_PX = 420  # Leaflet popup maxWidth; card-like popups. Codegen: scripts/generate_basemap_assets.py.
 # Family-locations map initial ``fit_bounds``; not tied to marker colour presets.
 MAP_FAMILY_MAP_FIT_BOUNDS_PADDING_PX = 48
 MAP_FAMILY_MAP_FIT_BOUNDS_MAX_ZOOM = 6

--- a/explorer/components/all_locations_map/frontend/src/AllLocationsMapPopup.css
+++ b/explorer/components/all_locations_map/frontend/src/AllLocationsMapPopup.css
@@ -1,10 +1,11 @@
 /**
  * Mirrors ``map_popup_theme_stylesheet`` in explorer/presentation/map_renderer.py
  * so experimental Leaflet popups match production All locations.
- * Keep MAP_POPUP_MAX_WIDTH_PX in sync with explorer/app/streamlit/defaults.py (420).
+ * Popup max width: ``map_popup_constants.generated.css`` (from ``defaults.py``).
  */
+@import "./map_popup_constants.generated.css";
+
 :root {
-  --pebird-map-popup-max-width: 420px;
   --pebird-font-stack: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --pebird-ui-text: #1a2e22;
   --pebird-ui-primary-green: #1f6f54;

--- a/explorer/components/all_locations_map/frontend/src/AllLocationsMapPopupSizing.ts
+++ b/explorer/components/all_locations_map/frontend/src/AllLocationsMapPopupSizing.ts
@@ -2,8 +2,7 @@
 
 import L from "leaflet";
 
-/** Matches ``MAP_POPUP_MAX_WIDTH_PX`` in ``explorer/app/streamlit/defaults.py`` (420). */
-const POPUP_MAX_WIDTH_PX = 420;
+import { POPUP_MAX_WIDTH_PX } from "./map_popup_constants.generated";
 
 /** Leaflet runs ``autoPan`` inside ``popup.update()`` — stacked updates caused large vertical pans. Disabled globally; ``maybePanPopupIntoView`` pans once when needed after layout settles. */
 export const POPUP_BIND_OPTIONS: L.PopupOptions = {

--- a/explorer/components/all_locations_map/frontend/src/map_popup_constants.generated.css
+++ b/explorer/components/all_locations_map/frontend/src/map_popup_constants.generated.css
@@ -1,0 +1,6 @@
+/** AUTO-GENERATED from explorer/app/streamlit/defaults.py — do not edit. */
+/** Regenerate: python3 scripts/generate_basemap_assets.py */
+
+:root {
+  --pebird-map-popup-max-width: 420px;
+}

--- a/explorer/components/all_locations_map/frontend/src/map_popup_constants.generated.ts
+++ b/explorer/components/all_locations_map/frontend/src/map_popup_constants.generated.ts
@@ -1,0 +1,4 @@
+/** AUTO-GENERATED from explorer/app/streamlit/defaults.py — do not edit. */
+/** Regenerate: python3 scripts/generate_basemap_assets.py */
+
+export const POPUP_MAX_WIDTH_PX = 420;

--- a/explorer/presentation/leaflet_map_html_export.py
+++ b/explorer/presentation/leaflet_map_html_export.py
@@ -42,6 +42,13 @@ def _read_static(name: str) -> str:
     return (_STATIC / name).read_text(encoding="utf-8")
 
 
+def _read_export_viewer_js() -> str:
+    """Concatenate generated popup constants with the hand-written export viewer."""
+    constants = _read_static("leaflet_map_export_constants.generated.js")
+    viewer = _read_static("leaflet_map_export.js")
+    return f"{constants}\n{viewer}"
+
+
 def _extract_style_inner(css_bundle: str) -> str:
     parts = re.findall(r"<style[^>]*>(.*?)</style>", css_bundle, flags=re.DOTALL | re.IGNORECASE)
     return "\n".join(p.strip() for p in parts if p.strip())
@@ -84,7 +91,7 @@ def leaflet_map_to_html_bytes(
     if _COMPONENT_CSS.is_file():
         popup_css = _COMPONENT_CSS.read_text(encoding="utf-8")
     page_css = _read_static("leaflet_map_export_page.css")
-    viewer_js = _read_static("leaflet_map_export.js")
+    viewer_js = _read_export_viewer_js()
     esc_title = html_module.escape(title, quote=False)
     banner = (banner_html or "").strip()
     legend = (legend_html or "").strip()

--- a/explorer/presentation/static/leaflet_map_export.js
+++ b/explorer/presentation/static/leaflet_map_export.js
@@ -2,8 +2,7 @@
 (function () {
   "use strict";
 
-  /* Popup shrink-wrap — keep in sync with AllLocationsMap.tsx (live component iframe). */
-  var POPUP_MAX_WIDTH_PX = 420;
+  /* POPUP_MAX_WIDTH_PX is defined in leaflet_map_export_constants.generated.js (from defaults.py). */
   var POPUP_SHRINK_WIDTH_BUFFER_PX = 48;
   var POPUP_SHRINK_MIN_CONTENT_WIDTH_PX = 140;
   var POPUP_WIDE_MEASURE_SELECTOR =

--- a/explorer/presentation/static/leaflet_map_export_constants.generated.js
+++ b/explorer/presentation/static/leaflet_map_export_constants.generated.js
@@ -1,0 +1,4 @@
+/** AUTO-GENERATED from explorer/app/streamlit/defaults.py — do not edit. */
+/** Regenerate: python3 scripts/generate_basemap_assets.py */
+
+var POPUP_MAX_WIDTH_PX = 420;

--- a/scripts/build_all_locations_map_frontend.py
+++ b/scripts/build_all_locations_map_frontend.py
@@ -9,8 +9,8 @@ The committed ``frontend/build/`` tree is what Explorer loads at runtime (see co
 This script runs ``npm ci`` + ``npm run build``, then reports expected vs stray files so you know
 what to ``git add`` and what to delete (e.g. macOS Finder duplicates like ``static/css 4/``).
 
-With ``--check-only``, validates committed ``frontend/build/`` **and** that
-``basemaps.generated.ts`` matches ``explorer/data/basemaps.yaml`` (via
+With ``--check-only``, validates committed ``frontend/build/`` **and** that generated map assets
+match ``explorer/data/basemaps.yaml`` and ``MAP_POPUP_MAX_WIDTH_PX`` in ``defaults.py`` (via
 ``scripts/generate_basemap_assets.py --check``).
 
 Exit 1 if junk or unexpected files remain under ``build/`` (use ``--prune-junk`` to remove known junk only).
@@ -37,10 +37,10 @@ _JUNK_DIR_RE = re.compile(r"^(css|js) \d+$")
 def _run_basemap_assets(*, check: bool) -> None:
     cmd = [sys.executable, str(_REPO_ROOT / "scripts/generate_basemap_assets.py")]
     if check:
-        print("Checking basemap assets against explorer/data/basemaps.yaml …")
+        print("Checking generated map assets (basemaps.yaml + defaults.py) …")
         cmd.append("--check")
     else:
-        print("Generating basemap assets from explorer/data/basemaps.yaml …")
+        print("Generating map assets from basemaps.yaml and defaults.py …")
     subprocess.run(cmd, cwd=_REPO_ROOT, check=True)
 
 

--- a/scripts/generate_basemap_assets.py
+++ b/scripts/generate_basemap_assets.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
-"""Generate frontend basemap assets from ``explorer/data/basemaps.yaml``.
+"""Generate frontend map assets from repo manifests and ``defaults.py``.
 
-Writes ``explorer/components/all_locations_map/frontend/src/basemaps.generated.ts``.
+Writes:
+
+- ``explorer/components/all_locations_map/frontend/src/basemaps.generated.ts`` (from ``basemaps.yaml``)
+- ``map_popup_constants.generated.ts`` / ``.css`` (from ``MAP_POPUP_MAX_WIDTH_PX`` in ``defaults.py``)
+- ``explorer/presentation/static/leaflet_map_export_constants.generated.js`` (same popup width)
 
 Run from repo root (also invoked by ``scripts/build_all_locations_map_frontend.py``):
 
@@ -18,18 +22,22 @@ import sys
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_TS_OUT = (
-    _REPO_ROOT
-    / "explorer/components/all_locations_map/frontend/src/basemaps.generated.ts"
-)
+_FRONTEND_SRC = _REPO_ROOT / "explorer/components/all_locations_map/frontend/src"
+_STATIC = _REPO_ROOT / "explorer/presentation/static"
 
 
 def _json_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
+def _popup_max_width_px() -> int:
+    sys.path.insert(0, str(_REPO_ROOT))
+    from explorer.app.streamlit.defaults import MAP_POPUP_MAX_WIDTH_PX  # noqa: PLC0415
+
+    return int(MAP_POPUP_MAX_WIDTH_PX)
+
+
 def render_basemaps_ts() -> str:
-    # Import after repo root is on path when run as script.
     sys.path.insert(0, str(_REPO_ROOT))
     from explorer.core.basemap_manifest import (  # noqa: PLC0415
         MAP_BASEMAP_DEFAULT,
@@ -76,33 +84,97 @@ def render_basemaps_ts() -> str:
     return "\n".join(lines)
 
 
+def render_popup_constants_ts() -> str:
+    width = _popup_max_width_px()
+    return "\n".join(
+        [
+            "/** AUTO-GENERATED from explorer/app/streamlit/defaults.py — do not edit. */",
+            "/** Regenerate: python3 scripts/generate_basemap_assets.py */",
+            "",
+            f"export const POPUP_MAX_WIDTH_PX = {width};",
+            "",
+        ]
+    )
+
+
+def render_popup_constants_css() -> str:
+    width = _popup_max_width_px()
+    return "\n".join(
+        [
+            "/** AUTO-GENERATED from explorer/app/streamlit/defaults.py — do not edit. */",
+            "/** Regenerate: python3 scripts/generate_basemap_assets.py */",
+            "",
+            ":root {",
+            f"  --pebird-map-popup-max-width: {width}px;",
+            "}",
+            "",
+        ]
+    )
+
+
+def render_export_popup_constants_js() -> str:
+    width = _popup_max_width_px()
+    return "\n".join(
+        [
+            "/** AUTO-GENERATED from explorer/app/streamlit/defaults.py — do not edit. */",
+            "/** Regenerate: python3 scripts/generate_basemap_assets.py */",
+            "",
+            f"var POPUP_MAX_WIDTH_PX = {width};",
+            "",
+        ]
+    )
+
+
+def _generated_outputs() -> tuple[tuple[Path, str], ...]:
+    return (
+        (_FRONTEND_SRC / "basemaps.generated.ts", render_basemaps_ts()),
+        (_FRONTEND_SRC / "map_popup_constants.generated.ts", render_popup_constants_ts()),
+        (_FRONTEND_SRC / "map_popup_constants.generated.css", render_popup_constants_css()),
+        (
+            _STATIC / "leaflet_map_export_constants.generated.js",
+            render_export_popup_constants_js(),
+        ),
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Exit 1 if generated TS is out of date (do not write).",
+        help="Exit 1 if any generated file is out of date (do not write).",
     )
     args = parser.parse_args()
 
-    rendered = render_basemaps_ts()
+    outputs = _generated_outputs()
+    stale: list[str] = []
+    for path, rendered in outputs:
+        rel = path.relative_to(_REPO_ROOT)
+        if args.check:
+            if not path.is_file():
+                stale.append(f"missing {rel}")
+                continue
+            existing = path.read_text(encoding="utf-8")
+            if existing != rendered:
+                stale.append(str(rel))
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(rendered, encoding="utf-8")
+            print(f"wrote {rel}")
+
     if args.check:
-        if not _TS_OUT.is_file():
-            print(f"error: missing {_TS_OUT.relative_to(_REPO_ROOT)}", file=sys.stderr)
-            sys.exit(1)
-        existing = _TS_OUT.read_text(encoding="utf-8")
-        if existing != rendered:
+        if stale:
             print(
-                f"error: {_TS_OUT.relative_to(_REPO_ROOT)} is stale; "
+                "error: generated map assets are stale; "
                 "run python3 scripts/generate_basemap_assets.py",
                 file=sys.stderr,
             )
+            for item in stale:
+                print(f"  - {item}", file=sys.stderr)
             sys.exit(1)
-        print(f"OK: {_TS_OUT.relative_to(_REPO_ROOT)} matches basemaps.yaml")
+        for path, _ in outputs:
+            print(f"OK: {path.relative_to(_REPO_ROOT)}")
         return
-
-    _TS_OUT.write_text(rendered, encoding="utf-8")
-    print(f"wrote {_TS_OUT.relative_to(_REPO_ROOT)}")
 
 
 if __name__ == "__main__":

--- a/tests/explorer/test_basemap_manifest.py
+++ b/tests/explorer/test_basemap_manifest.py
@@ -34,7 +34,7 @@ def test_basemap_manifest_options_labels_and_tiles():
         assert component[key]["opts"]["maxZoom"] == export[key]["opts"]["maxZoom"]
 
 
-def test_generated_basemap_ts_is_fresh():
+def test_generated_map_assets_are_fresh():
     result = subprocess.run(
         [sys.executable, str(_REPO_ROOT / "scripts/generate_basemap_assets.py"), "--check"],
         cwd=_REPO_ROOT,

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -7,6 +7,7 @@ import re
 
 import pytest
 
+from explorer.app.streamlit.defaults import MAP_POPUP_MAX_WIDTH_PX
 from explorer.core.basemap_manifest import (
     MAP_BASEMAP_DEFAULT,
     MAP_BASEMAP_OPTIONS,
@@ -258,3 +259,17 @@ def test_leaflet_map_to_html_bytes_includes_viewer_and_geojson():
     assert "pebird-export-shell" in text
     assert "shrinkPebirdLeafletPopups" in text
     assert "scheduleShrinkPebirdLeafletPopups" in text
+
+
+def test_leaflet_map_to_html_bytes_embeds_generated_popup_max_width():
+    raw = leaflet_map_to_html_bytes(
+        geojson=_minimal_export_geojson(),
+        height=400,
+        map_style="default",
+        cluster_options={"enabled": False},
+        circle_marker_style={"fill_hex": "#3388ff", "stroke_hex": "#1c2630", "radius_px": 7},
+        viewport={"v": 1, "mode": "center_zoom", "center": [-37.0, 145.0], "zoom": 10},
+    )
+    text = raw.decode("utf-8")
+    assert f"var POPUP_MAX_WIDTH_PX = {MAP_POPUP_MAX_WIDTH_PX};" in text
+    assert "AUTO-GENERATED from explorer/app/streamlit/defaults.py" in text


### PR DESCRIPTION
## Summary

`MAP_POPUP_MAX_WIDTH_PX` was hardcoded in three stacks (Python defaults, React popup sizing, HTML export viewer JS) with manual sync comments. This change generates TS, CSS, and export JS from the single Python constant in `defaults.py`.

## Changes

- **Codegen:** `scripts/generate_basemap_assets.py` now also emits:
  - `map_popup_constants.generated.ts` (React import)
  - `map_popup_constants.generated.css` (`--pebird-map-popup-max-width`)
  - `leaflet_map_export_constants.generated.js` (export viewer)
- **React:** `AllLocationsMapPopupSizing.ts` imports generated TS; CSS imports generated variable file
- **Export:** `leaflet_map_html_export.py` concatenates generated JS constants with `leaflet_map_export.js`
- **CI:** `--check` validates all four generated outputs (basemaps + popup constants)

## Testing

- `python3 -m ruff check explorer/`
- `python3 scripts/generate_basemap_assets.py --check`
- `python3 -m pytest tests/ -q` — 636 passed, 7 skipped

## Notes

To change popup width, edit `MAP_POPUP_MAX_WIDTH_PX` in `explorer/app/streamlit/defaults.py`, then run:

```bash
python3 scripts/generate_basemap_assets.py
```

(`build_all_locations_map_frontend.py` runs this automatically before npm build.)

## Issues

Fixes #265

Made with [Cursor](https://cursor.com)