### PR TITLE
Add share summary foundation — compute, layouts, and design app

### DIFF
--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -207,8 +207,9 @@ Do not duplicate HTML in UI code — use shared formatters.
 - **Map HTML export UX** — Shipped one-click sidebar export; alternative two-button design and browser-risk notes: [docs/explorer/map-html-export-ux-alternative.md](explorer/map-html-export-ux-alternative.md) (use if users report export/download failures).
 
 - **`explorer/core/settings_schema_defaults.py`** — **Persisted YAML settings schema** defaults (tables, rankings bounds, taxonomy locale, maintenance distance, pin **colour** names allowed in settings).
+- **`explorer/core/share_summary_defaults.py`** — **Share-summary card** colour schemes and layout stat defaults (#157); re-exported from `defaults.py` for Streamlit tuning.
 
-Do not hardcode tunable numbers in UI files; use `defaults.py` for those.
+Do not hardcode tunable numbers in UI files; use `defaults.py` (or the matching `explorer/core/*_defaults.py` module) for those.
 
 ---
 

--- a/docs/explorer/issue-157-share-summary-tracker.md
+++ b/docs/explorer/issue-157-share-summary-tracker.md
@@ -463,14 +463,15 @@ The explorer is a **browser-based web app**, developed and optimised primarily f
 | File | Role |
 |------|------|
 | `explorer/core/share_summary_compute.py` | Period definitions + stat computation |
+| `explorer/core/share_summary_defaults.py` | Colour schemes + default stat lists for share cards |
 | `explorer/presentation/share_summary_preview.py` | HTML layouts, footer logo, preview scaling |
-| `explorer/app/streamlit/defaults.py` | Colour schemes + default stat lists for share cards |
+| `explorer/app/streamlit/defaults.py` | Re-exports share-summary defaults for Streamlit tuning |
 | `explorer/app/streamlit/design_share_summary_app.py` | Standalone design utility (dev / tuning) |
 | `explorer/app/streamlit/streamlit_ui_constants.py` | `NOTEBOOK_MAIN_TAB_LABELS` — add **Socials** before Settings |
 | `explorer/app/streamlit/app_map_working_ui.py` | Map sidebar today — refactor target for tab-aware sidebar |
 | `explorer/app/streamlit/app_dashboard_shell.py` | Main tab shell — wire Socials fragment |
 | `tests/explorer/test_share_summary_preview.py` | Preview / extraction tests |
-| `tests/explorer/test_share_summary_compute.py` | Period stats tests (when added) |
+| `tests/explorer/test_share_summary_compute.py` | Period stats + date-range tests |
 
 ---
 

--- a/docs/explorer/issue-157-share-summary-tracker.md
+++ b/docs/explorer/issue-157-share-summary-tracker.md
@@ -1,0 +1,532 @@
+# Issue #157 — Share summary tracker
+
+Living document for the social media summary feature. Update this file as ideas land and work completes.
+
+**GitHub issue:** [#157 — Social Media Summary Generator](https://github.com/jimchurches/myebirdstuff/issues/157)
+
+**Implementation sub-issues:**
+
+| Phase | Issue | Scope |
+|-------|-------|--------|
+| 0 | [#273](https://github.com/jimchurches/myebirdstuff/issues/273) | Foundation — compute, layouts, tests, design app |
+| 1 | [#274](https://github.com/jimchurches/myebirdstuff/issues/274) | Period stats hardening |
+| 2 | [#275](https://github.com/jimchurches/myebirdstuff/issues/275) | Playwright PNG export |
+| 3 | [#276](https://github.com/jimchurches/myebirdstuff/issues/276) | Socials tab in main app |
+| 4 | [#277](https://github.com/jimchurches/myebirdstuff/issues/277) | v1 polish — stat picker, best birds, layout tuning |
+
+**Prototype branch:** `157-social-summary-prototype` → PR for #273 to `beta-next`
+
+**Design app:**
+
+```bash
+streamlit run explorer/app/streamlit/design_share_summary_app.py
+```
+
+---
+
+## Status at a glance
+
+| Area | Status | Notes |
+|------|--------|-------|
+| Layout mockups (HTML) | **Done (prototype)** | Hero, tiles, minimal, spotlight |
+| Aspect ratios | **Done (prototype)** | Square post, portrait post, story |
+| App logo on card | **Done (prototype)** | Footer banner only (no top-right corner) |
+| Period: yearly | **Done (prototype)** | From CSV or sample data |
+| Period: monthly | **Done (prototype)** | `compute_share_summary_stats` |
+| Period: weekly | **Done (prototype)** | Sun–Sat weeks; title `May 31, 2026 - June 6, 2026` |
+| Period: custom / trip | **Done (prototype)** | Date range + trip title as green subtitle |
+| Longest streak (year/month) | **Agreed** | Summary row when applicable; not week/custom v1 |
+| Birding days | **Done (prototype)** | Unique checklist days; label “Birding days” |
+| Countries | **Done (prototype)** | All period types; default on tiles/minimal |
+| World bird coverage | **Summary row only** | Available stat; not on card tiles by default |
+| Best bird(s) | **Roadmap** | Pure user pick (up to 3); choices from period species list |
+| PNG generation | **Agreed — Playwright** | Implementation not started; verify Streamlit Cloud |
+| PNG save UX | **Deferred** | Button vs right-click vs hybrid — decide when implementing |
+| Main app integration | **Design noted** | New **Socials** tab before Settings; tab-aware sidebar TBD |
+| Map thumbnail on card | **Dropped (v1)** | v2 |
+| Compare to last year | **Dropped (v1)** | v2 |
+| Custom @handle watermark | **Dropped (v1)** | v2 |
+| Media uploads | **Dropped** | Not in eBird observation CSV |
+| User picks stats on card | **Agreed (v1)** | Defaults per layout; picker UI TBD |
+| Current vs previous period | **Open** | Radio/toggle for year/month/week |
+| Colour schemes | **Config in defaults.py** | Index tunable; no UI yet |
+| Multiple themes (light/dark) | **Config only** | Add entries to colour scheme array |
+| User picks layout in app | **Agreed (v1)** | Hero grid, Stat tiles, Minimal list, **Spotlight** |
+
+---
+
+## Decisions (2026-06-09)
+
+Captured after second prototype review — closes most open layout/stat questions.
+
+### Dropped / deferred
+
+- **Media uploads** (photos/sounds per month) — not in observation CSV; idea dropped.
+- **Map thumbnail** on card — v2.
+- **Compare to last year** — v2.
+- **Custom watermark / @handle** — v2.
+- **Colour scheme UI** — v2 (config-only for now; see Colours).
+- **App-wide mobile UX** — out of scope; Socials tab should still be phone-friendly.
+
+### Default stats per layout
+
+Configured in ``explorer/app/streamlit/defaults.py`` as ``SHARE_SUMMARY_HERO_DEFAULT_STATS`` / ``SHARE_SUMMARY_TILES_DEFAULT_STATS``.
+
+| Layout | Default stats (in order) |
+|--------|--------------------------|
+| **Hero** (4 tiles) | Total species, Lifers, Total checklists, Unique locations |
+| **Stat tiles** (6) | Above + Countries, Birding days |
+| **Minimal list** (6) | Same as stat tiles |
+| **Spotlight** | **Lifers** (``SHARE_SUMMARY_SPOTLIGHT_STAT_DEFAULT``) |
+
+Users will eventually pick stats from the full catalogue; defaults above are the starting point.
+
+**Birding hours** — computed and shown in the **summary metrics row** (all available stats with values); **not** on card tiles by default.
+
+### Available stats catalogue (v1 target)
+
+All should appear in the summary row (with values) so users can pick interesting items for custom cards.
+
+| Stat | Scope | In compute today? | On card default? |
+|------|-------|-------------------|------------------|
+| Total species | Period | Yes | Yes (hero/tiles) |
+| Lifers | Period | Yes | Yes |
+| Total checklists | Period | Yes | Yes |
+| Unique locations | Period | Yes | Yes |
+| Countries | Period | Yes (all period types) | Yes (tiles/minimal) |
+| Birding days | Period | Yes | Yes (tiles/minimal) |
+| Total individuals | Period | Yes | No |
+| Total bird families | Period (taxonomy map) | Yes | No |
+| Birding hours | Period | Yes | **Summary only** |
+| Longest streak (days) | Period (year/month only) | Yes | No |
+| Shared checklists | Period | **Not yet** — reuse checklist-stats logic | No |
+| Days birding with others | Period | **Not yet** — reuse checklist-stats logic | No |
+| World bird coverage | All-time (taxonomy) | Yes (summary row) | No |
+| Total species (from taxa) | All-time | **Not yet** — Bird Families tab | No |
+| Total families (from taxa) | All-time | **Not yet** — Bird Families tab | No |
+| Best bird(s) | User pick (≤3) | Roadmap | No |
+| Trip title | User text (custom range) | Yes | Replaces green subtitle |
+
+**Note:** “Total bird families” (period) and “Total families (from taxa)” (all-time list) are **different metrics** — both may be offered; labels must distinguish them.
+
+**Also discussed, not in list above:** spotlight single-stat cards (“Year birds”, etc.) — layout choice, not a separate metric. **Label fine-tuning:** custom/trip species spotlight uses **Species** (not “Birds”) to match other layouts; year/month/week still use “Year birds” / “Month birds” / “Week birds” — revisit during tuning.
+
+### Countries
+
+- **Default** on stat tiles and minimal list for **all period types** (year, month, week, custom).
+- May revisit after user testing (previously year-only).
+
+### Longest streak
+
+- **Agreed:** computed for **year and month** periods only (matches Yearly Summary / checklist-stats logic).
+- Shown in the **summary metrics row** when applicable; **not** on default card tiles.
+- **Week and custom/trip** periods do not get longest streak unless compute is extended later — no plan to do that for v1.
+
+### Logo & titles
+
+- **Logo:** footer banner only (logo + “Personal eBird Explorer”). **No** top-right corner logo.
+- **Green subtitle** (smaller heading): period flavour text — “Birding year in review”, “Monthly birding summary”, etc.; or **trip title** on custom ranges.
+- **Large headline:** always the period label — year, month name, weekly date range, or custom date range.
+- **Trip title:** replaces the **green subtitle** on **all layouts** (hero, tiles, minimal, spotlight). Layout-specific subtitles (“My birding stats”, “Summary”) apply only when no trip title is set.
+- **Weekly title:** Sun–Sat week; format ``May 31, 2026 - June 6, 2026`` (same visual weight as year/month headlines).
+- **Custom date range:** compact range as large headline (existing ``format_custom_date_range``); trip title in green subtitle when set.
+
+### Colours
+
+- Current palette looks good for v1.
+- Schemes live in ``defaults.py`` → ``SHARE_SUMMARY_COLOR_SCHEMES`` (array of dicts: ``bg``, ``bg_alt``, ``text``, ``muted``, ``border``, ``accent``).
+- Active scheme: ``SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT`` (flip index to test new schemes without code changes).
+- **No UI control** for colour schemes yet.
+- **Dark theme:** add a second entry to the array when a good palette exists; otherwise mark v2 with colour-scheme work.
+
+### Period selection — current vs previous (open)
+
+Idea: control for **current period** vs **previous period** (radio, toggle, or dropdown — wording TBD).
+
+Example: on Saturday afternoon finishing the birding month → “current month”; on 2 June posting May results → “previous month”. Same for year/week.
+
+Not implemented in prototype yet — discuss wording and UX when building Socials tab controls.
+
+### Card layout iteration (still open)
+
+- Hero 4-tile grid may need **sizing** to reduce blank space (same for 6-tile stat card).
+- Square layout might fit **9 tiles** (room for best-bird slot later); portrait/story differ.
+- Per-layout iteration expected during user testing.
+
+### Controls & sidebar (still open)
+
+- Exact control layout (sidebar vs in-tab vs hybrid) TBD.
+- If sidebar: show **Socials controls only on Socials tab**; restore map controls elsewhere; preserve session state when switching (see Tab-aware sidebar section).
+
+---
+
+## User feedback (2025-06-09)
+
+Captured from initial prototype review:
+
+- **Direction confirmed** — mockups are the right idea; good starting point, tuning expected.
+- **Logo** — include Personal eBird Explorer logo on the image (can be small). ✅ Added in prototype (corner + footer).
+- **Aspect ratios** — want all three:
+  - **Story** — 1080×1920 ✅
+  - **Post (square)** — 1080×1080 ✅
+  - **Post (portrait)** — 1080×1350 (4:5 Instagram feed) ✅
+- **Periods** — yearly, monthly, weekly, and custom date range (trip report). ✅ Scaffolded in design app + `share_summary_compute.py`.
+- **Layouts** — user selects from **Hero grid**, **Stat tiles**, **Minimal list**, **Spotlight** (all agreed for v1).
+- **Spotlight species label** — period-aware: Year / Month / Week birds; **Species** for custom/trip range.
+- **Single-stat images** — ideas only for now (“Year birds”, “Lifers this year”, etc.). ✅ **Spotlight** layout added as a sketch.
+- **Community research** — user plans to look at what others have done with external tools before locking stats/layout.
+- **Trip title (custom range)** — optional name shown on the card **with** the date range, not instead of it. Examples:
+  - `1 – 7 June 2025` → **North Coast NSW Exploration**
+  - `6 May – 12 May 2025` → **Central NSW Loop**
+  ✅ Prototype: sidebar “Trip title (optional)” when custom range is selected; card shows dates above title.
+
+### Decisions (2025-06-09, continued)
+
+- **PNG generation: Playwright** — agreed. HTML layout → headless Chromium screenshot; downloadable image remains possible (display as real PNG in app). Pillow fallback only if Cloud blocks Chromium.
+- **Save UX: deferred** — button vs right-click vs hybrid to decide when building the PNG step; both remain viable once image is rendered via `st.image` / `<img>`.
+- **Mobile context** — app was developed desktop-first (author workflow), but share summaries are inherently “phone” (Instagram, stories, on-the-go sharing). Many users access the web app on phones even if tables/maps are desktop-oriented. Broader mobile polish is a separate concern but **this feature should be designed and tested on phone early** (save affordance, preview size, touch). Not a phone-native app, but not desktop-only for this feature.
+
+### Main app placement (2025-06-09 — design notes)
+
+- **Tab name (WIP):** **Socials** — working title for the share-summary generator tab; rename later if needed.
+- **Tab order:** last data tab, **immediately before Settings** (after Maintenance).
+  - Proposed strip: Map → Checklist Statistics → Ranking & Lists → Bird Families → Yearly Summary → Country → Maintenance → **Socials** → Settings
+  - Code touchpoint: `NOTEBOOK_MAIN_TAB_LABELS` in `explorer/app/streamlit/streamlit_ui_constants.py`
+- **Tab content:** Like the design mockup — user can choose period, layout, aspect ratio, spotlight stat, trip title, etc., and see a live preview (then PNG via Playwright when built).
+- **Not the standalone design app** long term — embed into main explorer once phases 1–2 are ready; keep `design_share_summary_app.py` as a dev utility until then.
+
+---
+
+## Open questions (for when you're back)
+
+Most items below were **resolved 2026-06-09** — see **Decisions (2026-06-09)**. Remaining open items:
+
+### Layouts
+
+1. ~~Ship all layouts~~ — **Agreed:** Hero grid, Stat tiles, Minimal list, Spotlight selectable in v1.
+2. ~~Spotlight species wording~~ — **Agreed:** Year / Month / Week birds; **Species** for custom trip (was “Birds”).
+3. ~~Hero/tiles/minimal default stats~~ — **Agreed** (see Decisions table).
+4. Card tile sizing / blank space — iterate during testing.
+
+### Stats on the card
+
+5. ~~Default 4-stat hero set~~ — **Agreed:** species, lifers, checklists, locations.
+6. ~~Birding days~~ — **Agreed:** on tiles/minimal defaults; summary row always.
+7. ~~Countries~~ — **Agreed:** all period types on tiles/minimal defaults.
+8. ~~Birding hours on card~~ — **Summary row only**, not default on cards.
+9. ~~Trip title placement~~ — **Agreed:** green subtitle; dates as large headline.
+10. **Best bird(s)** — roadmap.
+11. **World bird coverage** — summary row; card placement when user picks stat.
+12. **Shared checklists / days birding with others** — wire into period compute (phase 1).
+13. **Total species/families (from taxa)** — wire from Bird Families bundle when stat picker lands.
+
+### Visual design
+
+14. ~~Logo placement~~ — **Footer only.**
+15. ~~Accent colours~~ — **defaults.py schemes;** no UI yet.
+16. ~~Weekly title format~~ — **Sun–Sat + long US date range.**
+
+### Period UX
+
+17. **Current vs previous period** — open (see Decisions).
+
+### PNG / mobile / sidebar
+
+18. Save UX — deferred (phase 2).
+19. Phone testing — before v1.
+20. Tab-aware sidebar — phase 3.
+
+### World bird coverage (roadmap — partial)
+
+**Observed species (%)** against the eBird/Clements living taxonomy — same metric as **Rankings → Interesting Lists → Species: Coverage** and **Bird Families** overview.
+
+- Example display: **World bird coverage** → **6.8%**
+- **All-time / list-wide**, not period-scoped.
+- **Summary row:** included so users can add it via stat picker later.
+- **Not** on default card tiles.
+
+### Best bird(s) (roadmap — not implemented)
+
+Optional highlight of one or more memorable species on a share card (year summary, trip report, etc.).
+
+- **Pure user choice — not calculated.** No algorithmic “best bird” (no auto-pick by lifer, count, rarity, etc.). The user decides what counts as their best bird(s) for that card.
+- **Picker, not free text:** up to **3 species** chosen from birds **recorded in the selected period** (same export, filtered by date range). Type-ahead / searchable list from that set — avoids spelling errors and invalid species.
+- **Display TBD:** dedicated layout slot, footer strip, or extra panel on existing layouts (Hero / tiles / story may need more room).
+- **Data:** common + scientific names from export for selected species; static PNG only (no eBird links on image).
+- **Open questions when implementing:**
+  - Required for trip cards vs optional on all period types?
+  - One shared “best birds” list per card or separate picks per layout/format?
+  - How to render 1 vs 2 vs 3 species (stacked names, mini list, icons)?
+  - Sort order of picks — user-defined drag order?
+
+**Status:** roadmap only — do **not** implement until after v1 layouts + Playwright PNG land (likely phase 4 or follow-up issue).
+
+*(Visual design / PNG / mobile / sidebar open items moved to **Open questions** — most resolved 2026-06-09.)*
+
+## Tab-aware sidebar (design notes)
+
+### Current behaviour
+
+- Sidebar is built **once per rerun** in `render_map_sidebar_and_working_set()` (`app_map_working_ui.py`), **before** main tabs render.
+- It always shows **Map** controls (view mode, date filter, species search, basemap, etc.).
+- Widgets **do** change when switching **map view** (All locations ↔ Species ↔ Lifers ↔ Families) — that logic already lives in the map sidebar.
+- Sidebar does **not** change when switching **main tabs** (Checklist Statistics, Yearly Summary, etc.) — map controls stay visible even on non-map tabs.
+
+### Desired behaviour for Socials
+
+When the user selects the **Socials** tab:
+
+- Sidebar should show **Socials controls** (mirroring the design app sidebar):
+  - Period: year / month / week / custom (+ trip title when custom)
+  - Aspect ratio: square / portrait post / story
+  - Layout: Hero grid / Stat tiles / Minimal list / Spotlight
+  - Spotlight stat (when Spotlight layout)
+  - Optional: preview scale (maybe main panel only)
+- Main panel: card preview (+ PNG when Playwright lands).
+
+When the user leaves **Socials** (any other main tab):
+
+- Sidebar should **restore map controls** for the **currently selected map view** (preserve existing map session state — basemap, species pick, date filter, etc.).
+
+Other data tabs (Checklist, Yearly, …) — **no change for v1**; map sidebar can stay as today until/unless we revisit global sidebar policy.
+
+### Streamlit constraint (to discuss at implementation)
+
+`st.tabs()` does **not** expose which tab is selected on the server — all tab blocks run each rerun. Today the app has no `active_main_tab` session key.
+
+**Possible approaches** (pick one in phase 3):
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **A. Conditional sidebar + session tab key** | Clean swap Map ↔ Socials | Need a reliable way to set tab key (see below) |
+| **B. Socials controls in main panel only** | Simple; no tab detection | Sidebar still map-heavy on Socials tab |
+| **C. Replace top tabs with nav that sets session state** | Sidebar always knows context | Larger UX change |
+| **D. `@st.fragment` Socials tab + sidebar section** | Partial reruns for preview | Sidebar still global; still need conditional render at top level |
+
+**Likely path:** **A** — refactor sidebar into `render_map_sidebar(...)` and `render_socials_sidebar(...)`, gated by `st.session_state[STREAMLIT_MAIN_TAB_KEY]`. Set that key via one of:
+
+- Streamlit version/feature that reports tab selection (if available when we implement)
+- Lightweight sync widget (acceptable if minimal)
+- Socials-specific entry that sets key when its fragment mounts (evaluate against Streamlit behaviour)
+
+**Map state preservation:** When switching away from Socials, only sidebar **widgets** swap; do not clear map working-set keys (`STREAMLIT_MAP_VIEW_LABEL_KEY`, species search, export recipe, etc.).
+
+### UX reference
+
+Standalone prototype: `streamlit run explorer/app/streamlit/design_share_summary_app.py` — use as the template for Socials tab layout + control set.
+
+---
+
+Both turn your layout into a downloadable PNG. The prototype already builds the card as **HTML + CSS** (same pattern as map HTML export).
+
+### Playwright (HTML → screenshot)
+
+Uses headless Chromium to open the HTML and screenshot at exact pixel size (1080×1080, etc.).
+
+| | |
+|---|---|
+| **Pros** | What you see in the design app is what you get; easy to iterate layouts; repo already uses Playwright in **tests**; fits the existing “export HTML then render” architecture. |
+| **Cons** | Larger dependency; need Chromium binaries (~100MB+); **Streamlit Cloud** may need extra setup or may not support headless browsers — must verify before committing. |
+
+### Pillow (draw in Python)
+
+Draws rectangles and text directly onto a PNG canvas in code.
+
+| | |
+|---|---|
+| **Pros** | Small, simple dependency; no browser; predictable on Cloud/serverless. |
+| **Cons** | Every layout change means Python drawing code, not CSS; harder to match the HTML prototype; long labels and wrapping are painful; essentially **two implementations** (HTML preview + Pillow export) unless you drop HTML. |
+
+### Recommendation for this project
+
+**Agreed (2025-06-09): use Playwright** for PNG generation. A downloadable/saveable image remains possible by displaying the generated PNG in the app (`st.image` or equivalent).
+
+Reasons:
+
+1. The prototype and future tuning are **HTML-first** — Playwright preserves that single source of truth.
+2. Map export already established the “generate standalone HTML” pattern.
+3. Tests already install Playwright; team familiarity is higher than maintaining parallel Pillow layouts.
+
+**Fallback:** If Streamlit Cloud cannot run headless Chromium, options are:
+
+- PNG **local install only** (Playwright), preview-only on Cloud; or
+- Pillow export for **one fixed layout** only (more maintenance); or
+- Client-side export (browser canvas) — possible but awkward in Streamlit.
+
+**Decision:** ☑ Playwright  ☐ Pillow  ☐ Hybrid  ☐ Defer until Cloud checked *(Cloud verification still open)*
+
+---
+
+## Right-click save vs download button
+
+**User assumption (2025-06-09):** Maybe no dedicated export button — user right-clicks the preview and uses the browser’s **Save image as…** (default browser behaviour).
+
+### Important distinction
+
+| Question | What it decides |
+|----------|-----------------|
+| **Playwright vs Pillow** | How the PNG is **generated** on the server |
+| **Button vs right-click** | How the user **gets** the file — UX only |
+
+You still need PNG generation (Playwright or Pillow) for a good save experience. The current prototype is **HTML in a `<div>`**, scaled with CSS — right-click on that does **not** reliably offer “Save image as…” for the card at full 1080px resolution. It might copy HTML, save a fragment, or do nothing useful.
+
+For right-click save to work, the UI must show a **real image** — e.g. `st.image(png_bytes)` or `<img src="data:image/png;base64,...">` at the target size (or scaled display of that bitmap). Then desktop browsers expose Save image as… on the image itself.
+
+### Right-click only (no button)
+
+**Pros**
+
+- Minimal UI — no extra control in an already busy app
+- Familiar to desktop users who share screenshots and web images
+- Matches “here’s your card” rather than “export workflow”
+
+**Cons**
+
+- **Discoverability** — many users never right-click; mobile has no right-click (long-press “Save image” on iOS/Android is inconsistent in WebViews and Streamlit)
+- **Streamlit** — behaviour depends on how the image is embedded; worth testing on Cloud + phone
+- No obvious filename (browser picks something generic unless you use a download link with `download=` attribute — which is basically a button under the hood)
+
+### Download button (or link)
+
+**Pros**
+
+- Clear affordance — “this is meant to be saved and shared”
+- Can set filename (`2025-birding-summary.png`)
+- Works everywhere Streamlit serves files (`st.download_button`)
+- Better on mobile
+
+**Cons**
+
+- Extra UI element
+- Feels more “tool-like” than “here’s a card”
+
+### Hybrid (recommended to consider)
+
+- Render the card as a **PNG image** in the app (requires Playwright/Pillow either way).
+- **No prominent button** if you prefer clean UI — optional small caption: *Right-click the image to save* (desktop).
+- Optionally add a **low-emphasis** text link or icon (“Download”) for mobile and discoverability without a big primary button.
+
+### Project note
+
+Right-click-only is a **reasonable** choice for a desktop-first app if we accept:
+
+1. PNG generation still required (Playwright vs Pillow unchanged).
+2. Mobile / Streamlit Cloud need a quick UX test before committing.
+3. A subtle hint or fallback download link may still be needed for users who don’t discover right-click.
+
+**Decision:** ☐ Right-click only (+ hint)  ☐ Download button  ☐ Hybrid  ☑ **Defer** (revisit in phase 2; bias toward minimal UI, but phone testing may require download affordance)
+
+---
+
+## Mobile vs desktop (context)
+
+The explorer is a **browser-based web app**, developed and optimised primarily for **desktop** (author workflow, wide tables, maps). README already notes mobile is usable but not optimised.
+
+**Share summaries are different:**
+
+- Output targets social platforms consumed on **phones**.
+- Users may create a summary **on phone** after birding (upload CSV is harder on phone, but Streamlit Cloud access from mobile is real).
+- Save UX (right-click, long-press, share sheet) is inherently mobile-sensitive.
+
+**Agreed direction for this feature:**
+
+- Design cards at fixed social sizes (already done); preview sensibly on narrow viewports.
+- When Playwright PNG lands, **test save flow on iOS + Android browsers**, not just desktop right-click.
+- Save UX decision waits on that testing — don’t assume desktop-only.
+- Broader app mobile improvements remain a separate initiative; this feature is a good pilot for “phone matters” without rewriting the whole app.
+
+---
+
+## Layout catalogue (prototype)
+
+| ID | Description | Best for |
+|----|-------------|----------|
+| `hero` | Title + 2×2 stat blocks | Square / portrait post |
+| `tiles` | Up to 6 stat tiles | Portrait post / story |
+| `minimal` | Typographic list | Story / text-heavy |
+| `spotlight` | One large number + label | Single-stat shares (“47 lifers”) |
+
+---
+
+## Aspect ratios
+
+| ID | Size | Typical use |
+|----|------|-------------|
+| `square` | 1080×1080 | Instagram / Facebook square feed |
+| `portrait_post` | 1080×1350 | Instagram 4:5 portrait feed |
+| `story` | 1080×1920 | Instagram / Facebook stories |
+
+---
+
+## Code map
+
+| File | Role |
+|------|------|
+| `explorer/core/share_summary_compute.py` | Period definitions + stat computation |
+| `explorer/presentation/share_summary_preview.py` | HTML layouts, footer logo, preview scaling |
+| `explorer/app/streamlit/defaults.py` | Colour schemes + default stat lists for share cards |
+| `explorer/app/streamlit/design_share_summary_app.py` | Standalone design utility (dev / tuning) |
+| `explorer/app/streamlit/streamlit_ui_constants.py` | `NOTEBOOK_MAIN_TAB_LABELS` — add **Socials** before Settings |
+| `explorer/app/streamlit/app_map_working_ui.py` | Map sidebar today — refactor target for tab-aware sidebar |
+| `explorer/app/streamlit/app_dashboard_shell.py` | Main tab shell — wire Socials fragment |
+| `tests/explorer/test_share_summary_preview.py` | Preview / extraction tests |
+| `tests/explorer/test_share_summary_compute.py` | Period stats tests (when added) |
+
+---
+
+## Phased delivery (suggested)
+
+| Phase | Branch (example) | Deliverable | Status | Issue |
+|-------|------------------|-------------|--------|-------|
+| 0 | `157-social-summary-prototype` | Design app + tracker + core modules | **Ready to commit/PR** | [#273](https://github.com/jimchurches/myebirdstuff/issues/273) |
+| 1 | `157-share-summary-period-stats` | Harden compute + tests; align with main app data paths | Not started | [#274](https://github.com/jimchurches/myebirdstuff/issues/274) |
+| 2 | `157-share-summary-png-export` | Playwright HTML→PNG; display image; save UX TBD | Not started | [#275](https://github.com/jimchurches/myebirdstuff/issues/275) |
+| 3 | `157-share-summary-ui` | **Socials** main tab (before Settings); tab-aware sidebar; preview + PNG | Not started | [#276](https://github.com/jimchurches/myebirdstuff/issues/276) |
+| 4 | follow-ups | Best bird(s), stat picker, themes, layout tuning | Not started | [#277](https://github.com/jimchurches/myebirdstuff/issues/277) |
+
+---
+
+## Ideas backlog
+
+- **World bird coverage** — reuse `compute_world_species_coverage`; status metrics row in mockup; card placement TBD.
+- **Best bird(s)** — **pure user choice** (not algorithmic); up to **3 species** from a period-scoped picker (type-ahead over birds in range — no free-text spelling).
+- **Trip title on custom range** — optional user label alongside formatted dates (see User feedback).
+- **“Year birds”** spotlight card — species count with birding-friendly wording.
+- **Lifer highlight card** — big lifer count on spotlight card (separate from best-bird user picks).
+- **Carousel / multiple PNGs** — one download per stat for Instagram carousel posts.
+- **Map mini-preview** — dropped v1.
+- **Compare to last year** — dropped v1.
+- **Watermark / @handle** — v2.
+- **Mobile save UX pilot** — first feature to require phone save/share testing; informs app-wide mobile backlog.
+
+---
+
+## Risks / caveats
+
+- **Lifer counts** follow explorer logic (first sighting in your export), not necessarily eBird official totals — same as Yearly Summary tab.
+- **Weekly stats** use **Sun–Sat** calendar weeks (not ISO Mon–Sun).
+- **Empty periods** return zeroed stats object; cards may look sparse — may need “no data” state in UI.
+- Logo SVG is embedded via data URI; PNG export must bundle or inline the same asset.
+- **Playwright on Streamlit Cloud** — must verify headless Chromium in production; blocks Cloud PNG if unsupported.
+- **Phone save behaviour** — long-press / share sheet varies by browser; may force download button despite minimal UI preference.
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2025-06-09 | Initial prototype: 3 layouts, square + story, yearly stats only |
+| 2025-06-09 | User feedback: logo, portrait post, periods, spotlight layout, tracker doc, Playwright vs Pillow notes |
+| 2025-06-09 | Trip title on custom date range (dates + title on card); compact date formatting |
+| 2025-06-09 | Longest streak stat for year/month periods (reuses checklist stats logic) |
+| 2025-06-09 | Save UX notes: right-click vs download button; clarified vs Playwright/Pillow |
+| 2025-06-09 | **Decision:** Playwright for PNG; save UX deferred; mobile context for share feature documented |
+| 2025-06-09 | Layout choice: Hero / Stat tiles / Minimal list / Spotlight for v1; period-aware spotlight labels |
+| 2025-06-09 | Main app: **Socials** tab (WIP name) before Settings; tab-aware sidebar design notes |
+| 2025-06-09 | Stats: **Birding days** + **Countries** (year); period context for when to show TBD |
+| 2025-06-09 | Roadmap: **Best bird(s)** — user picks up to 3 highlight species (not implemented) |
+| 2025-06-09 | Best bird(s) clarified: **user-only** choice; picker from period species (not calculated) |
+| 2025-06-09 | **World bird coverage** on roadmap; mockup status row only (6.8% sample / live from taxonomy) |
+| 2026-06-09 | **Decisions batch:** default stats per layout, footer-only logo, trip title → green subtitle, Sun–Sat weekly titles, countries all periods, colour schemes in defaults.py, dropped media/map/compare/watermark v1 |
+| 2026-06-09 | GitHub sub-issues created: #273–#277; plan comment on #157 |

--- a/docs/explorer/issue-157-share-summary-tracker.md
+++ b/docs/explorer/issue-157-share-summary-tracker.md
@@ -70,7 +70,7 @@ Captured after second prototype review — closes most open layout/stat question
 
 ### Default stats per layout
 
-Configured in ``explorer/app/streamlit/defaults.py`` as ``SHARE_SUMMARY_HERO_DEFAULT_STATS`` / ``SHARE_SUMMARY_TILES_DEFAULT_STATS``.
+Configured in ``explorer/core/share_summary_defaults.py`` (re-exported from ``defaults.py``) as ``SHARE_SUMMARY_HERO_DEFAULT_STATS`` / ``SHARE_SUMMARY_TILES_DEFAULT_STATS``.
 
 | Layout | Default stats (in order) |
 |--------|--------------------------|
@@ -134,7 +134,7 @@ All should appear in the summary row (with values) so users can pick interesting
 ### Colours
 
 - Current palette looks good for v1.
-- Schemes live in ``defaults.py`` → ``SHARE_SUMMARY_COLOR_SCHEMES`` (array of dicts: ``bg``, ``bg_alt``, ``text``, ``muted``, ``border``, ``accent``).
+- Schemes live in ``explorer/core/share_summary_defaults.py`` → ``SHARE_SUMMARY_COLOR_SCHEMES`` (array of dicts: ``bg``, ``bg_alt``, ``text``, ``muted``, ``border``, ``accent``).
 - Active scheme: ``SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT`` (flip index to test new schemes without code changes).
 - **No UI control** for colour schemes yet.
 - **Dark theme:** add a second entry to the array when a good palette exists; otherwise mark v2 with colour-scheme work.

--- a/docs/explorer/issue-157-social-summary-prototype.md
+++ b/docs/explorer/issue-157-social-summary-prototype.md
@@ -1,0 +1,162 @@
+# Issue #157 — Social media summary generator (prototype notes)
+
+> **Living tracker:** [`issue-157-share-summary-tracker.md`](issue-157-share-summary-tracker.md) — status, open questions, changelog.
+
+**Status:** exploratory / prototype branch (`157-social-summary-prototype`) — not intended to merge as-is.
+
+**Issue:** [Social Media Summary Generator (Year / Month Stats)](https://github.com/jimchurches/myebirdstuff/issues/157)
+
+---
+
+## What the issue asks for
+
+Generate **shareable graphics** from personal eBird data — especially year-end “birding year in review” cards for Instagram and similar platforms.
+
+**v1 scope (from issue):**
+
+- One layout template
+- Year summary only
+- Basic stats: species, checklists, locations, lifers
+- Static PNG download
+
+**Later:** month / custom range, multiple themes, map snapshot, top sightings, story vs post formats.
+
+---
+
+## What already exists in the app
+
+| Area | Location | Reuse potential |
+|------|----------|-----------------|
+| Yearly stats | `explorer/core/stats.py` → `yearly_summary_stats` | High — same numbers as Yearly Summary tab |
+| Payload | `explorer/core/checklist_stats_compute.py` | High — `ChecklistStatsPayload.yearly_rows` |
+| Map export | `explorer/presentation/leaflet_map_html_export.py` | Medium — HTML map export exists; PNG snapshot would be new |
+| Design utility pattern | `explorer/app/streamlit/design_map_app.py` | High — standalone Streamlit tool for tuning before shipping |
+
+There is **no** image generation library in `requirements.txt` today (no Pillow, matplotlib, or Playwright in runtime deps — Playwright is test-only).
+
+---
+
+## Prototype on this branch
+
+Run the layout explorer:
+
+```bash
+streamlit run explorer/app/streamlit/design_share_summary_app.py
+```
+
+Files:
+
+- `explorer/presentation/share_summary_preview.py` — stat extraction + HTML layout mockups
+- `explorer/app/streamlit/design_share_summary_app.py` — sidebar controls, sample or CSV data
+
+Three layout sketches:
+
+1. **Hero grid** — title + 2×2 big stat blocks (4 metrics)
+2. **Stat tiles** — up to 6 tiles in a flex grid
+3. **Minimal list** — typographic row layout
+
+Aspect ratios rendered at true pixel size then CSS-scaled:
+
+- **Square** 1080×1080 (Instagram post)
+- **Story** 1080×1920 (Instagram story)
+
+Palette aligns with checklist stats UI greys + a green accent placeholder (`#2d6a4f`).
+
+---
+
+## Implementation approaches (for discussion)
+
+### A. HTML + CSS → PNG (recommended for v1)
+
+**How:** Build self-contained HTML (like map export), render with headless Chromium (Playwright — already in test stack) or similar.
+
+**Pros:** Matches existing HTML export pattern; easy to iterate on layout in browser; WYSIWYG with the design app.
+
+**Cons:** Heavier dependency if added to runtime; font rendering consistency; Streamlit Cloud may need extra setup for headless Chrome.
+
+### B. Pillow / programmatic drawing
+
+**How:** Draw text and boxes with Pillow (or cairo).
+
+**Pros:** No browser; predictable PNG output; small dependency.
+
+**Cons:** Layout iteration is slower; wrapping/long labels awkward; doesn’t match Streamlit HTML styling automatically.
+
+### C. In-app preview only (no PNG initially)
+
+**How:** Show HTML card in Streamlit; user screenshots manually.
+
+**Pros:** Fastest path to validate design.
+
+**Cons:** Poor UX for the stated feature goal.
+
+**Suggestion:** Use **this prototype (HTML)** to pick a layout, then implement **A or B** on a separate branch. Playwright is attractive because tests already use it; alternatively Pillow if Cloud deployment is a concern.
+
+---
+
+## Stats to show — brainstorm
+
+**Strong candidates (issue + community norms):**
+
+| Stat | In yearly summary? | Notes |
+|------|-------------------|-------|
+| Total species | Yes | Core |
+| Lifers | Yes | Core |
+| Total checklists | Yes | Core |
+| Unique locations | Yes | Core |
+| Days with checklist | Yes | Good “effort” metric |
+| Total birding hours | Yes | If duration present in export |
+| Total bird families | Yes | Nice extra |
+| Countries visited | Country tab | Needs aggregation, not in yearly row today |
+| Top species / high counts | Rankings | v2 — needs “most observed” for period |
+| Map thumbnail | Map pipeline | v2 — filter GeoJSON by year, static snapshot |
+
+**Default v1 set (proposal):** species, lifers, checklists, locations — four numbers fit cleanly on a square card.
+
+---
+
+## Visual design — what’s realistic without a designer
+
+You don’t need complex illustration. Data-first cards work well:
+
+- Large numerals, short labels
+- Plenty of whitespace
+- One accent colour + neutrals (already in app)
+- Optional: small logo from `docs/explorer/assets/personal-ebird-explorer-logo.svg`
+- Footer: “Personal eBird Explorer” or custom title (“My 2025 birding year”)
+
+**Avoid for v1:** photos, charts, animations, multiple fonts, dense paragraphs.
+
+**Story format:** same stats stacked vertically with more breathing room; room for a map strip or “top 3 lifers” later.
+
+---
+
+## Suggested work breakdown
+
+| Phase | Branch (example) | Deliverable |
+|-------|------------------|-------------|
+| **0 — Prototype** | `157-social-summary-prototype` (this branch) | Design app + doc; pick layout |
+| **1 — Data API** | `157-share-summary-period-stats` | `share_summary_stats(period)` for year/month/range; unit tests |
+| **2 — PNG export** | `157-share-summary-png-export` | Download button; one layout + square |
+| **3 — Main app UI** | `157-share-summary-tab` | Year picker + download in Yearly Summary or new Share section |
+| **4 — Enhancements** | separate issues | Story format, themes, map, top species |
+
+Merge order: 1 → 2 → 3. Phase 0 may be closed without merging (or squash doc + minimal module if useful).
+
+---
+
+## Risks and assumptions
+
+- **Lifer definition** matches explorer yearly table (first sighting per species in dataset), not necessarily eBird official totals — same caveat as rest of app.
+- **PNG on Streamlit Cloud** — verify headless browser availability before committing to Playwright in production deps.
+- **Month / custom range** — needs new aggregation (yearly pipeline is calendar-year only today).
+- **Map snapshot** — reuses filtered GeoJSON + tile rendering; non-trivial and likely v2.
+
+---
+
+## Next step
+
+1. Run the design app with your own CSV.
+2. Note which layout and stat set feel right (or what to change).
+3. Decide PNG approach (Playwright vs Pillow).
+4. Open sub-issues or tasks for phases 1–3 above.

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -38,6 +38,13 @@ from explorer.core.settings_schema_defaults import (  # noqa: F401 — re-export
     MAP_HEIGHT_PX_MAX,
     MAP_HEIGHT_PX_MIN,
 )
+from explorer.core.share_summary_defaults import (  # noqa: F401 — re-export for Streamlit UI
+    SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT,
+    SHARE_SUMMARY_COLOR_SCHEMES,
+    SHARE_SUMMARY_HERO_DEFAULT_STATS,
+    SHARE_SUMMARY_TILES_DEFAULT_STATS,
+    SHARE_SUMMARY_SPOTLIGHT_STAT_DEFAULT,
+)
 
 # ---------------------------------------------------------------------------
 # Marker cluster — default “all locations” map (Leaflet.markercluster)
@@ -424,40 +431,8 @@ RANKINGS_BUNDLE_SCROLL_HINT_DEFAULT = "shading"
 # and family/world coverage tables.
 TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE = False
 
-# ---------------------------------------------------------------------------
-# Share summary cards (#157) — colour schemes (no UI picker yet)
-# ---------------------------------------------------------------------------
-
-# Index into :data:`SHARE_SUMMARY_COLOR_SCHEMES` used by card HTML previews / PNG export.
-SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT = 0
-
-# Each scheme: ``bg``, ``bg_alt``, ``text``, ``muted``, ``border``, ``accent``.
-# Add entries here to trial themes; flip ``SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT`` to test.
-SHARE_SUMMARY_COLOR_SCHEMES: tuple[dict[str, str], ...] = (
-    {
-        "id": "light",
-        "bg": "#ffffff",
-        "bg_alt": "#f9fafb",
-        "text": "#111827",
-        "muted": "#6b7280",
-        "border": "#e5e7eb",
-        "accent": "#2d6a4f",
-    },
-)
-
-# Default stat labels per layout (user-selectable stats planned for v1 integration).
-SHARE_SUMMARY_HERO_DEFAULT_STATS: tuple[str, ...] = (
-    "Total species",
-    "Lifers",
-    "Total checklists",
-    "Unique locations",
-)
-SHARE_SUMMARY_TILES_DEFAULT_STATS: tuple[str, ...] = SHARE_SUMMARY_HERO_DEFAULT_STATS + (
-    "Countries",
-    "Birding days",
-)
-SHARE_SUMMARY_SPOTLIGHT_STAT_DEFAULT = "lifers"
-
+# Share summary cards (#157): colour schemes and layout stat defaults — see
+# :mod:`explorer.core.share_summary_defaults` (re-exported above; no UI picker yet).
 
 def debug_defaults_enabled() -> list[str]:
     """Return names of debug toggles in this module that are currently ``True``.

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -424,6 +424,40 @@ RANKINGS_BUNDLE_SCROLL_HINT_DEFAULT = "shading"
 # and family/world coverage tables.
 TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE = False
 
+# ---------------------------------------------------------------------------
+# Share summary cards (#157) — colour schemes (no UI picker yet)
+# ---------------------------------------------------------------------------
+
+# Index into :data:`SHARE_SUMMARY_COLOR_SCHEMES` used by card HTML previews / PNG export.
+SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT = 0
+
+# Each scheme: ``bg``, ``bg_alt``, ``text``, ``muted``, ``border``, ``accent``.
+# Add entries here to trial themes; flip ``SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT`` to test.
+SHARE_SUMMARY_COLOR_SCHEMES: tuple[dict[str, str], ...] = (
+    {
+        "id": "light",
+        "bg": "#ffffff",
+        "bg_alt": "#f9fafb",
+        "text": "#111827",
+        "muted": "#6b7280",
+        "border": "#e5e7eb",
+        "accent": "#2d6a4f",
+    },
+)
+
+# Default stat labels per layout (user-selectable stats planned for v1 integration).
+SHARE_SUMMARY_HERO_DEFAULT_STATS: tuple[str, ...] = (
+    "Total species",
+    "Lifers",
+    "Total checklists",
+    "Unique locations",
+)
+SHARE_SUMMARY_TILES_DEFAULT_STATS: tuple[str, ...] = SHARE_SUMMARY_HERO_DEFAULT_STATS + (
+    "Countries",
+    "Birding days",
+)
+SHARE_SUMMARY_SPOTLIGHT_STAT_DEFAULT = "lifers"
+
 
 def debug_defaults_enabled() -> list[str]:
     """Return names of debug toggles in this module that are currently ``True``.

--- a/explorer/app/streamlit/design_share_summary_app.py
+++ b/explorer/app/streamlit/design_share_summary_app.py
@@ -1,0 +1,229 @@
+"""
+Social summary **design** utility — prototype layouts for #157.
+
+No integration with the main explorer app. Run from repo root::
+
+    pip install -r requirements.txt
+    streamlit run explorer/app/streamlit/design_share_summary_app.py
+
+Upload an eBird CSV or use sample data; compare layout mockups at square post,
+portrait post, and story aspect ratios. PNG export is not implemented yet.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date
+
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import pandas as pd
+import streamlit as st
+
+from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
+from explorer.core.data_loader import load_dataset
+from explorer.core.share_summary_compute import ShareSummaryStats
+from explorer.presentation.share_summary_preview import (
+    FormatId,
+    LayoutId,
+    SpotlightStatId,
+    _FORMAT_LABELS,
+    all_layout_previews_html,
+    compute_share_summary_stats,
+    period_for_custom,
+    period_for_month,
+    period_for_week_containing,
+    period_for_year,
+    render_share_summary_preview_html,
+    sample_share_summary_stats,
+    spotlight_stat_label,
+    summary_status_metrics,
+)
+
+st.set_page_config(page_title="Share summary design", layout="wide")
+st.title("Share summary — layout prototype (#157)")
+st.caption(
+    "Exploratory tool only. Compare HTML mockups before choosing layouts for the main app."
+)
+
+with st.sidebar:
+    st.header("Data")
+    use_sample = st.toggle("Use sample data", value=True)
+    uploaded = None if use_sample else st.file_uploader("eBird CSV export", type=["csv"])
+
+    st.header("Period")
+    period_mode = st.selectbox(
+        "Range",
+        options=["year", "month", "week", "custom"],
+        format_func=lambda x: {
+            "year": "Yearly",
+            "month": "Monthly",
+            "week": "Weekly",
+            "custom": "Custom date range (trip)",
+        }[x],
+    )
+
+    st.header("Output")
+    fmt: FormatId = st.selectbox(
+        "Aspect ratio",
+        options=["square", "portrait_post", "story"],
+        format_func=lambda x: _FORMAT_LABELS[x],
+    )
+    scale = st.slider("Preview scale", min_value=0.22, max_value=0.55, value=0.36, step=0.01)
+    selected_layout: LayoutId = st.selectbox(
+        "Focus layout",
+        options=["hero", "tiles", "minimal", "spotlight"],
+        format_func=lambda x: {
+            "hero": "Hero grid (4 stats)",
+            "tiles": "Stat tiles (6)",
+            "minimal": "Minimal list",
+            "spotlight": "Single stat spotlight",
+        }[x],
+    )
+    spotlight_stat: SpotlightStatId = st.selectbox(
+        "Spotlight stat",
+        options=["species", "lifers", "checklists", "locations"],
+        format_func=lambda x: spotlight_stat_label(x, period_mode),
+        disabled=selected_layout != "spotlight",
+        help="Choose which stat to highlight when Spotlight layout is selected.",
+    )
+
+df: pd.DataFrame | None = None
+stats: ShareSummaryStats = sample_share_summary_stats()
+world_bird_coverage_pct: float | None = 6.8
+
+if not use_sample:
+    if uploaded is None:
+        st.info("Upload an eBird CSV in the sidebar, or enable **Use sample data**.")
+        st.stop()
+    with st.spinner("Loading CSV…"):
+        df = load_dataset(uploaded)
+    if df is None or df.empty:
+        st.warning("No data found in this file.")
+        st.stop()
+else:
+    st.sidebar.markdown("---")
+    if period_mode == "year":
+        y = st.sidebar.number_input("Sample year", min_value=2000, max_value=2100, value=2025)
+        stats = sample_share_summary_stats(period_label=str(int(y)), period_kind="year")
+    elif period_mode == "month":
+        y = st.sidebar.number_input("Sample year", min_value=2000, max_value=2100, value=2025)
+        m = st.sidebar.number_input("Sample month", min_value=1, max_value=12, value=6)
+        stats = sample_share_summary_stats(
+            period_label=date(int(y), int(m), 1).strftime("%B %Y"),
+            period_kind="month",
+        )
+    elif period_mode == "week":
+        stats = sample_share_summary_stats(
+            period_label="May 31, 2025 - June 6, 2025",
+            period_kind="week",
+        )
+    else:
+        stats = sample_share_summary_stats(
+            period_label="1 – 7 June 2025",
+            period_kind="custom",
+            trip_title="North Coast NSW Exploration",
+        )
+
+if df is not None:
+    dates = pd.to_datetime(df["Date"], errors="coerce").dropna()
+    if dates.empty:
+        st.warning("No dated checklists in this file.")
+        st.stop()
+    min_d = dates.min().date()
+    max_d = dates.max().date()
+
+    if period_mode == "year":
+        years = sorted({int(y) for y in dates.dt.year.unique()})
+        year = st.sidebar.selectbox("Year", options=years, index=len(years) - 1)
+        period = period_for_year(year)
+    elif period_mode == "month":
+        month_options = sorted({(int(r.year), int(r.month)) for r in dates.dt.to_pydatetime()})
+        labels = [date(y, m, 1).strftime("%B %Y") for y, m in month_options]
+        pick = st.sidebar.selectbox("Month", options=range(len(labels)), format_func=lambda i: labels[i])
+        y, m = month_options[pick]
+        period = period_for_month(y, m)
+    elif period_mode == "week":
+        from explorer.core.share_summary_compute import _week_sun_sat_containing
+
+        week_starts = sorted({_week_sun_sat_containing(d)[0] for d in dates.dt.date})
+        week_labels = [
+            period_for_week_containing(ws).label for ws in week_starts
+        ]
+        pick = st.sidebar.selectbox("Week", options=range(len(week_labels)), format_func=lambda i: week_labels[i])
+        period = period_for_week_containing(week_starts[pick])
+    else:
+        start = st.sidebar.date_input("Start date", value=min_d, min_value=min_d, max_value=max_d)
+        end = st.sidebar.date_input("End date", value=max_d, min_value=min_d, max_value=max_d)
+        trip_title = st.sidebar.text_input(
+            "Trip title (optional)",
+            value="",
+            placeholder="e.g. North Coast NSW Exploration",
+        )
+        period = period_for_custom(start, end, trip_title=trip_title.strip() or None)
+
+    computed = compute_share_summary_stats(df, period)
+    if computed is None:
+        st.warning("Could not compute stats for this period.")
+        st.stop()
+    stats = computed
+    try:
+        from explorer.app.streamlit.bird_families_streamlit_html import (
+            build_group_coverage_tables,
+            compute_world_species_coverage,
+        )
+
+        _summary, detail = build_group_coverage_tables(df, TAXONOMY_LOCALE_DEFAULT)
+        if not detail.empty:
+            _, _, world_bird_coverage_pct = compute_world_species_coverage(detail)
+        else:
+            world_bird_coverage_pct = None
+    except Exception:
+        world_bird_coverage_pct = None
+
+status_metrics = summary_status_metrics(stats, world_bird_coverage_pct=world_bird_coverage_pct)
+
+if stats.trip_title:
+    st.subheader(stats.trip_title)
+    st.caption(stats.period_label)
+else:
+    st.subheader(f"Stats — {stats.period_label}")
+cols = st.columns(4)
+for i, (label, value) in enumerate(status_metrics):
+    cols[i % 4].metric(label, value)
+
+st.divider()
+st.subheader("Focused layout")
+st.markdown(
+    render_share_summary_preview_html(
+        stats,
+        layout=selected_layout,
+        fmt=fmt,
+        scale=scale,
+        spotlight_stat=spotlight_stat,
+    ),
+    unsafe_allow_html=True,
+)
+
+st.divider()
+st.subheader("All layouts")
+previews = all_layout_previews_html(stats, fmt=fmt, scale=scale, spotlight_stat=spotlight_stat)
+layout_cols = st.columns(4)
+labels = {
+    "hero": "Hero grid",
+    "tiles": "Stat tiles",
+    "minimal": "Minimal list",
+    "spotlight": "Spotlight",
+}
+for col, (layout_id, html) in zip(layout_cols, previews.items()):
+    with col:
+        st.markdown(f"**{labels[layout_id]}**")
+        st.markdown(html, unsafe_allow_html=True)
+
+st.divider()
+st.caption(
+    "Living design notes: `docs/explorer/issue-157-share-summary-tracker.md`"
+)

--- a/explorer/app/streamlit/design_share_summary_app.py
+++ b/explorer/app/streamlit/design_share_summary_app.py
@@ -147,9 +147,7 @@ if df is not None:
         y, m = month_options[pick]
         period = period_for_month(y, m)
     elif period_mode == "week":
-        from explorer.core.share_summary_compute import _week_sun_sat_containing
-
-        week_starts = sorted({_week_sun_sat_containing(d)[0] for d in dates.dt.date})
+        week_starts = sorted({period_for_week_containing(d).start for d in dates.dt.date})
         week_labels = [
             period_for_week_containing(ws).label for ws in week_starts
         ]

--- a/explorer/core/share_summary_compute.py
+++ b/explorer/core/share_summary_compute.py
@@ -1,0 +1,265 @@
+"""
+Period-scoped stats for share-summary graphics (#157).
+
+Computes the same headline metrics as yearly summary rows, but for an arbitrary
+inclusive date window (year, month, ISO week, or custom trip range).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Literal
+
+import pandas as pd
+
+from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
+from explorer.core.species_family import build_base_species_to_family_map
+from explorer.core.species_logic import countable_species_vectorized
+from explorer.core.stats import checklist_country_keys, longest_streak, safe_count
+
+PeriodKind = Literal["year", "month", "week", "custom"]
+
+
+def _fmt_short_date(d: date) -> str:
+    """Portable short date (e.g. ``5 Jan 2025``)."""
+    return d.strftime("%d %b %Y").lstrip("0")
+
+
+def format_us_date_range(start: date, end: date) -> str:
+    """Long-form date range for weekly titles (e.g. ``May 31, 2026 - June 6, 2026``)."""
+    if end < start:
+        start, end = end, start
+    if start == end:
+        return _fmt_us_long_date(start)
+    return f"{_fmt_us_long_date(start)} - {_fmt_us_long_date(end)}"
+
+
+def _fmt_us_long_date(d: date) -> str:
+    """``May 31, 2026`` — full month name, no zero-padded day."""
+    return d.strftime("%B %d, %Y").replace(" 0", " ")
+
+
+def format_custom_date_range(start: date, end: date) -> str:
+    """Compact date range for trip cards (e.g. ``1 – 7 June 2025``, ``6 May – 12 May 2025``)."""
+    if end < start:
+        start, end = end, start
+    if start == end:
+        return _fmt_short_date(start)
+    if start.year == end.year and start.month == end.month:
+        month_year = start.strftime("%B %Y")
+        return f"{start.day} – {end.day} {month_year}"
+    if start.year == end.year:
+        return f"{start.day} {start.strftime('%b')} – {end.day} {end.strftime('%b %Y')}"
+    return f"{_fmt_short_date(start)} – {_fmt_short_date(end)}"
+
+
+@dataclass(frozen=True)
+class ShareSummaryPeriod:
+    """Inclusive calendar period for share-summary stats."""
+
+    kind: PeriodKind
+    start: date
+    end: date
+    label: str
+    trip_title: str | None = None
+
+    @property
+    def start_ts(self) -> pd.Timestamp:
+        return pd.Timestamp(self.start)
+
+    @property
+    def end_ts(self) -> pd.Timestamp:
+        return pd.Timestamp(self.end) + pd.Timedelta(days=1) - pd.Timedelta(microseconds=1)
+
+
+def period_for_year(year: int) -> ShareSummaryPeriod:
+    start = date(int(year), 1, 1)
+    end = date(int(year), 12, 31)
+    return ShareSummaryPeriod(kind="year", start=start, end=end, label=str(year))
+
+
+def period_for_month(year: int, month: int) -> ShareSummaryPeriod:
+    start = date(int(year), int(month), 1)
+    if month == 12:
+        end = date(int(year), 12, 31)
+    else:
+        end = date(int(year), int(month) + 1, 1) - timedelta(days=1)
+    label = start.strftime("%B %Y")
+    return ShareSummaryPeriod(kind="month", start=start, end=end, label=label)
+
+
+def _week_sun_sat_containing(day: date) -> tuple[date, date]:
+    """Inclusive Sun–Sat week containing *day*."""
+    days_since_sunday = (day.weekday() + 1) % 7
+    start = day - timedelta(days=days_since_sunday)
+    return start, start + timedelta(days=6)
+
+
+def period_for_week_containing(day: date) -> ShareSummaryPeriod:
+    """Calendar week Sun–Sat containing *day*; label is a long US-style date range."""
+    start, end = _week_sun_sat_containing(day)
+    return ShareSummaryPeriod(
+        kind="week",
+        start=start,
+        end=end,
+        label=format_us_date_range(start, end),
+    )
+
+
+def period_for_iso_week(year: int, week: int) -> ShareSummaryPeriod:
+    """Deprecated alias — use :func:`period_for_week_containing` (Sun–Sat weeks)."""
+    return period_for_week_containing(date.fromisocalendar(int(year), int(week), 1))
+
+
+def period_for_custom(
+    start: date,
+    end: date,
+    *,
+    trip_title: str | None = None,
+    label: str | None = None,
+) -> ShareSummaryPeriod:
+    """Custom inclusive date range; optional *trip_title* shown on the card above stats.
+
+    *label* is a deprecated alias for *trip_title* (kept for callers that used the old name).
+    """
+    if end < start:
+        start, end = end, start
+    title = (trip_title or label or "").strip() or None
+    date_label = format_custom_date_range(start, end)
+    return ShareSummaryPeriod(
+        kind="custom",
+        start=start,
+        end=end,
+        label=date_label,
+        trip_title=title,
+    )
+
+
+@dataclass(frozen=True)
+class ShareSummaryStats:
+    """Headline stats for one share-summary period."""
+
+    period_label: str
+    period_kind: PeriodKind
+    trip_title: str | None = None
+    species: int | None = None
+    families: int | None = None
+    individuals: int | None = None
+    checklists: int | None = None
+    locations: int | None = None
+    lifers: int | None = None
+    birding_hours: float | None = None
+    days_with_checklist: int | None = None
+    longest_streak: int | None = None
+    countries: int | None = None
+
+
+def _countries_in_period(cl: pd.DataFrame) -> int | None:
+    """Distinct countries with checklists in *cl* (same keys as Country tab)."""
+    if cl.empty:
+        return None
+    if "Country" not in cl.columns and "State/Province" not in cl.columns:
+        return None
+    keys = checklist_country_keys(cl)
+    known = keys[(keys != "_UNKNOWN") & keys.notna()]
+    if known.empty:
+        return None
+    return int(known.nunique())
+
+
+def _mask_in_period(dates: pd.Series, period: ShareSummaryPeriod) -> pd.Series:
+    ts = pd.to_datetime(dates, errors="coerce")
+    return ts.notna() & (ts >= period.start_ts) & (ts <= period.end_ts)
+
+
+def compute_share_summary_stats(
+    df: pd.DataFrame,
+    period: ShareSummaryPeriod,
+    *,
+    taxonomy_locale: str | None = None,
+) -> ShareSummaryStats | None:
+    """Compute headline share stats for *period* from a sighting-level export frame."""
+    if df.empty or "Date" not in df.columns:
+        return None
+
+    cl = df.drop_duplicates(subset=["Submission ID"]).copy()
+    cl["Date"] = pd.to_datetime(cl["Date"], errors="coerce")
+    cl = cl.dropna(subset=["Date"])
+    if cl.empty:
+        return None
+
+    in_period_cl = cl[_mask_in_period(cl["Date"], period)]
+    if in_period_cl.empty:
+        return ShareSummaryStats(
+            period_label=period.label,
+            period_kind=period.kind,
+            trip_title=period.trip_title,
+        )
+
+    df_all = df.copy()
+    df_all["Date"] = pd.to_datetime(df_all["Date"], errors="coerce")
+    in_period_df = df_all[_mask_in_period(df_all["Date"], period)]
+
+    sp = countable_species_vectorized(in_period_df)
+    in_period_df = in_period_df.assign(_base=sp, _count=in_period_df["Count"].apply(safe_count))
+
+    species = int(in_period_df["_base"].dropna().nunique()) if not in_period_df.empty else 0
+    individuals = int(in_period_df["_count"].sum()) if not in_period_df.empty else 0
+    checklists = int(len(in_period_cl))
+    locations = int(in_period_cl["Location ID"].nunique()) if "Location ID" in in_period_cl.columns else None
+
+    # Lifers: first checklist date for each species in the full dataset falls in period.
+    lifers = None
+    base_all = countable_species_vectorized(df_all.dropna(subset=["Date"]))
+    lifer_df = df_all.dropna(subset=["Date"]).assign(_base=base_all).dropna(subset=["_base"])
+    if not lifer_df.empty:
+        first_seen = lifer_df.groupby("_base")["Date"].min()
+        first_in_period = first_seen[_mask_in_period(first_seen, period)]
+        lifers = int(len(first_in_period))
+
+    families = None
+    loc = (taxonomy_locale or "").strip() or TAXONOMY_LOCALE_DEFAULT
+    base_to_family = build_base_species_to_family_map(loc)
+    if base_to_family and not in_period_df.empty:
+        fam_df = in_period_df.dropna(subset=["_base"]).copy()
+        fam_df["_family"] = fam_df["_base"].astype(str).str.strip().map(base_to_family)
+        families = int(fam_df.dropna(subset=["_family"])["_family"].nunique())
+
+    birding_hours = None
+    dur_col = "Duration (Min)" if "Duration (Min)" in cl.columns else None
+    if dur_col:
+        timed = in_period_cl.dropna(subset=[dur_col]).copy()
+        if "Protocol" in timed.columns:
+            proto = timed["Protocol"].astype(str).str.strip().str.lower()
+            excl = proto.str.contains("incidental|historical|casual observation", na=False, regex=True)
+            timed = timed[~excl]
+        if not timed.empty:
+            mins = pd.to_numeric(timed[dur_col], errors="coerce").fillna(0).sum()
+            birding_hours = float(mins) / 60.0
+
+    days = int(in_period_cl["Date"].dt.normalize().nunique())
+
+    longest_streak_days = None
+    if period.kind in ("year", "month"):
+        unique_dates = in_period_cl["Date"].dt.normalize().unique()
+        streak_val, *_ = longest_streak(unique_dates, in_period_cl)
+        longest_streak_days = int(streak_val)
+
+    countries = _countries_in_period(in_period_cl)
+
+    return ShareSummaryStats(
+        period_label=period.label,
+        period_kind=period.kind,
+        trip_title=period.trip_title,
+        species=species,
+        lifers=lifers,
+        checklists=checklists,
+        locations=locations,
+        families=families,
+        individuals=individuals,
+        days_with_checklist=days,
+        birding_hours=birding_hours,
+        longest_streak=longest_streak_days,
+        countries=countries,
+    )

--- a/explorer/core/share_summary_defaults.py
+++ b/explorer/core/share_summary_defaults.py
@@ -1,0 +1,38 @@
+"""
+Default colour schemes and stat selections for share-summary cards (#157).
+
+Framework-neutral: no Streamlit imports. Presentation and PNG export read from here;
+``explorer.app.streamlit.defaults`` re-exports these for developer tuning.
+"""
+
+from __future__ import annotations
+
+# Index into :data:`SHARE_SUMMARY_COLOR_SCHEMES` used by card HTML previews / PNG export.
+SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT = 0
+
+# Each scheme: ``bg``, ``bg_alt``, ``text``, ``muted``, ``border``, ``accent``.
+# Add entries here to trial themes; flip ``SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT`` to test.
+SHARE_SUMMARY_COLOR_SCHEMES: tuple[dict[str, str], ...] = (
+    {
+        "id": "light",
+        "bg": "#ffffff",
+        "bg_alt": "#f9fafb",
+        "text": "#111827",
+        "muted": "#6b7280",
+        "border": "#e5e7eb",
+        "accent": "#2d6a4f",
+    },
+)
+
+# Default stat labels per layout (user-selectable stats planned for v1 integration).
+SHARE_SUMMARY_HERO_DEFAULT_STATS: tuple[str, ...] = (
+    "Total species",
+    "Lifers",
+    "Total checklists",
+    "Unique locations",
+)
+SHARE_SUMMARY_TILES_DEFAULT_STATS: tuple[str, ...] = SHARE_SUMMARY_HERO_DEFAULT_STATS + (
+    "Countries",
+    "Birding days",
+)
+SHARE_SUMMARY_SPOTLIGHT_STAT_DEFAULT = "lifers"

--- a/explorer/presentation/share_summary_preview.py
+++ b/explorer/presentation/share_summary_preview.py
@@ -251,11 +251,31 @@ def _yearly_row_lookup(
     return out
 
 
+def _countries_in_year_from_payload(payload: ChecklistStatsPayload, year: int) -> int | None:
+    """Count countries with checklists in *year* (from Country tab payload blocks)."""
+    sections = payload.country_sections or []
+    if not sections:
+        return None
+    count = 0
+    for country_key, years, _rows in sections:
+        if not country_key or country_key == "_UNKNOWN" or not years:
+            continue
+        if year in years:
+            count += 1
+    return count if count > 0 else None
+
+
 def share_summary_stats_for_year(
     payload: ChecklistStatsPayload,
     year: int,
 ) -> ShareSummaryStats | None:
-    """Extract summary stats for one calendar year from a checklist stats payload."""
+    """Extract summary stats for one calendar year from a checklist stats payload.
+
+    Reads the Yearly Summary table rows in *payload* plus country blocks for
+    **Countries**. ``longest_streak`` is left ``None`` here — yearly rows do not
+    include per-year streak; use :func:`compute_share_summary_stats` with
+    :func:`period_for_year` when a full year card is needed from raw CSV data.
+    """
     years = list(payload.years_list or [])
     if year not in years:
         return None
@@ -285,6 +305,7 @@ def share_summary_stats_for_year(
         individuals=_int("Total individuals"),
         days_with_checklist=_int("Days with checklist"),
         birding_hours=_float("Total birding hours"),
+        countries=_countries_in_year_from_payload(payload, year),
     )
 
 

--- a/explorer/presentation/share_summary_preview.py
+++ b/explorer/presentation/share_summary_preview.py
@@ -24,7 +24,7 @@ from explorer.core.share_summary_compute import (
     period_for_year,
 )
 
-from explorer.app.streamlit.defaults import (
+from explorer.core.share_summary_defaults import (
     SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT,
     SHARE_SUMMARY_COLOR_SCHEMES,
     SHARE_SUMMARY_HERO_DEFAULT_STATS,

--- a/explorer/presentation/share_summary_preview.py
+++ b/explorer/presentation/share_summary_preview.py
@@ -1,0 +1,629 @@
+"""
+HTML layout prototypes for social-media-style birding summaries (#157).
+
+Standalone design utility — not wired into the main explorer app yet.
+"""
+
+from __future__ import annotations
+
+import html as html_module
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable, Literal
+
+from explorer.core.checklist_stats_compute import ChecklistStatsPayload
+from explorer.core.share_summary_compute import (
+    PeriodKind,
+    ShareSummaryStats,
+    compute_share_summary_stats,
+    period_for_custom,
+    period_for_iso_week,
+    period_for_month,
+    period_for_week_containing,
+    period_for_year,
+)
+
+from explorer.app.streamlit.defaults import (
+    SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT,
+    SHARE_SUMMARY_COLOR_SCHEMES,
+    SHARE_SUMMARY_HERO_DEFAULT_STATS,
+    SHARE_SUMMARY_TILES_DEFAULT_STATS,
+    SHARE_SUMMARY_SPOTLIGHT_STAT_DEFAULT,
+)
+
+LayoutId = Literal["hero", "tiles", "minimal", "spotlight"]
+FormatId = Literal["square", "portrait_post", "story"]
+SpotlightStatId = Literal["species", "lifers", "checklists", "locations"]
+
+
+def _colour(key: str) -> str:
+    schemes = SHARE_SUMMARY_COLOR_SCHEMES
+    idx = SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT
+    scheme = schemes[idx] if 0 <= idx < len(schemes) else schemes[0]
+    return scheme[key]
+
+
+_FORMAT_PX: dict[FormatId, tuple[int, int]] = {
+    "square": (1080, 1080),
+    "portrait_post": (1080, 1350),
+    "story": (1080, 1920),
+}
+
+_FORMAT_LABELS: dict[FormatId, str] = {
+    "square": "Square post (1080×1080)",
+    "portrait_post": "Portrait post (1080×1350)",
+    "story": "Story (1080×1920)",
+}
+
+_STAT_LABELS: dict[str, str] = {
+    "species": "Total species",
+    "families": "Total bird families",
+    "individuals": "Total individuals",
+    "checklists": "Total checklists",
+    "locations": "Unique locations",
+    "lifers": "Lifers",
+    "birding_hours": "Total birding hours",
+    "days_with_checklist": "Birding days",
+    "longest_streak": "Longest streak",
+    "countries": "Countries",
+}
+
+_SPOTLIGHT_TITLES: dict[SpotlightStatId, str] = {
+    "lifers": "Lifers",
+    "checklists": "Checklists",
+    "locations": "Locations visited",
+}
+
+
+def spotlight_species_label(period_kind: PeriodKind) -> str:
+    """Spotlight label for species count — matches selected period."""
+    if period_kind == "year":
+        return "Year birds"
+    if period_kind == "month":
+        return "Month birds"
+    if period_kind == "week":
+        return "Week birds"
+    return "Species"
+
+
+def spotlight_stat_label(stat: SpotlightStatId, period_kind: PeriodKind) -> str:
+    """Human label for a spotlight stat (sidebar + card)."""
+    if stat == "species":
+        return spotlight_species_label(period_kind)
+    return _SPOTLIGHT_TITLES[stat]
+
+_YEARLY_ICON_RE = re.compile(
+    r'\s*<span class="stats-info-icon">.*?</span>',
+    flags=re.DOTALL,
+)
+
+_LOGO_PATH = Path(__file__).resolve().parents[2] / "docs" / "explorer" / "assets" / "personal-ebird-explorer-logo.svg"
+
+
+@lru_cache(maxsize=1)
+def _logo_svg_inline(*, height_px: int = 56, accent: bool = True) -> str:
+    """Small inline logo for card headers/footers."""
+    if not _LOGO_PATH.is_file():
+        return ""
+    raw = _LOGO_PATH.read_text(encoding="utf-8")
+    fill = _colour("accent") if accent else _colour("muted")
+    raw = raw.replace('fill="#000000"', f'fill="{fill}"')
+    return (
+        f'<img src="data:image/svg+xml;base64,{_svg_to_data_uri(raw)}" '
+        f'alt="" style="height:{height_px}px;width:auto;display:block;margin:0 auto;" />'
+    )
+
+
+def _svg_to_data_uri(svg: str) -> str:
+    import base64
+
+    return base64.b64encode(svg.encode("utf-8")).decode("ascii")
+
+
+def stat_pairs(stats: ShareSummaryStats) -> list[tuple[str, str]]:
+    """Ordered (label, display value) pairs for layouts; skips missing stats."""
+    raw: list[tuple[str, int | float | None, str]] = [
+        ("species", stats.species, "species"),
+        ("lifers", stats.lifers, "lifers"),
+        ("checklists", stats.checklists, "checklists"),
+        ("locations", stats.locations, "locations"),
+        ("families", stats.families, "families"),
+        ("individuals", stats.individuals, "individuals"),
+        ("days_with_checklist", stats.days_with_checklist, "birding_days"),
+        ("countries", stats.countries, "countries"),
+        ("longest_streak", stats.longest_streak, "streak"),
+        ("birding_hours", stats.birding_hours, "hours"),
+    ]
+    out: list[tuple[str, str]] = []
+    for key, val, fmt in raw:
+        if val is None:
+            continue
+        if fmt == "hours":
+            display = f"{val:,.1f}" if val else "—"
+            label = "Birding hours"
+        elif fmt == "birding_days":
+            display = f"{int(val):,}"
+            label = "Birding days"
+        elif fmt == "countries":
+            display = f"{int(val):,}"
+            label = "Countries"
+        elif fmt == "streak":
+            display = f"{int(val):,}"
+            label = "Longest streak (days)"
+        else:
+            display = f"{int(val):,}"
+            label = _STAT_LABELS.get(key, key.replace("_", " ").title())
+        out.append((label, display))
+    return out
+
+
+def summary_status_metrics(
+    stats: ShareSummaryStats,
+    *,
+    world_bird_coverage_pct: float | None = None,
+) -> list[tuple[str, str]]:
+    """Metrics row above card previews (period stats + optional global coverage).
+
+    World bird coverage is **not** included on card tiles — status row only until layout TBD.
+    """
+    pairs = list(stat_pairs(stats))
+    if world_bird_coverage_pct is not None:
+        pairs.append(("World bird coverage", f"{world_bird_coverage_pct:.1f}%"))
+    return pairs
+
+
+def card_stat_pairs(
+    stats: ShareSummaryStats,
+    *,
+    max_count: int,
+    layout: LayoutId | None = None,
+) -> list[tuple[str, str]]:
+    """Stats for share cards — layout defaults first, then any remaining computed stats."""
+    all_p = stat_pairs(stats)
+    lookup = {label: value for label, value in all_p}
+
+    if layout == "hero":
+        preferred = SHARE_SUMMARY_HERO_DEFAULT_STATS
+    elif layout in ("tiles", "minimal"):
+        preferred = SHARE_SUMMARY_TILES_DEFAULT_STATS
+    elif max_count <= 4:
+        preferred = SHARE_SUMMARY_HERO_DEFAULT_STATS
+    else:
+        preferred = SHARE_SUMMARY_TILES_DEFAULT_STATS
+
+    labels: list[str] = []
+    for lab in preferred:
+        if lab in lookup and lab not in labels:
+            labels.append(lab)
+    for lab, _ in all_p:
+        if lab not in labels:
+            labels.append(lab)
+
+    return [(lab, lookup[lab]) for lab in labels[:max_count]]
+
+
+def spotlight_value(stats: ShareSummaryStats, stat: SpotlightStatId) -> tuple[str, str] | None:
+    """Return (title, display value) for single-stat spotlight cards."""
+    values: dict[SpotlightStatId, int | None] = {
+        "species": stats.species,
+        "lifers": stats.lifers,
+        "checklists": stats.checklists,
+        "locations": stats.locations,
+    }
+    val = values[stat]
+    if val is None:
+        return None
+    title = spotlight_stat_label(stat, stats.period_kind)
+    return title, f"{int(val):,}"
+
+
+def _strip_yearly_label(label: str) -> str:
+    return _YEARLY_ICON_RE.sub("", label or "").strip()
+
+
+def _parse_display_int(cell: str) -> int | None:
+    s = (cell or "").strip().replace(",", "")
+    if not s or s == "—":
+        return None
+    try:
+        return int(float(s))
+    except ValueError:
+        return None
+
+
+def _parse_display_float(cell: str) -> float | None:
+    s = (cell or "").strip().replace(",", "")
+    if not s or s == "—":
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def _yearly_row_lookup(
+    yearly_rows: Iterable[tuple[str, list[str]]],
+) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    for label, vals in yearly_rows:
+        out[_strip_yearly_label(label)] = list(vals)
+    return out
+
+
+def share_summary_stats_for_year(
+    payload: ChecklistStatsPayload,
+    year: int,
+) -> ShareSummaryStats | None:
+    """Extract summary stats for one calendar year from a checklist stats payload."""
+    years = list(payload.years_list or [])
+    if year not in years:
+        return None
+    idx = years.index(year)
+    rows = _yearly_row_lookup(payload.yearly_rows or [])
+
+    def _int(label: str) -> int | None:
+        vals = rows.get(label)
+        if not vals or idx >= len(vals):
+            return None
+        return _parse_display_int(vals[idx])
+
+    def _float(label: str) -> float | None:
+        vals = rows.get(label)
+        if not vals or idx >= len(vals):
+            return None
+        return _parse_display_float(vals[idx])
+
+    return ShareSummaryStats(
+        period_label=str(year),
+        period_kind="year",
+        species=_int("Total species"),
+        lifers=_int("Lifers"),
+        checklists=_int("Total checklists"),
+        locations=_int("Unique locations"),
+        families=_int("Total bird families"),
+        individuals=_int("Total individuals"),
+        days_with_checklist=_int("Days with checklist"),
+        birding_hours=_float("Total birding hours"),
+    )
+
+
+def sample_share_summary_stats(
+    *,
+    period_label: str = "2025",
+    period_kind: PeriodKind = "year",
+    trip_title: str | None = None,
+) -> ShareSummaryStats:
+    """Dummy stats for layout tuning without eBird data."""
+    # Illustrative counts per period so previews change when toggling range in sample mode.
+    demo: dict[PeriodKind, dict[str, int | float]] = {
+        "year": {
+            "species": 312,
+            "lifers": 47,
+            "checklists": 186,
+            "locations": 42,
+            "families": 89,
+            "individuals": 12_450,
+            "days_with_checklist": 98,
+            "birding_hours": 214.5,
+            "longest_streak": 14,
+            "countries": 5,
+        },
+        "week": {
+            "species": 34,
+            "lifers": 2,
+            "checklists": 6,
+            "locations": 4,
+            "families": 28,
+            "individuals": 420,
+            "days_with_checklist": 5,
+            "birding_hours": 12.0,
+            "countries": 2,
+        },
+        "month": {
+            "species": 89,
+            "lifers": 8,
+            "checklists": 22,
+            "locations": 11,
+            "families": 45,
+            "individuals": 1_840,
+            "days_with_checklist": 14,
+            "birding_hours": 38.5,
+            "longest_streak": 5,
+            "countries": 3,
+        },
+        "custom": {
+            "species": 56,
+            "lifers": 3,
+            "checklists": 8,
+            "locations": 6,
+            "families": 32,
+            "individuals": 680,
+            "days_with_checklist": 7,
+            "birding_hours": 18.0,
+            "countries": 2,
+        },
+    }
+    d = demo.get(period_kind, demo["year"])
+    return ShareSummaryStats(
+        period_label=period_label,
+        period_kind=period_kind,
+        trip_title=trip_title,
+        species=int(d["species"]),
+        lifers=int(d["lifers"]),
+        checklists=int(d["checklists"]),
+        locations=int(d["locations"]),
+        families=int(d["families"]),
+        individuals=int(d["individuals"]),
+        days_with_checklist=int(d["days_with_checklist"]),
+        birding_hours=float(d["birding_hours"]),
+        longest_streak=int(d["longest_streak"]) if "longest_streak" in d else None,
+        countries=int(d["countries"]) if "countries" in d else None,
+    )
+
+
+def _esc(text: Any) -> str:
+    return html_module.escape(str(text), quote=False)
+
+
+def _is_tall(fmt: FormatId, width: int, height: int) -> bool:
+    return height > width
+
+
+def _footer_pad(fmt: FormatId, width: int, height: int) -> int:
+    if fmt == "story":
+        return 140
+    if fmt == "portrait_post":
+        return 120
+    return 80
+
+
+def _card_shell(
+    *,
+    width: int,
+    height: int,
+    inner_html: str,
+    scale: float = 0.38,
+) -> str:
+    """Fixed-size card scaled down for in-browser preview."""
+    display_w = int(width * scale)
+    display_h = int(height * scale)
+    return f"""
+<div class="pebird-share-preview-wrap" style="
+  width:{display_w}px;height:{display_h}px;overflow:hidden;margin:0 auto 16px;
+  border:1px solid {_colour("border")};border-radius:8px;background:{_colour("bg_alt")};
+  box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+  <div style="
+    width:{width}px;height:{height}px;overflow:hidden;
+    transform:scale({scale});transform-origin:top left;
+    font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+    background:{_colour("bg")};color:{_colour("text")};box-sizing:border-box;">
+    {inner_html}
+  </div>
+</div>"""
+
+
+def _subtitle_for_period(stats: ShareSummaryStats) -> str:
+    if stats.trip_title:
+        return stats.trip_title
+    if stats.period_kind == "year":
+        return "Birding year in review"
+    if stats.period_kind == "month":
+        return "Monthly birding summary"
+    if stats.period_kind == "week":
+        return "Weekly birding summary"
+    return "Birding summary"
+
+
+def _headline_for_period(stats: ShareSummaryStats) -> str:
+    return stats.period_label
+
+
+def _header_block(stats: ShareSummaryStats, *, subtitle: str | None = None) -> str:
+    sub = subtitle if subtitle is not None else _subtitle_for_period(stats)
+    headline = _headline_for_period(stats)
+    title_size = "96px" if len(headline) <= 5 else ("64px" if len(headline) > 28 else "72px")
+    sub_style = (
+        f"margin:0 0 8px;font-size:28px;letter-spacing:0.08em;text-transform:uppercase;"
+        f"color:{_colour('accent')};font-weight:600;"
+    )
+    return f"""
+<div style="padding:48px 56px 24px;text-align:center;">
+  <p style="{sub_style}">{_esc(sub)}</p>
+  <h1 style="margin:0;font-size:{title_size};font-weight:700;line-height:1.08;">{_esc(headline)}</h1>
+</div>"""
+
+
+def _footer_block() -> str:
+    logo = _logo_svg_inline(height_px=40, accent=False)
+    logo_row = logo if logo else ""
+    return f"""
+<div style="position:absolute;left:0;right:0;bottom:0;padding:24px 56px 28px;text-align:center;
+  border-top:1px solid {_colour("border")};background:{_colour("bg_alt")};">
+  {logo_row}
+  <p style="margin:8px 0 0;font-size:20px;color:{_colour("muted")};">Personal eBird Explorer</p>
+</div>"""
+
+
+def _layout_hero(stats: ShareSummaryStats, width: int, height: int, fmt: FormatId) -> str:
+    pairs = card_stat_pairs(stats, max_count=4, layout="hero")
+    cells = []
+    for label, value in pairs:
+        cells.append(f"""
+<div style="flex:1;min-width:40%;padding:28px 24px;border:1px solid {_colour("border")};
+  border-radius:16px;background:{_colour("bg_alt")};text-align:center;">
+  <div style="font-size:64px;font-weight:700;line-height:1.1;">{_esc(value)}</div>
+  <div style="margin-top:12px;font-size:24px;color:{_colour("muted")};">{_esc(label)}</div>
+</div>""")
+    pad_bottom = _footer_pad(fmt, width, height)
+    return f"""
+<div style="position:relative;width:100%;height:100%;box-sizing:border-box;">
+  {_header_block(stats)}
+  <div style="display:flex;flex-wrap:wrap;gap:24px;padding:16px 56px {pad_bottom}px;justify-content:center;">
+    {''.join(cells)}
+  </div>
+  {_footer_block()}
+</div>"""
+
+
+def _layout_subtitle(stats: ShareSummaryStats, layout_default: str) -> str | None:
+    """Layout-specific green subtitle; trip title wins on custom ranges."""
+    if stats.trip_title:
+        return None
+    return layout_default
+
+
+def _layout_tiles(stats: ShareSummaryStats, width: int, height: int, fmt: FormatId) -> str:
+    pairs = card_stat_pairs(stats, max_count=6, layout="tiles")
+    cells = []
+    for label, value in pairs:
+        cells.append(f"""
+<div style="flex:1 1 30%;min-width:28%;padding:32px 20px;border-radius:12px;
+  background:linear-gradient(145deg,{_colour("bg_alt")},{_colour("bg")});
+  border:1px solid {_colour("border")};text-align:center;">
+  <div style="font-size:52px;font-weight:700;">{_esc(value)}</div>
+  <div style="margin-top:8px;font-size:20px;color:{_colour("muted")};">{_esc(label)}</div>
+</div>""")
+    pad_bottom = _footer_pad(fmt, width, height)
+    return f"""
+<div style="position:relative;width:100%;height:100%;box-sizing:border-box;">
+  {_header_block(stats, subtitle=_layout_subtitle(stats, "My birding stats"))}
+  <div style="display:flex;flex-wrap:wrap;gap:20px;padding:8px 48px {pad_bottom}px;">
+    {''.join(cells)}
+  </div>
+  {_footer_block()}
+</div>"""
+
+
+def _layout_minimal(stats: ShareSummaryStats, width: int, height: int, fmt: FormatId) -> str:
+    pairs = card_stat_pairs(stats, max_count=6, layout="minimal")
+    rows = []
+    for label, value in pairs:
+        rows.append(f"""
+<div style="display:flex;justify-content:space-between;align-items:baseline;
+  padding:20px 0;border-bottom:1px solid {_colour("border")};">
+  <span style="font-size:28px;color:{_colour("muted")};">{_esc(label)}</span>
+  <span style="font-size:44px;font-weight:700;">{_esc(value)}</span>
+</div>""")
+    pad_bottom = _footer_pad(fmt, width, height)
+    return f"""
+<div style="position:relative;width:100%;height:100%;box-sizing:border-box;">
+  {_header_block(stats, subtitle=_layout_subtitle(stats, "Summary"))}
+  <div style="padding:24px 72px {pad_bottom}px;">
+    {''.join(rows)}
+  </div>
+  {_footer_block()}
+</div>"""
+
+
+def _layout_spotlight(
+    stats: ShareSummaryStats,
+    width: int,
+    height: int,
+    fmt: FormatId,
+    *,
+    spotlight_stat: SpotlightStatId = SHARE_SUMMARY_SPOTLIGHT_STAT_DEFAULT,
+) -> str:
+    pair = spotlight_value(stats, spotlight_stat)
+    if pair is None:
+        title, value = "Lifers", "—"
+    else:
+        title, value = pair
+    pad_bottom = _footer_pad(fmt, width, height)
+    num_size = "200px" if _is_tall(fmt, width, height) else "160px"
+    label_size = "40px" if _is_tall(fmt, width, height) else "36px"
+    if stats.trip_title:
+        header_html = f"""
+<p style="margin:0 0 8px;font-size:28px;letter-spacing:0.06em;text-transform:uppercase;
+  color:{_colour('accent')};font-weight:600;">{_esc(stats.trip_title)}</p>
+<p style="margin:0 0 28px;font-size:36px;font-weight:700;line-height:1.1;color:{_colour('text')};">
+  {_esc(stats.period_label)}</p>"""
+    else:
+        header_html = f"""
+<p style="margin:0 0 32px;font-size:36px;letter-spacing:0.04em;color:{_colour('accent')};font-weight:600;">
+  {_esc(stats.period_label)}</p>"""
+    return f"""
+<div style="position:relative;width:100%;height:100%;box-sizing:border-box;overflow:hidden;">
+  <div style="position:absolute;left:0;right:0;top:0;bottom:{pad_bottom}px;
+    display:flex;flex-direction:column;align-items:center;justify-content:center;
+    padding:64px 56px 32px;text-align:center;box-sizing:border-box;">
+    {header_html}
+    <div style="font-size:{num_size};font-weight:800;line-height:1.05;color:{_colour('text')};">
+      {_esc(value)}</div>
+    <div style="margin-top:20px;font-size:{label_size};color:{_colour('muted')};font-weight:500;">
+      {_esc(title)}</div>
+  </div>
+  {_footer_block()}
+</div>"""
+
+
+_LAYOUT_BUILDERS = {
+    "hero": _layout_hero,
+    "tiles": _layout_tiles,
+    "minimal": _layout_minimal,
+}
+
+
+def render_share_summary_preview_html(
+    stats: ShareSummaryStats,
+    *,
+    layout: LayoutId = "hero",
+    fmt: FormatId = "square",
+    scale: float = 0.38,
+    spotlight_stat: SpotlightStatId = "lifers",
+) -> str:
+    """Return scaled HTML preview for one layout + aspect ratio."""
+    width, height = _FORMAT_PX[fmt]
+    if layout == "spotlight":
+        inner = _layout_spotlight(stats, width, height, fmt, spotlight_stat=spotlight_stat)
+    else:
+        builder = _LAYOUT_BUILDERS.get(layout, _layout_hero)
+        inner = builder(stats, width, height, fmt)
+    return _card_shell(width=width, height=height, inner_html=inner, scale=scale)
+
+
+def all_layout_previews_html(
+    stats: ShareSummaryStats,
+    *,
+    fmt: FormatId = "square",
+    scale: float = 0.38,
+    spotlight_stat: SpotlightStatId = "lifers",
+) -> dict[str, str]:
+    """All prototype layouts for side-by-side comparison."""
+    layouts: list[LayoutId] = ["hero", "tiles", "minimal", "spotlight"]
+    return {
+        layout_id: render_share_summary_preview_html(
+            stats,
+            layout=layout_id,
+            fmt=fmt,
+            scale=scale,
+            spotlight_stat=spotlight_stat,
+        )
+        for layout_id in layouts
+    }
+
+
+# Re-export period helpers for the design app.
+__all__ = [
+    "FormatId",
+    "LayoutId",
+    "SpotlightStatId",
+    "ShareSummaryStats",
+    "all_layout_previews_html",
+    "compute_share_summary_stats",
+    "period_for_custom",
+    "period_for_iso_week",
+    "period_for_week_containing",
+    "period_for_month",
+    "period_for_year",
+    "render_share_summary_preview_html",
+    "sample_share_summary_stats",
+    "share_summary_stats_for_year",
+    "spotlight_value",
+    "spotlight_species_label",
+    "spotlight_stat_label",
+    "stat_pairs",
+    "summary_status_metrics",
+    "card_stat_pairs",
+    "_FORMAT_LABELS",
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,3 +13,4 @@ ignore = ["E501"]
 # Entrypoint prepends repo root to sys.path before package imports (refs #70).
 "explorer/app/streamlit/app.py" = ["E402"]
 "explorer/app/streamlit/design_map_app.py" = ["E402"]
+"explorer/app/streamlit/design_share_summary_app.py" = ["E402"]

--- a/tests/explorer/test_share_summary_compute.py
+++ b/tests/explorer/test_share_summary_compute.py
@@ -1,0 +1,156 @@
+"""Tests for :mod:`explorer.core.share_summary_compute`."""
+
+from datetime import date
+
+import pandas as pd
+
+from explorer.core.share_summary_compute import (
+    compute_share_summary_stats,
+    format_custom_date_range,
+    period_for_custom,
+    period_for_year,
+)
+
+
+def _row(*, sid: str, dt: str, species: str, loc: str = "L1", country: str = "AU") -> dict:
+    return {
+        "Submission ID": sid,
+        "Date": dt,
+        "Scientific Name": species,
+        "Common Name": species,
+        "Count": 1,
+        "Location ID": loc,
+        "Location": loc,
+        "Country": country,
+        "Protocol": "Traveling",
+        "All Obs Reported": 1,
+    }
+
+
+def test_compute_share_summary_stats_year():
+    df = pd.DataFrame(
+        [
+            _row(sid="S1", dt="2025-01-10", species="Species a"),
+            _row(sid="S1", dt="2025-01-10", species="Species b"),
+            _row(sid="S2", dt="2025-06-01", species="Species c"),
+            _row(sid="S3", dt="2024-12-31", species="Species old"),
+        ]
+    )
+    stats = compute_share_summary_stats(df, period_for_year(2025))
+    assert stats is not None
+    assert stats.species == 3
+    assert stats.checklists == 2
+    assert stats.lifers == 3
+
+
+def test_longest_streak_for_month_period():
+    df = pd.DataFrame(
+        [
+            _row(sid="S1", dt="2025-06-01", species="Species a"),
+            _row(sid="S2", dt="2025-06-02", species="Species a"),
+            _row(sid="S3", dt="2025-06-03", species="Species a"),
+            _row(sid="S4", dt="2025-06-10", species="Species b"),
+        ]
+    )
+    from explorer.core.share_summary_compute import period_for_month
+
+    stats = compute_share_summary_stats(df, period_for_month(2025, 6))
+    assert stats is not None
+    assert stats.longest_streak == 3
+
+
+def test_longest_streak_not_computed_for_custom_trip():
+    df = pd.DataFrame(
+        [
+            _row(sid="S1", dt="2025-06-01", species="Species a"),
+            _row(sid="S2", dt="2025-06-02", species="Species a"),
+        ]
+    )
+    stats = compute_share_summary_stats(
+        df,
+        period_for_custom(date(2025, 6, 1), date(2025, 6, 7), trip_title="Trip"),
+    )
+    assert stats is not None
+    assert stats.longest_streak is None
+
+
+def test_countries_for_year_period():
+    df = pd.DataFrame(
+        [
+            _row(sid="S1", dt="2025-03-01", species="Species a", country="AU"),
+            _row(sid="S2", dt="2025-04-01", species="Species b", country="US"),
+        ]
+    )
+    stats = compute_share_summary_stats(df, period_for_year(2025))
+    assert stats is not None
+    assert stats.countries == 2
+
+
+def test_countries_computed_for_custom_trip():
+    df = pd.DataFrame([_row(sid="S1", dt="2025-06-01", species="Species a", country="AU")])
+    stats = compute_share_summary_stats(
+        df,
+        period_for_custom(date(2025, 6, 1), date(2025, 6, 7), trip_title="Trip"),
+    )
+    assert stats is not None
+    assert stats.countries == 1
+
+
+def test_period_for_week_containing_sun_sat():
+    from explorer.core.share_summary_compute import period_for_week_containing
+
+    period = period_for_week_containing(date(2026, 6, 3))  # Wed
+    assert period.start == date(2026, 5, 31)  # Sunday
+    assert period.end == date(2026, 6, 6)  # Saturday
+    assert period.label == "May 31, 2026 - June 6, 2026"
+
+
+def test_birding_days_in_stat_pairs():
+    from explorer.presentation.share_summary_preview import stat_pairs
+
+    stats = compute_share_summary_stats(
+        pd.DataFrame([_row(sid="S1", dt="2025-06-01", species="a"), _row(sid="S2", dt="2025-06-02", species="b")]),
+        period_for_custom(date(2025, 6, 1), date(2025, 6, 7)),
+    )
+    pairs = dict(stat_pairs(stats))
+    assert pairs["Birding days"] == "2"
+
+
+def test_format_custom_date_range_same_month():
+    assert format_custom_date_range(date(2025, 6, 1), date(2025, 6, 7)) == "1 – 7 June 2025"
+    assert format_custom_date_range(date(2025, 5, 6), date(2025, 5, 12)) == "6 – 12 May 2025"
+
+
+def test_compute_share_summary_stats_custom_trip():
+    df = pd.DataFrame(
+        [
+            _row(sid="S1", dt="2025-03-05", species="Species a", loc="A"),
+            _row(sid="S2", dt="2025-03-07", species="Species b", loc="B"),
+        ]
+    )
+    period = period_for_custom(
+        date(2025, 3, 5),
+        date(2025, 3, 7),
+        trip_title="Tassie trip",
+    )
+    stats = compute_share_summary_stats(df, period)
+    assert stats is not None
+    assert stats.period_label == "5 – 7 March 2025"
+    assert stats.trip_title == "Tassie trip"
+    assert stats.checklists == 2
+    assert stats.locations == 2
+
+
+def test_trip_title_renders_on_card():
+    from explorer.presentation.share_summary_preview import render_share_summary_preview_html
+    from explorer.core.share_summary_compute import ShareSummaryStats
+
+    stats = ShareSummaryStats(
+        period_label="1 – 7 June 2025",
+        period_kind="custom",
+        trip_title="North Coast NSW Exploration",
+        lifers=12,
+    )
+    html = render_share_summary_preview_html(stats, layout="hero")
+    assert "1 – 7 June 2025" in html
+    assert "North Coast NSW Exploration" in html

--- a/tests/explorer/test_share_summary_preview.py
+++ b/tests/explorer/test_share_summary_preview.py
@@ -55,6 +55,24 @@ def test_share_summary_stats_for_year_extracts_species():
     assert stats is not None
     assert stats.species == 312
     assert stats.period_label == "2025"
+    assert stats.longest_streak is None
+
+
+def test_share_summary_stats_for_year_counts_countries_from_sections():
+    payload = _minimal_payload(years=[2025], species_vals=["10"])
+    payload = ChecklistStatsPayload(
+        **{
+            **payload.__dict__,
+            "country_sections": [
+                ("AU", [2024, 2025], []),
+                ("US", [2025], []),
+                ("_UNKNOWN", [2025], []),
+            ],
+        }
+    )
+    stats = share_summary_stats_for_year(payload, 2025)
+    assert stats is not None
+    assert stats.countries == 2
 
 
 def test_render_preview_includes_period_label_and_logo():

--- a/tests/explorer/test_share_summary_preview.py
+++ b/tests/explorer/test_share_summary_preview.py
@@ -1,0 +1,151 @@
+"""Tests for :mod:`explorer.presentation.share_summary_preview`."""
+
+from explorer.core.checklist_stats_compute import ChecklistStatsPayload
+from explorer.core.share_summary_compute import ShareSummaryStats
+from explorer.presentation.share_summary_preview import (
+    render_share_summary_preview_html,
+    sample_share_summary_stats,
+    share_summary_stats_for_year,
+)
+
+
+def _minimal_payload(*, years: list[int], species_vals: list[str]) -> ChecklistStatsPayload:
+    yearly_rows = [("Total species", species_vals)]
+    return ChecklistStatsPayload(
+        n_checklists=1,
+        n_species=1,
+        n_individuals=1,
+        n_completed_display="1",
+        protocol_rows=[],
+        total_minutes=0.0,
+        total_hours=0.0,
+        total_days_dec=0.0,
+        total_months=0.0,
+        total_years=0.0,
+        n_days_with_checklist=1,
+        n_shared=0,
+        shared_minutes=0.0,
+        shared_hours=0.0,
+        n_days_birding_with_others=0,
+        total_km=0.0,
+        parkruns=0.0,
+        marathons=0.0,
+        times_equator=0.0,
+        times_godwit=0.0,
+        streak=0,
+        streak_start_date="",
+        streak_start_loc="",
+        streak_start_sid="",
+        streak_start_lid="",
+        streak_end_date="",
+        streak_end_loc="",
+        streak_end_sid="",
+        streak_end_lid="",
+        rankings={},
+        years_list=years,
+        yearly_rows=yearly_rows,
+        incomplete_by_year={},
+        country_sections=[],
+    )
+
+
+def test_share_summary_stats_for_year_extracts_species():
+    payload = _minimal_payload(years=[2024, 2025], species_vals=["100", "312"])
+    stats = share_summary_stats_for_year(payload, 2025)
+    assert stats is not None
+    assert stats.species == 312
+    assert stats.period_label == "2025"
+
+
+def test_render_preview_includes_period_label_and_logo():
+    html = render_share_summary_preview_html(sample_share_summary_stats(), layout="hero")
+    assert "2025" in html
+    assert "pebird-share-preview-wrap" in html
+    assert "Personal eBird Explorer" in html
+
+
+def test_spotlight_layout_renders():
+    stats = ShareSummaryStats(period_label="2025", period_kind="year", lifers=47)
+    html = render_share_summary_preview_html(stats, layout="spotlight", spotlight_stat="lifers")
+    assert "47" in html
+    assert "Lifers" in html
+
+
+def test_spotlight_species_label_by_period():
+    from explorer.presentation.share_summary_preview import spotlight_species_label, spotlight_value
+
+    year = ShareSummaryStats(period_label="2025", period_kind="year", species=312)
+    assert spotlight_value(year, "species") == ("Year birds", "312")
+
+    month = ShareSummaryStats(period_label="June 2025", period_kind="month", species=89)
+    assert spotlight_value(month, "species") == ("Month birds", "89")
+
+    week = ShareSummaryStats(period_label="May 31, 2025 - June 6, 2025", period_kind="week", species=34)
+    assert spotlight_value(week, "species") == ("Week birds", "34")
+
+    custom = ShareSummaryStats(period_label="1 – 7 June 2025", period_kind="custom", species=56)
+    assert spotlight_value(custom, "species") == ("Species", "56")
+
+
+def test_summary_status_metrics_includes_world_coverage():
+    from explorer.presentation.share_summary_preview import summary_status_metrics
+
+    stats = sample_share_summary_stats()
+    metrics = summary_status_metrics(stats, world_bird_coverage_pct=6.8)
+    assert metrics[-1] == ("World bird coverage", "6.8%")
+
+
+def test_card_stat_pairs_year_includes_countries():
+    from explorer.presentation.share_summary_preview import card_stat_pairs
+
+    stats = sample_share_summary_stats(period_kind="year")
+    labels = [lab for lab, _ in card_stat_pairs(stats, max_count=6)]
+    assert "Countries" in labels
+    assert "Birding days" in labels
+
+
+def test_card_stat_pairs_hero_default_four():
+    from explorer.presentation.share_summary_preview import card_stat_pairs
+
+    stats = sample_share_summary_stats(period_kind="custom", trip_title="Trip")
+    labels = [lab for lab, _ in card_stat_pairs(stats, max_count=4, layout="hero")]
+    assert labels == ["Total species", "Lifers", "Total checklists", "Unique locations"]
+
+
+def test_card_stat_pairs_tiles_includes_countries_and_birding_days():
+    from explorer.presentation.share_summary_preview import card_stat_pairs
+
+    stats = sample_share_summary_stats(period_kind="month")
+    labels = [lab for lab, _ in card_stat_pairs(stats, max_count=6, layout="tiles")]
+    assert labels == [
+        "Total species",
+        "Lifers",
+        "Total checklists",
+        "Unique locations",
+        "Countries",
+        "Birding days",
+    ]
+
+
+def test_trip_title_on_all_layouts():
+    stats = ShareSummaryStats(
+        period_label="1 – 7 June 2025",
+        period_kind="custom",
+        trip_title="North Coast NSW Exploration",
+        species=56,
+        lifers=3,
+        checklists=8,
+        locations=6,
+        days_with_checklist=7,
+        countries=2,
+    )
+    for layout in ("hero", "tiles", "minimal", "spotlight"):
+        html = render_share_summary_preview_html(stats, layout=layout)
+        assert "North Coast NSW Exploration" in html
+
+    tiles_html = render_share_summary_preview_html(stats, layout="tiles")
+    minimal_html = render_share_summary_preview_html(stats, layout="minimal")
+    assert "My birding stats" not in tiles_html
+    assert ">Summary</p>" not in minimal_html
+    html = render_share_summary_preview_html(sample_share_summary_stats(), fmt="portrait_post")
+    assert "1350px" in html


### PR DESCRIPTION
## Summary

Land phase 0 of the social media share summary feature: period-scoped stats computation, HTML card layout previews, configuration defaults, unit tests, and a standalone Streamlit design utility for layout tuning. No main-app tab or PNG export in this PR.

## Changes

- Add `explorer/core/share_summary_compute.py` — year/month/week (Sun–Sat)/custom period stats including lifers, countries, birding days, and longest streak (year/month only)
- Add `explorer/presentation/share_summary_preview.py` — Hero, Stat tiles, Minimal, and Spotlight layouts across square, portrait, and story aspect ratios
- Add `explorer/app/streamlit/design_share_summary_app.py` — dev utility for previewing layouts with sample data or CSV upload
- Add `explorer/core/share_summary_defaults.py` — colour schemes and layout stat defaults (framework-neutral; re-exported from `defaults.py` for Streamlit tuning)
- Add unit tests for compute and preview modules
- Add tracker and prototype notes under `docs/explorer/`

## Testing

- `python3 -m ruff check explorer/` — all checks passed
- `python3 -m pytest tests/ -q` — 655 passed, 7 skipped
- Manual: design app (`streamlit run explorer/app/streamlit/design_share_summary_app.py`) — all four layouts × three aspect ratios with sample data and CSV upload

## Notes

- Footer logo only (no corner logo); trip title appears as green subtitle on all layouts
- Weekly period titles use Sun–Sat range format (e.g. `May 31, 2026 - June 6, 2026`)
- Share-summary config lives in `explorer/core/share_summary_defaults.py`; `streamlit/defaults.py` re-exports for developer tuning without coupling presentation to Streamlit

## Issues

Refs #273
Refs #157