### PR TITLE
[#157] Share summary — period stats hardening

### DIFF
--- a/docs/explorer/issue-157-share-summary-tracker.md
+++ b/docs/explorer/issue-157-share-summary-tracker.md
@@ -48,7 +48,7 @@ streamlit run explorer/app/streamlit/design_share_summary_app.py
 | Custom @handle watermark | **Dropped (v1)** | v2 |
 | Media uploads | **Dropped** | Not in eBird observation CSV |
 | User picks stats on card | **Agreed (v1)** | Defaults per layout; picker UI TBD |
-| Current vs previous period | **Open** | Radio/toggle for year/month/week |
+| Current vs previous period | **Done (design app)** | Radio for year/month/week; default via `suggest_period_anchor()` |
 | Colour schemes | **Config in defaults.py** | Index tunable; no UI yet |
 | Multiple themes (light/dark) | **Config only** | Add entries to colour scheme array |
 | User picks layout in app | **Agreed (v1)** | Hero grid, Stat tiles, Minimal list, **Spotlight** |
@@ -99,11 +99,12 @@ All should appear in the summary row (with values) so users can pick interesting
 | Total bird families | Period (taxonomy map) | Yes | No |
 | Birding hours | Period | Yes | **Summary only** |
 | Longest streak (days) | Period (year/month only) | Yes | No |
-| Shared checklists | Period | **Not yet** — reuse checklist-stats logic | No |
-| Days birding with others | Period | **Not yet** — reuse checklist-stats logic | No |
+| Shared checklists | Period | Yes | No |
+| Days birding with others | Period | Yes | No |
 | World bird coverage | All-time (taxonomy) | Yes (summary row) | No |
-| Total species (from taxa) | All-time | **Not yet** — Bird Families tab | No |
-| Total families (from taxa) | All-time | **Not yet** — Bird Families tab | No |
+| Total species (from taxa) | All-time | Yes (summary row) | No |
+| Observed species (from taxa) | All-time | Yes (summary row) | No |
+| Total families (from taxa) | All-time | Yes (summary row) | No |
 | Best bird(s) | User pick (≤3) | Roadmap | No |
 | Trip title | User text (custom range) | Yes | Replaces green subtitle |
 
@@ -139,13 +140,15 @@ All should appear in the summary row (with values) so users can pick interesting
 - **No UI control** for colour schemes yet.
 - **Dark theme:** add a second entry to the array when a good palette exists; otherwise mark v2 with colour-scheme work.
 
-### Period selection — current vs previous (open)
+### Period selection — current vs previous
 
-Idea: control for **current period** vs **previous period** (radio, toggle, or dropdown — wording TBD).
+Control for **current period** vs **previous period** (radio in design app; Socials tab wording TBD).
 
 Example: on Saturday afternoon finishing the birding month → “current month”; on 2 June posting May results → “previous month”. Same for year/week.
 
-Not implemented in prototype yet — discuss wording and UX when building Socials tab controls.
+**Default anchor** (`suggest_period_anchor` in `share_summary_compute.py`, reference = today): month → previous if day ≤ 7 else current; year → previous if 1–14 January else current; week → current on Sat/Sun, previous on Mon/Tue, else current.
+
+Period resolved via `resolve_period()` relative to reference date (design app uses `date.today()`).
 
 ### Card layout iteration (still open)
 
@@ -480,7 +483,7 @@ The explorer is a **browser-based web app**, developed and optimised primarily f
 | Phase | Branch (example) | Deliverable | Status | Issue |
 |-------|------------------|-------------|--------|-------|
 | 0 | `157-social-summary-prototype` | Design app + tracker + core modules | **Ready to commit/PR** | [#273](https://github.com/jimchurches/myebirdstuff/issues/273) |
-| 1 | `157-share-summary-period-stats` | Harden compute + tests; align with main app data paths | Not started | [#274](https://github.com/jimchurches/myebirdstuff/issues/274) |
+| 1 | `157-share-summary-period-stats` | Harden compute + tests; align with main app data paths | **In PR** | [#274](https://github.com/jimchurches/myebirdstuff/issues/274) |
 | 2 | `157-share-summary-png-export` | Playwright HTML→PNG; display image; save UX TBD | Not started | [#275](https://github.com/jimchurches/myebirdstuff/issues/275) |
 | 3 | `157-share-summary-ui` | **Socials** main tab (before Settings); tab-aware sidebar; preview + PNG | Not started | [#276](https://github.com/jimchurches/myebirdstuff/issues/276) |
 | 4 | follow-ups | Best bird(s), stat picker, themes, layout tuning | Not started | [#277](https://github.com/jimchurches/myebirdstuff/issues/277) |
@@ -531,3 +534,4 @@ The explorer is a **browser-based web app**, developed and optimised primarily f
 | 2025-06-09 | **World bird coverage** on roadmap; mockup status row only (6.8% sample / live from taxonomy) |
 | 2026-06-09 | **Decisions batch:** default stats per layout, footer-only logo, trip title → green subtitle, Sun–Sat weekly titles, countries all periods, colour schemes in defaults.py, dropped media/map/compare/watermark v1 |
 | 2026-06-09 | GitHub sub-issues created: #273–#277; plan comment on #157 |
+| 2026-06-11 | #274: period stats hardening — shared stats, all-time taxonomy row, current/previous period + `suggest_period_anchor` heuristics documented |

--- a/explorer/app/streamlit/design_share_summary_app.py
+++ b/explorer/app/streamlit/design_share_summary_app.py
@@ -25,7 +25,14 @@ import streamlit as st
 
 from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
 from explorer.core.data_loader import load_dataset
-from explorer.core.share_summary_compute import ShareSummaryStats
+from explorer.core.share_summary_compute import (
+    PeriodAnchor,
+    ShareSummaryAllTimeStats,
+    ShareSummaryStats,
+    compute_share_summary_all_time_stats,
+    resolve_period,
+    suggest_period_anchor,
+)
 from explorer.presentation.share_summary_preview import (
     FormatId,
     LayoutId,
@@ -65,6 +72,19 @@ with st.sidebar:
             "custom": "Custom date range (trip)",
         }[x],
     )
+    period_anchor: PeriodAnchor | None = None
+    if period_mode in ("year", "month", "week"):
+        default_anchor = suggest_period_anchor(period_mode, date.today())
+        period_anchor = st.radio(
+            "Period",
+            options=["current", "previous"],
+            index=0 if default_anchor == "current" else 1,
+            format_func=lambda x: {
+                "current": f"Current {period_mode}",
+                "previous": f"Previous {period_mode}",
+            }[x],
+            help="Current vs previous calendar period (e.g. post May results on 2 June → previous month).",
+        )
 
     st.header("Output")
     fmt: FormatId = st.selectbox(
@@ -93,7 +113,11 @@ with st.sidebar:
 
 df: pd.DataFrame | None = None
 stats: ShareSummaryStats = sample_share_summary_stats()
-world_bird_coverage_pct: float | None = 6.8
+all_time: ShareSummaryAllTimeStats | None = ShareSummaryAllTimeStats(
+    total_species_taxa=10_800,
+    total_families_taxa=248,
+    world_bird_coverage_pct=6.8,
+)
 
 if not use_sample:
     if uploaded is None:
@@ -136,23 +160,33 @@ if df is not None:
     min_d = dates.min().date()
     max_d = dates.max().date()
 
+    reference = date.today()
     if period_mode == "year":
-        years = sorted({int(y) for y in dates.dt.year.unique()})
-        year = st.sidebar.selectbox("Year", options=years, index=len(years) - 1)
-        period = period_for_year(year)
+        if period_anchor is not None:
+            period = resolve_period("year", anchor=period_anchor, reference=reference)
+        else:
+            years = sorted({int(y) for y in dates.dt.year.unique()})
+            year = st.sidebar.selectbox("Year", options=years, index=len(years) - 1)
+            period = period_for_year(year)
     elif period_mode == "month":
-        month_options = sorted({(int(r.year), int(r.month)) for r in dates.dt.to_pydatetime()})
-        labels = [date(y, m, 1).strftime("%B %Y") for y, m in month_options]
-        pick = st.sidebar.selectbox("Month", options=range(len(labels)), format_func=lambda i: labels[i])
-        y, m = month_options[pick]
-        period = period_for_month(y, m)
+        if period_anchor is not None:
+            period = resolve_period("month", anchor=period_anchor, reference=reference)
+        else:
+            month_options = sorted({(int(r.year), int(r.month)) for r in dates.dt.to_pydatetime()})
+            labels = [date(y, m, 1).strftime("%B %Y") for y, m in month_options]
+            pick = st.sidebar.selectbox("Month", options=range(len(labels)), format_func=lambda i: labels[i])
+            y, m = month_options[pick]
+            period = period_for_month(y, m)
     elif period_mode == "week":
-        week_starts = sorted({period_for_week_containing(d).start for d in dates.dt.date})
-        week_labels = [
-            period_for_week_containing(ws).label for ws in week_starts
-        ]
-        pick = st.sidebar.selectbox("Week", options=range(len(week_labels)), format_func=lambda i: week_labels[i])
-        period = period_for_week_containing(week_starts[pick])
+        if period_anchor is not None:
+            period = resolve_period("week", anchor=period_anchor, reference=reference)
+        else:
+            week_starts = sorted({period_for_week_containing(d).start for d in dates.dt.date})
+            week_labels = [
+                period_for_week_containing(ws).label for ws in week_starts
+            ]
+            pick = st.sidebar.selectbox("Week", options=range(len(week_labels)), format_func=lambda i: week_labels[i])
+            period = period_for_week_containing(week_starts[pick])
     else:
         start = st.sidebar.date_input("Start date", value=min_d, min_value=min_d, max_value=max_d)
         end = st.sidebar.date_input("End date", value=max_d, min_value=min_d, max_value=max_d)
@@ -168,21 +202,9 @@ if df is not None:
         st.warning("Could not compute stats for this period.")
         st.stop()
     stats = computed
-    try:
-        from explorer.app.streamlit.bird_families_streamlit_html import (
-            build_group_coverage_tables,
-            compute_world_species_coverage,
-        )
+    all_time = compute_share_summary_all_time_stats(df, taxonomy_locale=TAXONOMY_LOCALE_DEFAULT)
 
-        _summary, detail = build_group_coverage_tables(df, TAXONOMY_LOCALE_DEFAULT)
-        if not detail.empty:
-            _, _, world_bird_coverage_pct = compute_world_species_coverage(detail)
-        else:
-            world_bird_coverage_pct = None
-    except Exception:
-        world_bird_coverage_pct = None
-
-status_metrics = summary_status_metrics(stats, world_bird_coverage_pct=world_bird_coverage_pct)
+status_metrics = summary_status_metrics(stats, all_time=all_time)
 
 if stats.trip_title:
     st.subheader(stats.trip_title)

--- a/explorer/core/checklist_stats_compute.py
+++ b/explorer/core/checklist_stats_compute.py
@@ -16,8 +16,12 @@ from explorer.core.stats import (
     compute_rankings,
     country_summary_stats,
     longest_streak,
+    protocol_excludes_timed_birding,
     rankings_not_seen_recently_in_country,
     safe_count,
+    shared_checklist_stats,
+    sum_shared_checklist_minutes,
+    sum_timed_birding_minutes,
     yearly_summary_stats,
 )
 
@@ -136,9 +140,7 @@ def compute_checklist_stats_payload(
         n_completed = f"{reported.sum():,}"
         incomplete = a.notna() & ~reported
         if "Protocol" in cl.columns:
-            excl_inc_hist = cl["Protocol"].astype(str).str.strip().str.lower().str.contains(
-                "incidental|historical|casual observation", na=False, regex=True
-            )
+            excl_inc_hist = protocol_excludes_timed_birding(cl["Protocol"])
         else:
             excl_inc_hist = pd.Series(False, index=cl.index)
         n_incomplete = f"{int((incomplete & ~excl_inc_hist).sum()):,}"
@@ -156,15 +158,7 @@ def compute_checklist_stats_payload(
     protocol_rows.append(("Incomplete checklists", n_incomplete))
     protocol_rows.append(("Completed checklists", n_completed))
 
-    total_minutes = 0.0
-    if dur_col:
-        timed = cl.dropna(subset=[dur_col]).copy()
-        if "Protocol" in timed.columns:
-            excl = timed["Protocol"].str.strip().str.lower().str.contains(
-                "incidental|historical|casual observation", na=False, regex=True
-            )
-            timed = timed[~excl]
-        total_minutes = pd.to_numeric(timed[dur_col], errors="coerce").fillna(0).sum()
+    total_minutes = sum_timed_birding_minutes(cl, dur_col) if dur_col else 0.0
     total_hours = total_minutes / 60
     total_days_dec = total_minutes / (60 * 24)
     total_months = total_minutes / (60 * 24 * 30.44)
@@ -173,21 +167,8 @@ def compute_checklist_stats_payload(
     unique_dates = dates.dt.normalize().unique()
     n_days_with_checklist = len(unique_dates)
 
-    n_shared = 0
-    shared_minutes = 0.0
-    n_days_birding_with_others = 0
-    if "Number of Observers" in df.columns:
-        shared_cl = cl.dropna(subset=["Number of Observers"])
-        shared_mask = shared_cl["Number of Observers"].astype(float) > 1
-        n_shared = int(shared_mask.sum())
-        if n_shared > 0:
-            shared_ids = set(shared_cl.loc[shared_mask, "Submission ID"])
-            shared_subset = cl[cl["Submission ID"].isin(shared_ids)]
-            if "Date" in shared_subset.columns:
-                n_days_birding_with_others = shared_subset["Date"].dt.normalize().nunique()
-            if dur_col:
-                shared_dur = shared_subset.dropna(subset=[dur_col])
-                shared_minutes = pd.to_numeric(shared_dur[dur_col], errors="coerce").fillna(0).sum()
+    n_shared, n_days_birding_with_others = shared_checklist_stats(cl)
+    shared_minutes = sum_shared_checklist_minutes(cl, dur_col) if dur_col else 0.0
     shared_hours = shared_minutes / 60
 
     total_km = 0.0

--- a/explorer/core/share_summary_compute.py
+++ b/explorer/core/share_summary_compute.py
@@ -18,6 +18,7 @@ from explorer.core.species_family import build_base_species_to_family_map
 from explorer.core.species_logic import countable_species_vectorized
 from explorer.core.stats import checklist_country_keys, longest_streak, safe_count
 
+PeriodAnchor = Literal["current", "previous"]
 PeriodKind = Literal["year", "month", "week", "custom"]
 
 
@@ -112,6 +113,59 @@ def period_for_iso_week(year: int, week: int) -> ShareSummaryPeriod:
     return period_for_week_containing(date.fromisocalendar(int(year), int(week), 1))
 
 
+def period_for_previous_month(year: int, month: int) -> ShareSummaryPeriod:
+    """Calendar month immediately before *year*/*month*."""
+    if int(month) == 1:
+        return period_for_month(int(year) - 1, 12)
+    return period_for_month(int(year), int(month) - 1)
+
+
+def period_for_previous_week_containing(day: date) -> ShareSummaryPeriod:
+    """Sun–Sat week immediately before the week containing *day*."""
+    start, _ = _week_sun_sat_containing(day)
+    return period_for_week_containing(start - timedelta(days=1))
+
+
+def resolve_period(
+    kind: Literal["year", "month", "week"],
+    *,
+    anchor: PeriodAnchor,
+    reference: date,
+) -> ShareSummaryPeriod:
+    """Resolve year/month/week period from *reference* date and current/previous anchor."""
+    if kind == "year":
+        y = reference.year if anchor == "current" else reference.year - 1
+        return period_for_year(y)
+    if kind == "month":
+        if anchor == "current":
+            return period_for_month(reference.year, reference.month)
+        return period_for_previous_month(reference.year, reference.month)
+    # week
+    if anchor == "current":
+        return period_for_week_containing(reference)
+    return period_for_previous_week_containing(reference)
+
+
+def suggest_period_anchor(kind: Literal["year", "month", "week"], reference: date) -> PeriodAnchor:
+    """Heuristic default for current vs previous (social-posting context).
+
+    Examples: early in a new month → previous month; weekend → current week.
+    """
+    if kind == "month":
+        return "previous" if reference.day <= 7 else "current"
+    if kind == "year":
+        if reference.month == 1 and reference.day <= 14:
+            return "previous"
+        return "current"
+    if kind == "week":
+        if reference.weekday() >= 5:  # Saturday or Sunday
+            return "current"
+        if reference.weekday() <= 1:  # Monday or Tuesday
+            return "previous"
+        return "current"
+    return "current"
+
+
 def period_for_custom(
     start: date,
     end: date,
@@ -153,6 +207,18 @@ class ShareSummaryStats:
     days_with_checklist: int | None = None
     longest_streak: int | None = None
     countries: int | None = None
+    shared_checklists: int | None = None
+    days_birding_with_others: int | None = None
+
+
+@dataclass(frozen=True)
+class ShareSummaryAllTimeStats:
+    """All-time taxonomy metrics for the summary row (not period-scoped)."""
+
+    total_species_taxa: int | None = None
+    total_families_taxa: int | None = None
+    observed_species_taxa: int | None = None
+    world_bird_coverage_pct: float | None = None
 
 
 def _countries_in_period(cl: pd.DataFrame) -> int | None:
@@ -166,6 +232,27 @@ def _countries_in_period(cl: pd.DataFrame) -> int | None:
     if known.empty:
         return None
     return int(known.nunique())
+
+
+def _shared_stats_in_period(cl: pd.DataFrame) -> tuple[int | None, int | None]:
+    """Shared checklists and days birding with others (Number of Observers > 1).
+
+    Same rules as :mod:`explorer.core.checklist_stats_compute`.
+    """
+    if "Number of Observers" not in cl.columns:
+        return None, None
+    shared_cl = cl.dropna(subset=["Number of Observers"])
+    if shared_cl.empty:
+        return 0, 0
+    shared_mask = shared_cl["Number of Observers"].astype(float) > 1
+    n_shared = int(shared_mask.sum())
+    n_days = 0
+    if n_shared > 0:
+        shared_ids = set(shared_cl.loc[shared_mask, "Submission ID"])
+        shared_subset = cl[cl["Submission ID"].isin(shared_ids)]
+        if "Date" in shared_subset.columns and not shared_subset.empty:
+            n_days = int(shared_subset["Date"].dt.normalize().nunique())
+    return n_shared, n_days
 
 
 def _mask_in_period(dates: pd.Series, period: ShareSummaryPeriod) -> pd.Series:
@@ -247,6 +334,7 @@ def compute_share_summary_stats(
         longest_streak_days = int(streak_val)
 
     countries = _countries_in_period(in_period_cl)
+    shared_checklists, days_birding_with_others = _shared_stats_in_period(in_period_cl)
 
     return ShareSummaryStats(
         period_label=period.label,
@@ -262,4 +350,40 @@ def compute_share_summary_stats(
         birding_hours=birding_hours,
         longest_streak=longest_streak_days,
         countries=countries,
+        shared_checklists=shared_checklists,
+        days_birding_with_others=days_birding_with_others,
+    )
+
+
+def compute_share_summary_all_time_stats(
+    df: pd.DataFrame,
+    *,
+    taxonomy_locale: str | None = None,
+) -> ShareSummaryAllTimeStats | None:
+    """All-time taxonomy metrics via Bird Families coverage tables."""
+    if df.empty:
+        return None
+    loc = (taxonomy_locale or "").strip() or TAXONOMY_LOCALE_DEFAULT
+    try:
+        from explorer.app.streamlit.bird_families_streamlit_html import (
+            build_group_coverage_tables,
+            compute_world_species_coverage,
+        )
+    except ImportError:
+        return None
+
+    try:
+        summary, detail = build_group_coverage_tables(df, loc)
+    except Exception:
+        return None
+    if detail.empty:
+        return None
+
+    observed, total_sp, pct = compute_world_species_coverage(detail)
+    total_families = int(summary["group_name"].nunique()) if not summary.empty else None
+    return ShareSummaryAllTimeStats(
+        total_species_taxa=total_sp,
+        total_families_taxa=total_families,
+        observed_species_taxa=observed,
+        world_bird_coverage_pct=pct,
     )

--- a/explorer/core/share_summary_compute.py
+++ b/explorer/core/share_summary_compute.py
@@ -16,7 +16,14 @@ import pandas as pd
 from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
 from explorer.core.species_family import build_base_species_to_family_map
 from explorer.core.species_logic import countable_species_vectorized
-from explorer.core.stats import checklist_country_keys, longest_streak, safe_count
+from explorer.core.stats import (
+    checklist_country_keys,
+    longest_streak,
+    safe_count,
+    shared_checklist_stats,
+    sum_timed_birding_minutes,
+    timed_checklists_excl_incidental,
+)
 
 PeriodAnchor = Literal["current", "previous"]
 PeriodKind = Literal["year", "month", "week", "custom"]
@@ -234,27 +241,6 @@ def _countries_in_period(cl: pd.DataFrame) -> int | None:
     return int(known.nunique())
 
 
-def _shared_stats_in_period(cl: pd.DataFrame) -> tuple[int | None, int | None]:
-    """Shared checklists and days birding with others (Number of Observers > 1).
-
-    Same rules as :mod:`explorer.core.checklist_stats_compute`.
-    """
-    if "Number of Observers" not in cl.columns:
-        return None, None
-    shared_cl = cl.dropna(subset=["Number of Observers"])
-    if shared_cl.empty:
-        return 0, 0
-    shared_mask = shared_cl["Number of Observers"].astype(float) > 1
-    n_shared = int(shared_mask.sum())
-    n_days = 0
-    if n_shared > 0:
-        shared_ids = set(shared_cl.loc[shared_mask, "Submission ID"])
-        shared_subset = cl[cl["Submission ID"].isin(shared_ids)]
-        if "Date" in shared_subset.columns and not shared_subset.empty:
-            n_days = int(shared_subset["Date"].dt.normalize().nunique())
-    return n_shared, n_days
-
-
 def _mask_in_period(dates: pd.Series, period: ShareSummaryPeriod) -> pd.Series:
     ts = pd.to_datetime(dates, errors="coerce")
     return ts.notna() & (ts >= period.start_ts) & (ts <= period.end_ts)
@@ -314,16 +300,11 @@ def compute_share_summary_stats(
         families = int(fam_df.dropna(subset=["_family"])["_family"].nunique())
 
     birding_hours = None
-    dur_col = "Duration (Min)" if "Duration (Min)" in cl.columns else None
+    dur_col = "Duration (Min)" if "Duration (Min)" in in_period_cl.columns else None
     if dur_col:
-        timed = in_period_cl.dropna(subset=[dur_col]).copy()
-        if "Protocol" in timed.columns:
-            proto = timed["Protocol"].astype(str).str.strip().str.lower()
-            excl = proto.str.contains("incidental|historical|casual observation", na=False, regex=True)
-            timed = timed[~excl]
+        timed = timed_checklists_excl_incidental(in_period_cl, dur_col)
         if not timed.empty:
-            mins = pd.to_numeric(timed[dur_col], errors="coerce").fillna(0).sum()
-            birding_hours = float(mins) / 60.0
+            birding_hours = sum_timed_birding_minutes(in_period_cl, dur_col) / 60.0
 
     days = int(in_period_cl["Date"].dt.normalize().nunique())
 
@@ -334,7 +315,9 @@ def compute_share_summary_stats(
         longest_streak_days = int(streak_val)
 
     countries = _countries_in_period(in_period_cl)
-    shared_checklists, days_birding_with_others = _shared_stats_in_period(in_period_cl)
+    shared_checklists, days_birding_with_others = shared_checklist_stats(
+        in_period_cl, absent_column="none"
+    )
 
     return ShareSummaryStats(
         period_label=period.label,

--- a/explorer/core/stats.py
+++ b/explorer/core/stats.py
@@ -236,6 +236,87 @@ def longest_streak(unique_dates, cl):
 
 
 # ---------------------------------------------------------------------------
+# Timed birding & shared checklists (checklist-stats + share-summary)
+# ---------------------------------------------------------------------------
+
+_PROTOCOL_EXCL_TIMED_BIRDING = "incidental|historical|casual observation"
+
+
+def protocol_excludes_timed_birding(protocol: pd.Series) -> pd.Series:
+    """True for protocols excluded from timed birding totals (incidental/historical/casual)."""
+    return protocol.astype(str).str.strip().str.lower().str.contains(
+        _PROTOCOL_EXCL_TIMED_BIRDING, na=False, regex=True
+    )
+
+
+def timed_checklists_excl_incidental(cl: pd.DataFrame, dur_col: str) -> pd.DataFrame:
+    """Checklist rows with *dur_col* set, excluding incidental/historical/casual protocols."""
+    timed = cl.dropna(subset=[dur_col]).copy()
+    if "Protocol" in timed.columns:
+        timed = timed[~protocol_excludes_timed_birding(timed["Protocol"])]
+    return timed
+
+
+def sum_timed_birding_minutes(cl: pd.DataFrame, dur_col: str) -> float:
+    """Sum checklist duration minutes with protocol exclusions applied."""
+    timed = timed_checklists_excl_incidental(cl, dur_col)
+    if timed.empty:
+        return 0.0
+    return float(pd.to_numeric(timed[dur_col], errors="coerce").fillna(0).sum())
+
+
+def shared_checklist_rows(cl: pd.DataFrame) -> pd.DataFrame | None:
+    """Rows in deduped checklist *cl* where Number of Observers > 1.
+
+    Returns ``None`` when the observers column is missing; empty frame when none qualify.
+    """
+    if "Number of Observers" not in cl.columns:
+        return None
+    shared_cl = cl.dropna(subset=["Number of Observers"])
+    if shared_cl.empty:
+        return shared_cl
+    nobs = pd.to_numeric(shared_cl["Number of Observers"], errors="coerce").fillna(0)
+    return shared_cl[nobs > 1]
+
+
+def shared_checklist_stats(
+    cl: pd.DataFrame,
+    *,
+    absent_column: str = "zero",
+) -> tuple[int | None, int | None]:
+    """Return ``(n_shared, n_days_birding_with_others)`` for checklist-level *cl*.
+
+    *absent_column*: ``\"zero\"`` when observers column missing (checklist stats default);
+    ``\"none\"`` for share summary (``None``, ``None``).
+    """
+    shared_rows = shared_checklist_rows(cl)
+    if shared_rows is None:
+        return (None, None) if absent_column == "none" else (0, 0)
+    n_shared = int(len(shared_rows))
+    if n_shared == 0:
+        return 0, 0
+    shared_ids = set(shared_rows["Submission ID"])
+    shared_subset = cl[cl["Submission ID"].isin(shared_ids)]
+    n_days = 0
+    if "Date" in shared_subset.columns and not shared_subset.empty:
+        n_days = int(shared_subset["Date"].dt.normalize().nunique())
+    return n_shared, n_days
+
+
+def sum_shared_checklist_minutes(cl: pd.DataFrame, dur_col: str) -> float:
+    """Sum duration minutes for shared checklists (observers > 1)."""
+    shared_rows = shared_checklist_rows(cl)
+    if shared_rows is None or shared_rows.empty:
+        return 0.0
+    shared_ids = set(shared_rows["Submission ID"])
+    shared_subset = cl[cl["Submission ID"].isin(shared_ids)]
+    shared_dur = shared_subset.dropna(subset=[dur_col])
+    if shared_dur.empty:
+        return 0.0
+    return float(pd.to_numeric(shared_dur[dur_col], errors="coerce").fillna(0).sum())
+
+
+# ---------------------------------------------------------------------------
 # Ranking helpers
 # ---------------------------------------------------------------------------
 
@@ -985,23 +1066,16 @@ def yearly_summary_stats(df, cl, dur_col, dist_col, *, taxonomy_locale: str | No
         row_incidental_checklists = ("Incidental checklists", ["—"] * len(years_sorted))
 
     # Shared checklists / Days birding with others
-    if "Number of Observers" in cl.columns:
-        shared_cl = cl.dropna(subset=["Number of Observers"]).copy()
-        shared_cl["_nobs"] = pd.to_numeric(shared_cl["Number of Observers"], errors="coerce").fillna(0)
-        shared_mask = shared_cl["_nobs"] > 1
-        shared_sub = shared_cl[shared_mask]
-        if not shared_sub.empty:
-            by_yr_shared = shared_sub.groupby("_year").size()
-            vals_shared = [int(by_yr_shared.get(y, 0)) for y in years_sorted]
-            row_shared_checklists = ("Shared checklists", [f"{v:,}" for v in vals_shared])
-            shared_sub = shared_sub.copy()
-            shared_sub["_date"] = shared_sub["Date"].dt.normalize()
-            by_yr_days = shared_sub.groupby("_year")["_date"].nunique()
-            vals_days_bo = [int(by_yr_days.get(y, 0)) for y in years_sorted]
-            row_days_birding_with_others = ("Days birding with others", [f"{v:,}" for v in vals_days_bo])
-        else:
-            row_shared_checklists = ("Shared checklists", ["—"] * len(years_sorted))
-            row_days_birding_with_others = ("Days birding with others", ["—"] * len(years_sorted))
+    shared_sub = shared_checklist_rows(cl)
+    if shared_sub is not None and not shared_sub.empty:
+        by_yr_shared = shared_sub.groupby("_year").size()
+        vals_shared = [int(by_yr_shared.get(y, 0)) for y in years_sorted]
+        row_shared_checklists = ("Shared checklists", [f"{v:,}" for v in vals_shared])
+        shared_sub = shared_sub.copy()
+        shared_sub["_date"] = shared_sub["Date"].dt.normalize()
+        by_yr_days = shared_sub.groupby("_year")["_date"].nunique()
+        vals_days_bo = [int(by_yr_days.get(y, 0)) for y in years_sorted]
+        row_days_birding_with_others = ("Days birding with others", [f"{v:,}" for v in vals_days_bo])
     else:
         row_shared_checklists = ("Shared checklists", ["—"] * len(years_sorted))
         row_days_birding_with_others = ("Days birding with others", ["—"] * len(years_sorted))
@@ -1018,12 +1092,9 @@ def yearly_summary_stats(df, cl, dur_col, dist_col, *, taxonomy_locale: str | No
 
     # Total birding hours
     if dur_col:
-        timed = cl.dropna(subset=[dur_col]).copy()
+        timed = timed_checklists_excl_incidental(cl, dur_col)
         timed["_dur"] = pd.to_numeric(timed[dur_col], errors="coerce").fillna(0)
         timed["_year"] = timed["Date"].dt.year
-        if has_protocol:
-            excl = timed["Protocol"].astype(str).str.strip().str.lower().str.contains("incidental|historical|casual observation", na=False, regex=True)
-            timed = timed[~excl]
         by_yr_min = timed.groupby("_year")["_dur"].sum()
         vals_hours = [by_yr_min.get(y, 0) / 60 for y in years_sorted]
         row_total_birding_hours = ("Total birding hours", [f"{v:.1f}" if v else "—" for v in vals_hours])

--- a/explorer/presentation/share_summary_preview.py
+++ b/explorer/presentation/share_summary_preview.py
@@ -15,6 +15,7 @@ from typing import Any, Iterable, Literal
 from explorer.core.checklist_stats_compute import ChecklistStatsPayload
 from explorer.core.share_summary_compute import (
     PeriodKind,
+    ShareSummaryAllTimeStats,
     ShareSummaryStats,
     compute_share_summary_stats,
     period_for_custom,
@@ -67,6 +68,8 @@ _STAT_LABELS: dict[str, str] = {
     "days_with_checklist": "Birding days",
     "longest_streak": "Longest streak",
     "countries": "Countries",
+    "shared_checklists": "Shared checklists",
+    "days_birding_with_others": "Days birding with others",
 }
 
 _SPOTLIGHT_TITLES: dict[SpotlightStatId, str] = {
@@ -134,6 +137,8 @@ def stat_pairs(stats: ShareSummaryStats) -> list[tuple[str, str]]:
         ("countries", stats.countries, "countries"),
         ("longest_streak", stats.longest_streak, "streak"),
         ("birding_hours", stats.birding_hours, "hours"),
+        ("shared_checklists", stats.shared_checklists, "shared"),
+        ("days_birding_with_others", stats.days_birding_with_others, "shared_days"),
     ]
     out: list[tuple[str, str]] = []
     for key, val, fmt in raw:
@@ -151,6 +156,12 @@ def stat_pairs(stats: ShareSummaryStats) -> list[tuple[str, str]]:
         elif fmt == "streak":
             display = f"{int(val):,}"
             label = "Longest streak (days)"
+        elif fmt == "shared":
+            display = f"{int(val):,}"
+            label = _STAT_LABELS["shared_checklists"]
+        elif fmt == "shared_days":
+            display = f"{int(val):,}"
+            label = _STAT_LABELS["days_birding_with_others"]
         else:
             display = f"{int(val):,}"
             label = _STAT_LABELS.get(key, key.replace("_", " ").title())
@@ -161,14 +172,22 @@ def stat_pairs(stats: ShareSummaryStats) -> list[tuple[str, str]]:
 def summary_status_metrics(
     stats: ShareSummaryStats,
     *,
+    all_time: ShareSummaryAllTimeStats | None = None,
     world_bird_coverage_pct: float | None = None,
 ) -> list[tuple[str, str]]:
-    """Metrics row above card previews (period stats + optional global coverage).
+    """Metrics row above card previews (period stats + optional all-time taxonomy).
 
-    World bird coverage is **not** included on card tiles — status row only until layout TBD.
+    All-time metrics and world bird coverage are **not** on card tiles — summary row only.
     """
     pairs = list(stat_pairs(stats))
-    if world_bird_coverage_pct is not None:
+    if all_time is not None:
+        if all_time.total_species_taxa is not None:
+            pairs.append(("Total species (from taxa)", f"{all_time.total_species_taxa:,}"))
+        if all_time.total_families_taxa is not None:
+            pairs.append(("Total families (from taxa)", f"{all_time.total_families_taxa:,}"))
+        if all_time.world_bird_coverage_pct is not None:
+            pairs.append(("World bird coverage", f"{all_time.world_bird_coverage_pct:.1f}%"))
+    elif world_bird_coverage_pct is not None:
         pairs.append(("World bird coverage", f"{world_bird_coverage_pct:.1f}%"))
     return pairs
 
@@ -352,6 +371,8 @@ def sample_share_summary_stats(
             "birding_hours": 38.5,
             "longest_streak": 5,
             "countries": 3,
+            "shared_checklists": 4,
+            "days_birding_with_others": 3,
         },
         "custom": {
             "species": 56,
@@ -380,6 +401,8 @@ def sample_share_summary_stats(
         birding_hours=float(d["birding_hours"]),
         longest_streak=int(d["longest_streak"]) if "longest_streak" in d else None,
         countries=int(d["countries"]) if "countries" in d else None,
+        shared_checklists=int(d["shared_checklists"]) if "shared_checklists" in d else None,
+        days_birding_with_others=int(d["days_birding_with_others"]) if "days_birding_with_others" in d else None,
     )
 
 
@@ -629,6 +652,7 @@ __all__ = [
     "FormatId",
     "LayoutId",
     "SpotlightStatId",
+    "ShareSummaryAllTimeStats",
     "ShareSummaryStats",
     "all_layout_previews_html",
     "compute_share_summary_stats",

--- a/explorer/presentation/share_summary_preview.py
+++ b/explorer/presentation/share_summary_preview.py
@@ -183,6 +183,8 @@ def summary_status_metrics(
     if all_time is not None:
         if all_time.total_species_taxa is not None:
             pairs.append(("Total species (from taxa)", f"{all_time.total_species_taxa:,}"))
+        if all_time.observed_species_taxa is not None:
+            pairs.append(("Observed species (from taxa)", f"{all_time.observed_species_taxa:,}"))
         if all_time.total_families_taxa is not None:
             pairs.append(("Total families (from taxa)", f"{all_time.total_families_taxa:,}"))
         if all_time.world_bird_coverage_pct is not None:

--- a/tests/explorer/test_share_summary_compute.py
+++ b/tests/explorer/test_share_summary_compute.py
@@ -5,14 +5,30 @@ from datetime import date
 import pandas as pd
 
 from explorer.core.share_summary_compute import (
+    compute_share_summary_all_time_stats,
     compute_share_summary_stats,
     format_custom_date_range,
     period_for_custom,
+    period_for_month,
+    period_for_previous_month,
+    period_for_previous_week_containing,
+    period_for_week_containing,
     period_for_year,
+    resolve_period,
+    suggest_period_anchor,
 )
+from explorer.presentation.share_summary_preview import summary_status_metrics
 
 
-def _row(*, sid: str, dt: str, species: str, loc: str = "L1", country: str = "AU") -> dict:
+def _row(
+    *,
+    sid: str,
+    dt: str,
+    species: str,
+    loc: str = "L1",
+    country: str = "AU",
+    observers: float = 1.0,
+) -> dict:
     return {
         "Submission ID": sid,
         "Date": dt,
@@ -24,6 +40,7 @@ def _row(*, sid: str, dt: str, species: str, loc: str = "L1", country: str = "AU
         "Country": country,
         "Protocol": "Traveling",
         "All Obs Reported": 1,
+        "Number of Observers": observers,
     }
 
 
@@ -139,6 +156,125 @@ def test_compute_share_summary_stats_custom_trip():
     assert stats.trip_title == "Tassie trip"
     assert stats.checklists == 2
     assert stats.locations == 2
+
+
+def test_shared_checklists_and_days_birding_with_others():
+    df = pd.DataFrame(
+        [
+            _row(sid="S1", dt="2025-06-01", species="Species a", observers=2),
+            _row(sid="S2", dt="2025-06-02", species="Species b", observers=2),
+            _row(sid="S3", dt="2025-06-02", species="Species c", observers=1),
+            _row(sid="S4", dt="2025-06-10", species="Species d", observers=1),
+        ]
+    )
+    stats = compute_share_summary_stats(df, period_for_month(2025, 6))
+    assert stats is not None
+    assert stats.shared_checklists == 2
+    assert stats.days_birding_with_others == 2
+
+
+def test_shared_stats_none_without_observers_column():
+    row = _row(sid="S1", dt="2025-06-01", species="Species a")
+    del row["Number of Observers"]
+    stats = compute_share_summary_stats(pd.DataFrame([row]), period_for_month(2025, 6))
+    assert stats is not None
+    assert stats.shared_checklists is None
+    assert stats.days_birding_with_others is None
+
+
+def test_resolve_period_current_and_previous_month():
+    ref = date(2026, 6, 2)
+    current = resolve_period("month", anchor="current", reference=ref)
+    previous = resolve_period("month", anchor="previous", reference=ref)
+    assert current.label == "June 2026"
+    assert previous.label == "May 2026"
+
+
+def test_resolve_period_previous_week():
+    ref = date(2026, 6, 3)  # Wed in week May 31 – Jun 6
+    previous = resolve_period("week", anchor="previous", reference=ref)
+    assert previous.start == date(2026, 5, 24)
+    assert previous.end == date(2026, 5, 30)
+
+
+def test_period_for_previous_month_january():
+    period = period_for_previous_month(2026, 1)
+    assert period.label == "December 2025"
+
+
+def test_period_for_previous_week_containing():
+    period = period_for_previous_week_containing(date(2026, 6, 3))
+    assert period.start == date(2026, 5, 24)
+    assert period.end == date(2026, 5, 30)
+
+
+def test_suggest_period_anchor_early_month():
+    assert suggest_period_anchor("month", date(2026, 6, 2)) == "previous"
+    assert suggest_period_anchor("month", date(2026, 6, 15)) == "current"
+
+
+def test_suggest_period_anchor_weekend():
+    assert suggest_period_anchor("week", date(2026, 6, 6)) == "current"  # Saturday
+    assert suggest_period_anchor("week", date(2026, 6, 1)) == "previous"  # Monday
+
+
+def test_summary_status_metrics_includes_all_time_stats():
+    from explorer.core.share_summary_compute import ShareSummaryAllTimeStats, ShareSummaryStats
+
+    stats = ShareSummaryStats(period_label="2025", period_kind="year", species=10)
+    all_time = ShareSummaryAllTimeStats(
+        total_species_taxa=10_800,
+        total_families_taxa=248,
+        world_bird_coverage_pct=6.8,
+    )
+    pairs = dict(summary_status_metrics(stats, all_time=all_time))
+    assert pairs["Total species (from taxa)"] == "10,800"
+    assert pairs["Total families (from taxa)"] == "248"
+    assert pairs["World bird coverage"] == "6.8%"
+
+
+def test_compute_share_summary_all_time_stats_from_fixture(monkeypatch):
+    from pathlib import Path
+
+    from explorer.app.streamlit import bird_families_streamlit_html as bf
+    from explorer.core.data_loader import load_dataset
+
+    tax = pd.DataFrame(
+        [
+            {
+                "scientific_name": "Anas gracilis",
+                "common_name": "Grey Teal",
+                "species_code": "grytea1",
+                "taxon_order": 637.0,
+                "base_species": "anas gracilis",
+                "is_extinct": False,
+            },
+            {
+                "scientific_name": "Cacatua galerita",
+                "common_name": "Sulphur-crested Cockatoo",
+                "species_code": "sulcoc2",
+                "taxon_order": 12212.0,
+                "base_species": "cacatua galerita",
+                "is_extinct": False,
+            },
+        ]
+    )
+    groups = [
+        {"group_name": "Waterfowl", "group_order": 1, "bounds": [(0.0, 1000.0)]},
+        {"group_name": "Parrots", "group_order": 2, "bounds": [(12000.0, 13000.0)]},
+    ]
+    monkeypatch.setattr(bf, "_load_taxonomy_species_rows", lambda _loc: tax)
+    monkeypatch.setattr(bf, "_load_taxonomy_groups", lambda _loc: groups)
+
+    fixture = Path(__file__).resolve().parents[1] / "fixtures" / "ebird_integration_fixture.csv"
+    df = load_dataset(fixture)
+    assert df is not None and not df.empty
+    all_time = compute_share_summary_all_time_stats(df, taxonomy_locale="en_AU")
+    assert all_time is not None
+    assert all_time.total_species_taxa == 2
+    assert all_time.total_families_taxa == 2
+    assert all_time.world_bird_coverage_pct is not None
+    assert all_time.world_bird_coverage_pct > 0
 
 
 def test_trip_title_renders_on_card():

--- a/tests/explorer/test_share_summary_compute.py
+++ b/tests/explorer/test_share_summary_compute.py
@@ -224,11 +224,13 @@ def test_summary_status_metrics_includes_all_time_stats():
     stats = ShareSummaryStats(period_label="2025", period_kind="year", species=10)
     all_time = ShareSummaryAllTimeStats(
         total_species_taxa=10_800,
+        observed_species_taxa=312,
         total_families_taxa=248,
         world_bird_coverage_pct=6.8,
     )
     pairs = dict(summary_status_metrics(stats, all_time=all_time))
     assert pairs["Total species (from taxa)"] == "10,800"
+    assert pairs["Observed species (from taxa)"] == "312"
     assert pairs["Total families (from taxa)"] == "248"
     assert pairs["World bird coverage"] == "6.8%"
 

--- a/tests/explorer/test_stats.py
+++ b/tests/explorer/test_stats.py
@@ -20,6 +20,10 @@ from explorer.core.stats import (
     rankings_not_seen_recently,
     rankings_not_seen_recently_in_country,
     rankings_high_counts,
+    protocol_excludes_timed_birding,
+    shared_checklist_stats,
+    sum_timed_birding_minutes,
+    timed_checklists_excl_incidental,
 )
 
 
@@ -42,6 +46,49 @@ class TestSafeCount:
 
     def test_plain_int(self):
         assert safe_count(42) == 42
+
+
+# ---------------------------------------------------------------------------
+# Timed birding & shared checklists
+# ---------------------------------------------------------------------------
+
+class TestSharedChecklistStats:
+    def _cl(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Submission ID": ["S1", "S2", "S3"],
+                "Date": pd.to_datetime(["2025-06-01", "2025-06-02", "2025-06-02"]),
+                "Number of Observers": [2.0, 2.0, 1.0],
+                "Duration (Min)": [60, 30, 45],
+            }
+        )
+
+    def test_shared_checklist_stats_counts(self):
+        n_shared, n_days = shared_checklist_stats(self._cl())
+        assert n_shared == 2
+        assert n_days == 2
+
+    def test_shared_checklist_stats_absent_column_none(self):
+        cl = self._cl().drop(columns=["Number of Observers"])
+        assert shared_checklist_stats(cl, absent_column="none") == (None, None)
+
+    def test_timed_checklists_excl_incidental(self):
+        cl = pd.DataFrame(
+            {
+                "Submission ID": ["S1", "S2"],
+                "Protocol": ["eBird - Traveling Count", "eBird - Casual Observation"],
+                "Duration (Min)": [60, 120],
+            }
+        )
+        timed = timed_checklists_excl_incidental(cl, "Duration (Min)")
+        assert len(timed) == 1
+        assert timed.iloc[0]["Submission ID"] == "S1"
+        assert sum_timed_birding_minutes(cl, "Duration (Min)") == 60.0
+
+    def test_protocol_excludes_timed_birding(self):
+        proto = pd.Series(["eBird - Traveling Count", "Incidental", "Historical checklist"])
+        mask = protocol_excludes_timed_birding(proto)
+        assert list(mask) == [False, True, True]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the share-summary metrics catalogue for #157 phase 1: wires missing period stats into compute, adds current/previous period selection in the design app, and aligns all-time taxonomy metrics with the Bird Families data path.

## Changes

- Add **shared checklists** and **days birding with others** to period-scoped compute (reuses checklist-stats `Number of Observers > 1` logic)
- Add **ShareSummaryAllTimeStats** and `compute_share_summary_all_time_stats()` for taxonomy totals and world bird coverage
- Extend summary metrics row with distinct labels for period vs all-time stats (e.g. “Total species (from taxa)”)
- Add current/previous period helpers (`resolve_period`, `suggest_period_anchor`) and radio control in the design app for year/month/week
- Extend unit tests for new stats, period resolution, and offline fixture coverage

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` — 666 passed, 7 skipped

## Notes

- Longest streak remains year/month only (unchanged)
- Period anchor uses `date.today()` as reference for social-posting context
- Stat picker UI, PNG export, and Socials tab shell remain out of scope (#275–#277)

Refs #274
Refs #157

Made with [Cursor](https://cursor.com)