### PR TITLE
fix: Load code circle defaults on layout switch until edited

### DIFF
--- a/explorer/presentation/share_summary_circle_layout_playground.py
+++ b/explorer/presentation/share_summary_circle_layout_playground.py
@@ -633,6 +633,35 @@ def render_circle_layout_playground_html(
   let diameter = CFG.diameter;
   let norms = [];
   let drag = null;
+  let applyingDefaults = false;
+  const sessionEdits = new Map();
+
+  function layoutKeyFor(ct, format, n) {{
+    const slots = ct === "spotlight" ? 1 : n;
+    return ct + "|" + format + "|" + slots;
+  }}
+
+  function layoutKey() {{
+    return layoutKeyFor(cardType, fmt, count);
+  }}
+
+  function codeDefaults(n) {{
+    return {{
+      norms: layoutForCount(n).map((p) => [p[0], p[1]]),
+      diameter: presetDiameter(n),
+    }};
+  }}
+
+  function saveSessionEdit() {{
+    sessionEdits.set(layoutKey(), {{
+      norms: norms.map((p) => [p[0], p[1]]),
+      diameter,
+    }});
+  }}
+
+  function clearSessionEdit(key) {{
+    sessionEdits.delete(key);
+  }}
 
   function clamp(n, lo, hi) {{ return Math.min(hi, Math.max(lo, n)); }}
 
@@ -847,6 +876,7 @@ def render_circle_layout_playground_html(
     drag.el.classList.remove("dragging");
     drag.el.releasePointerCapture(event.pointerId);
     drag = null;
+    saveSessionEdit();
   }}
 
   function formatExport() {{
@@ -896,24 +926,31 @@ def render_circle_layout_playground_html(
       " y=" + Math.round(b.yMin) + "–" + Math.round(b.yMax);
   }}
 
-  function setCount(n) {{
+  function loadLayoutState(n) {{
     const m = mode();
-    count = clamp(n, m.min_count, m.max_count);
+    const nextCount = clamp(n, m.min_count, m.max_count);
+    const key = layoutKeyFor(cardType, fmt, nextCount);
+    count = nextCount;
     countInput.value = String(count);
-    const preset = m.layouts[String(count)];
-    if (preset && preset.length === count) {{
-      norms = preset.map((p) => [p[0], p[1]]);
+
+    const saved = sessionEdits.get(key);
+    if (saved) {{
+      norms = saved.norms.map((p) => [p[0], p[1]]);
+      applyingDefaults = true;
+      setDiameter(saved.diameter);
+      applyingDefaults = false;
     }} else {{
-      const next = norms.slice(0, count);
-      if (next.length < count) {{
-        const defaults = layoutForCount(count);
-        for (let i = next.length; i < count; i += 1) {{
-          next.push(defaults[i]);
-        }}
-      }}
-      norms = next;
+      const defaults = codeDefaults(nextCount);
+      norms = defaults.norms;
+      applyingDefaults = true;
+      setDiameter(defaults.diameter);
+      applyingDefaults = false;
     }}
     renderCircles();
+  }}
+
+  function setCount(n) {{
+    loadLayoutState(n);
   }}
 
   function setDiameter(d) {{
@@ -927,21 +964,14 @@ def render_circle_layout_playground_html(
   function loadPreset(n) {{
     const preset = mode().layouts[String(n)];
     if (!preset) return;
-    count = n;
-    countInput.value = String(count);
-    norms = preset.map((p) => [p[0], p[1]]);
-    setDiameter(presetDiameter(n));
+    clearSessionEdit(layoutKeyFor(cardType, fmt, n));
+    loadLayoutState(n);
   }}
 
   function activateMode() {{
-    const m = mode();
-    count = m.default_count;
-    diameter = m.default_diameter;
-    norms = layoutForCount(count);
     applyModeUi();
     applyScale();
-    setDiameter(diameter);
-    setCount(count);
+    loadLayoutState(mode().default_count);
   }}
 
   cardTypeSelect.addEventListener("change", () => {{
@@ -953,15 +983,23 @@ def render_circle_layout_playground_html(
     activateMode();
   }});
   countInput.addEventListener("change", () => setCount(Number(countInput.value)));
-  diameterInput.addEventListener("input", () => setDiameter(Number(diameterInput.value)));
+  diameterInput.addEventListener("input", () => {{
+    setDiameter(Number(diameterInput.value));
+    if (!applyingDefaults) saveSessionEdit();
+  }});
   presetSelect.addEventListener("change", () => {{
     const val = presetSelect.value;
     if (val) loadPreset(Number(val));
     presetSelect.value = "";
   }});
   document.getElementById("reset-btn").addEventListener("click", () => {{
-    norms = layoutForCount(count);
-    setDiameter(presetDiameter(count));
+    clearSessionEdit(layoutKey());
+    const defaults = codeDefaults(count);
+    norms = defaults.norms;
+    applyingDefaults = true;
+    setDiameter(defaults.diameter);
+    applyingDefaults = false;
+    renderCircles();
   }});
   document.getElementById("copy-btn").addEventListener("click", async () => {{
     const text = formatExport();
@@ -980,10 +1018,7 @@ def render_circle_layout_playground_html(
   document.addEventListener("pointerup", onPointerUp);
   document.addEventListener("pointercancel", onPointerUp);
 
-  applyModeUi();
-  applyScale();
-  norms = layoutForCount(count);
-  renderCircles();
+  activateMode();
 }})();
 </script>
 </body>

--- a/explorer/presentation/share_summary_circle_layout_playground.py
+++ b/explorer/presentation/share_summary_circle_layout_playground.py
@@ -647,14 +647,24 @@ def render_circle_layout_playground_html(
 
   function codeDefaults(n) {{
     return {{
-      norms: layoutForCount(n).map((p) => [p[0], p[1]]),
+      norms: cloneNorms(layoutForCount(n)),
       diameter: presetDiameter(n),
     }};
   }}
 
+  function cloneNorms(source) {{
+    return source.map((p) => [p[0], p[1]]);
+  }}
+
+  function applyDiameterWithoutSessionSave(d) {{
+    applyingDefaults = true;
+    setDiameter(d);
+    applyingDefaults = false;
+  }}
+
   function saveSessionEdit() {{
     sessionEdits.set(layoutKey(), {{
-      norms: norms.map((p) => [p[0], p[1]]),
+      norms: cloneNorms(norms),
       diameter,
     }});
   }}
@@ -854,6 +864,7 @@ def render_circle_layout_playground_html(
       offsetX: (event.clientX - rect.left) / scale - pos.x,
       offsetY: (event.clientY - rect.top) / scale - pos.y,
       el: target,
+      moved: false,
     }};
     event.preventDefault();
   }}
@@ -866,6 +877,7 @@ def render_circle_layout_playground_html(
     const y = (event.clientY - rect.top) / scale - drag.offsetY;
     const norm = pixelToNorm(x, y);
     norms[drag.index] = [norm.nx, norm.ny];
+    drag.moved = true;
     drag.el.style.left = normToPixel(norm.nx, norm.ny).x + "px";
     drag.el.style.top = normToPixel(norm.nx, norm.ny).y + "px";
     updateExport();
@@ -875,8 +887,8 @@ def render_circle_layout_playground_html(
     if (!drag) return;
     drag.el.classList.remove("dragging");
     drag.el.releasePointerCapture(event.pointerId);
+    if (drag.moved) saveSessionEdit();
     drag = null;
-    saveSessionEdit();
   }}
 
   function formatExport() {{
@@ -935,22 +947,13 @@ def render_circle_layout_playground_html(
 
     const saved = sessionEdits.get(key);
     if (saved) {{
-      norms = saved.norms.map((p) => [p[0], p[1]]);
-      applyingDefaults = true;
-      setDiameter(saved.diameter);
-      applyingDefaults = false;
+      norms = cloneNorms(saved.norms);
+      applyDiameterWithoutSessionSave(saved.diameter);
     }} else {{
       const defaults = codeDefaults(nextCount);
       norms = defaults.norms;
-      applyingDefaults = true;
-      setDiameter(defaults.diameter);
-      applyingDefaults = false;
+      applyDiameterWithoutSessionSave(defaults.diameter);
     }}
-    renderCircles();
-  }}
-
-  function setCount(n) {{
-    loadLayoutState(n);
   }}
 
   function setDiameter(d) {{
@@ -982,7 +985,7 @@ def render_circle_layout_playground_html(
     fmt = formatSelect.value;
     activateMode();
   }});
-  countInput.addEventListener("change", () => setCount(Number(countInput.value)));
+  countInput.addEventListener("change", () => loadLayoutState(Number(countInput.value)));
   diameterInput.addEventListener("input", () => {{
     setDiameter(Number(diameterInput.value));
     if (!applyingDefaults) saveSessionEdit();
@@ -994,12 +997,7 @@ def render_circle_layout_playground_html(
   }});
   document.getElementById("reset-btn").addEventListener("click", () => {{
     clearSessionEdit(layoutKey());
-    const defaults = codeDefaults(count);
-    norms = defaults.norms;
-    applyingDefaults = true;
-    setDiameter(defaults.diameter);
-    applyingDefaults = false;
-    renderCircles();
+    loadLayoutState(count);
   }});
   document.getElementById("copy-btn").addEventListener("click", async () => {{
     const text = formatExport();

--- a/tests/explorer/test_share_summary_circle_layout_playground.py
+++ b/tests/explorer/test_share_summary_circle_layout_playground.py
@@ -71,9 +71,12 @@ def test_circle_layout_playground_count_change_loads_code_defaults_when_untouche
     assert "const sessionEdits = new Map();" in html
     assert "function layoutKeyFor(" in html
     assert "function codeDefaults(n)" in html
+    assert "function applyDiameterWithoutSessionSave(d)" in html
     assert "function loadLayoutState(n)" in html
     assert "sessionEdits.get(key)" in html
     assert "clearSessionEdit(layoutKey());" in html
+    assert "loadLayoutState(count);" in html
+    assert "if (drag.moved) saveSessionEdit();" in html
     assert "if (!applyingDefaults) saveSessionEdit();" in html
 
 

--- a/tests/explorer/test_share_summary_circle_layout_playground.py
+++ b/tests/explorer/test_share_summary_circle_layout_playground.py
@@ -63,14 +63,18 @@ def test_circle_layout_playground_tiles_uses_format_specific_count_limits():
         assert f'"default_count": {PLAYGROUND_TILES_DEFAULT_COUNT}' in fmt_html
 
 
-def test_circle_layout_playground_count_change_loads_full_preset():
+def test_circle_layout_playground_count_change_loads_code_defaults_when_untouched():
     html = render_circle_layout_playground_html(
         initial_card_type="tiles",
         initial_fmt="portrait_post",
     )
-    assert 'const preset = m.layouts[String(count)];' in html
-    assert "preset && preset.length === count" in html
-    assert "norms = preset.map((p) => [p[0], p[1]]);" in html
+    assert "const sessionEdits = new Map();" in html
+    assert "function layoutKeyFor(" in html
+    assert "function codeDefaults(n)" in html
+    assert "function loadLayoutState(n)" in html
+    assert "sessionEdits.get(key)" in html
+    assert "clearSessionEdit(layoutKey());" in html
+    assert "if (!applyingDefaults) saveSessionEdit();" in html
 
 
 def test_circle_layout_playground_spotlight_is_not_draggable():


### PR DESCRIPTION
## Summary
- Circle layout playground now loads positions and diameter from code presets when switching format, layout, or circle count, unless that layout was edited in the session
- Session edits (drag or diameter slider) are remembered per layout key until Reset clears them
- Resolves #302

## Test plan
- [x] `ruff check explorer/` passes
- [x] `pytest tests/ -q` — 773 passed, 11 skipped
- [ ] In design app Circle layout tab: switch circle counts on untouched layout — diameter/positions match code presets
- [ ] Drag or change diameter, switch away and back — edits restored
- [ ] Reset reloads code defaults and clears session override for active layout

Made with [Cursor](https://cursor.com)