### PR TITLE
Retune story circle diameters for counts 3 and 7

### DIFF
--- a/explorer/presentation/share_summary_circles_preview.py
+++ b/explorer/presentation/share_summary_circles_preview.py
@@ -689,11 +689,11 @@ CIRCLE_CARD_TEMPLATES: dict[tuple[TilesCircleCardType, FormatId], CircleCardTemp
         diameters={
             1: _SINGLE_CIRCLE_DIAMETER_PX,
             2: 380,
-            3: 360,
+            3: 380,
             4: 340,
             5: 340,
             6: 340,
-            7: 270,
+            7: 295,
             8: 265,
             9: 255,
             10: 255,

--- a/tests/explorer/test_share_summary_circle_layout_playground.py
+++ b/tests/explorer/test_share_summary_circle_layout_playground.py
@@ -91,7 +91,9 @@ def test_circle_layout_playground_story_tiles_uses_code_layout():
     assert '"max_diameter": 400' in html
     assert '"1": 400' in html
     assert '"2": 380' in html
+    assert '"3": 380' in html
     assert '"6": 340' in html
+    assert '"7": 295' in html
     assert '"canvas_h": 1490' in html
     assert "0.29" in html
 


### PR DESCRIPTION
## Summary
Playground-tuned diameter updates for story Statistics Tiles circle layouts as part of the #296 regression pass. Positions unchanged; diameters increased for counts 3 and 7.

## Changes
- Story count 3: diameter 360 → **380px** (positions unchanged)
- Story count 7: diameter 270 → **295px** (positions unchanged)

## Testing
- `python3 -m ruff check explorer/` — pass
- `python3 -m pytest tests/ -q` — 773 passed, 11 skipped
- Manual visual QA in design app Circle layout playground (story format)

## Notes
Partial #296 work — counts 8–10 not yet retuned. Further playground exports can follow on this branch or a follow-up PR.

Refs #296

Made with [Cursor](https://cursor.com)