### PR TITLE
test: Strengthen share-summary test integrity (#298)

### DIFF
--- a/tests/explorer/test_design_share_summary_app.py
+++ b/tests/explorer/test_design_share_summary_app.py
@@ -92,6 +92,15 @@ def test_card_stat_data_scope_changes_when_source_or_period_changes():
     assert other_month == "MyEBirdData.csv|month|May 2025|world"
     assert sample != csv
     assert csv != other_month
+    assert (
+        _card_stat_data_scope(
+            use_sample=True,
+            period_kind="month",
+            period_label="June 2025",
+            upload_name=None,
+        )
+        == sample
+    )
 
 
 def test_card_stat_data_scope_changes_when_geo_scope_changes():

--- a/tests/explorer/test_design_share_summary_app.py
+++ b/tests/explorer/test_design_share_summary_app.py
@@ -16,11 +16,38 @@ from explorer.core.share_summary_compute import (
 )
 
 
-def test_card_stat_ui_row_count_uses_slot_count_not_format_max():
+def test_card_stat_ui_row_count_clamps_slot_count_to_layout_limit():
     assert _card_stat_ui_row_count("tiles", "story", slot_count=4) == 4
     assert _card_stat_ui_row_count("minimal", "story", slot_count=6) == 6
     assert _card_stat_ui_row_count("tiles", "story", slot_count=12) == 10
     assert _card_stat_ui_row_count("tiles", "portrait_post", slot_count=3) == 3
+    assert (
+        _card_stat_ui_row_count(
+            "tiles",
+            "square",
+            slot_count=8,
+            tiles_presentation="circles",
+        )
+        == 6
+    )
+    assert (
+        _card_stat_ui_row_count(
+            "tiles",
+            "portrait_post",
+            slot_count=12,
+            tiles_presentation="circles",
+        )
+        == 8
+    )
+    assert (
+        _card_stat_ui_row_count(
+            "tiles",
+            "story",
+            slot_count=12,
+            tiles_presentation="circles",
+        )
+        == 10
+    )
 
 
 def test_default_card_stat_slot_count():
@@ -60,6 +87,9 @@ def test_card_stat_data_scope_changes_when_source_or_period_changes():
         period_label="May 2025",
         upload_name="MyEBirdData.csv",
     )
+    assert sample == "sample|month|June 2025|world"
+    assert csv == "MyEBirdData.csv|month|June 2025|world"
+    assert other_month == "MyEBirdData.csv|month|May 2025|world"
     assert sample != csv
     assert csv != other_month
 
@@ -79,6 +109,8 @@ def test_card_stat_data_scope_changes_when_geo_scope_changes():
         upload_name="MyEBirdData.csv",
         geo_scope=ShareSummaryGeoScope(country_key="AU-NSW"),
     )
+    assert world == "MyEBirdData.csv|year|2025|world"
+    assert country == "MyEBirdData.csv|year|2025|AU-NSW"
     assert world != country
 
 
@@ -123,8 +155,15 @@ def test_design_sample_dataset_has_checklists_for_current_year():
     df = _design_sample_dataset(year)
     stats = compute_share_summary_stats(df, period_for_year(year))
     assert stats is not None
-    assert stats.checklists is not None and stats.checklists > 0
-    assert stats.species is not None and stats.species > 0
+    assert stats.checklists == 4
+    assert stats.species == 12
+    assert stats.individuals == 24
+    assert stats.completed_checklists == 4
+    assert stats.incidental_checklists == 0
+    assert stats.locations == 4
+    assert stats.countries == 2
+    assert stats.birding_hours == 4.0
+    assert stats.days_with_checklist == 4
 
 
 def test_period_has_checklist_data():

--- a/tests/explorer/test_share_summary_circles_preview.py
+++ b/tests/explorer/test_share_summary_circles_preview.py
@@ -753,30 +753,6 @@ def test_tiles_circle_cluster_max_is_format_specific():
     assert tiles_circle_cluster_max("story") == TILES_CIRCLE_CLUSTER_STORY_MAX
 
 
-def test_layout_tiles_circle_cluster_square_clamps_seventh_user_stat():
-    stats = sample_share_summary_stats()
-    labels = (
-        "Total species",
-        "Lifers",
-        "Total checklists",
-        "Unique locations",
-        "Countries",
-        "Birding days",
-        "Total individuals",
-    )
-    html = layout_tiles_circle_cluster(
-        stats,
-        1080,
-        1080,
-        "square",
-        scope_label="World",
-        card_stat_labels=labels,
-    )
-    assert html.count("border-radius:50%") == TILES_CIRCLE_CLUSTER_SQUARE_MAX
-    assert "Birding days" in html
-    assert "Total individuals" not in html
-
-
 def test_circle_value_font_shrinks_for_long_numbers():
     assert _circle_value_font_px("312", 48, diameter=170) == 48
     assert _circle_value_font_px("12,450", 48, diameter=170) == 36

--- a/tests/explorer/test_share_summary_circles_preview.py
+++ b/tests/explorer/test_share_summary_circles_preview.py
@@ -92,8 +92,16 @@ def _placed_diameter(
     )
 
 
-def test_circle_variant_ids_count():
-    assert len(CIRCLE_VARIANT_IDS) == 7
+def test_circle_variant_ids_are_stable_for_design_picker():
+    assert CIRCLE_VARIANT_IDS == (
+        "cluster_soft",
+        "cluster_tight",
+        "cluster_stagger_a",
+        "cluster_stagger_b",
+        "cluster_wide",
+        "cluster_compact",
+        "tiles_cluster",
+    )
 
 
 def test_grid_reading_order_does_not_start_with_centre():
@@ -310,6 +318,16 @@ def test_layout_tiles_circle_cluster_story_renders_six_defaults():
     sizes = re.findall(r"width:(\d+)px;height:\1px;border-radius:50%", html)
     assert len(sizes) == 6
     assert int(sizes[0]) == STORY_CIRCLE_LAYOUT_DIAMETERS[6]
+    for label, value in (
+        ("Species", "312"),
+        ("Lifers", "47"),
+        ("Total checklists", "186"),
+        ("Unique locations", "42"),
+        ("Countries", "5"),
+        ("Birding days", "98"),
+    ):
+        assert label in html
+        assert value in html
 
 
 def test_story_circle_layouts_defined_for_one_through_ten():
@@ -668,6 +686,8 @@ def test_layout_tiles_circle_cluster_square_clamps_to_six():
     sizes = re.findall(r"width:(\d+)px;height:\1px;border-radius:50%", html)
     assert len(sizes) == TILES_CIRCLE_CLUSTER_SQUARE_MAX
     assert int(sizes[0]) == 250
+    assert "Birding days" in html
+    assert "Total individuals" not in html
 
 
 def test_layout_tiles_circle_cluster_portrait_circles_clear_footer():
@@ -753,6 +773,8 @@ def test_layout_tiles_circle_cluster_square_clamps_seventh_user_stat():
         card_stat_labels=labels,
     )
     assert html.count("border-radius:50%") == TILES_CIRCLE_CLUSTER_SQUARE_MAX
+    assert "Birding days" in html
+    assert "Total individuals" not in html
 
 
 def test_circle_value_font_shrinks_for_long_numbers():

--- a/tests/explorer/test_share_summary_compute.py
+++ b/tests/explorer/test_share_summary_compute.py
@@ -159,6 +159,46 @@ def test_longest_streak_not_computed_for_custom_trip():
     assert stats.longest_streak is None
 
 
+def test_week_period_omits_longest_streak_and_distance():
+    df = pd.DataFrame(
+        [
+            _row(sid="S1", dt="2025-06-01", species="Species a", distance_km=3.0),
+            _row(sid="S2", dt="2025-06-02", species="Species b", distance_km=4.0),
+            _row(sid="S3", dt="2025-06-08", species="Species c", distance_km=5.0),
+        ]
+    )
+    stats = compute_share_summary_stats(df, period_for_week_containing(date(2025, 6, 3)))
+    assert stats is not None
+    assert stats.period_kind == "week"
+    assert stats.checklists == 2
+    assert stats.species == 2
+    assert stats.days_with_checklist == 2
+    assert stats.longest_streak is None
+    assert stats.distance_km is None
+
+
+def test_compute_share_summary_stats_returns_none_for_empty_or_missing_date():
+    assert compute_share_summary_stats(pd.DataFrame(), period_for_year(2025)) is None
+    assert (
+        compute_share_summary_stats(
+            pd.DataFrame([{"Submission ID": "S1", "Common Name": "Species a"}]),
+            period_for_year(2025),
+        )
+        is None
+    )
+
+
+def test_compute_share_summary_stats_empty_period_returns_sparse_stats():
+    df = pd.DataFrame([_row(sid="S1", dt="2025-01-10", species="Species a")])
+    stats = compute_share_summary_stats(df, period_for_year(2026))
+    assert stats is not None
+    assert stats.period_label == "2026"
+    assert stats.period_kind == "year"
+    assert stats.species is None
+    assert stats.checklists is None
+    assert stats.lifers is None
+
+
 def test_period_for_lifetime_uses_full_export_span():
     period = period_for_lifetime(date(2018, 3, 15), date(2025, 11, 2))
     assert period.kind == "lifetime"
@@ -407,6 +447,7 @@ def test_geo_scope_world_leaves_df_unchanged():
     df = pd.DataFrame([_row(sid="S1", dt="2025-01-01", species="Species a")])
     out = filter_df_by_geo_scope(df, ShareSummaryGeoScope())
     assert len(out) == len(df)
+    assert list(out["Submission ID"]) == list(df["Submission ID"])
 
 
 def test_geo_scope_is_country_only():

--- a/tests/explorer/test_share_summary_hex_preview.py
+++ b/tests/explorer/test_share_summary_hex_preview.py
@@ -10,8 +10,21 @@ from explorer.presentation.share_summary_hex_preview import (
 from explorer.presentation.share_summary_preview import sample_share_summary_stats
 
 
-def test_hex_variant_ids_count():
-    assert len(HEX_VARIANT_IDS) == 12
+def test_hex_variant_ids_are_stable_for_design_picker():
+    assert HEX_VARIANT_IDS == (
+        "clip_flat_classic",
+        "clip_flat_compact",
+        "clip_flat_shadow",
+        "clip_pointy",
+        "svg_flat",
+        "clip_flat_gradient",
+        "tessellate_flat",
+        "tessellate_flat_shadow",
+        "tessellate_pointy",
+        "blob_ring",
+        "blob_spiral",
+        "blob_cluster",
+    )
 
 
 def test_render_hex_grid_preview_html_all_variants():

--- a/tests/explorer/test_share_summary_png_export.py
+++ b/tests/explorer/test_share_summary_png_export.py
@@ -42,8 +42,11 @@ def test_share_summary_png_filename_trip_title():
 
 
 def test_share_summary_png_filename_empty_label_falls_back():
+    # _slugify("") -> "birding-summary", then filename adds "-birding-summary.png"
     stats = ShareSummaryStats(period_label="", period_kind="custom")
     assert share_summary_png_filename(stats) == "birding-summary-birding-summary.png"
+    stats_whitespace = ShareSummaryStats(period_label="   ", period_kind="custom")
+    assert share_summary_png_filename(stats_whitespace) == "birding-summary-birding-summary.png"
 
 
 def test_png_dimensions_rejects_invalid_bytes():

--- a/tests/explorer/test_share_summary_png_export.py
+++ b/tests/explorer/test_share_summary_png_export.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from explorer.core.share_summary_compute import ShareSummaryStats
 from explorer.presentation.share_summary_png_export import (
     png_dimensions,
     share_summary_png_filename,
@@ -38,6 +39,18 @@ def test_share_summary_png_filename_trip_title():
         trip_title="North Coast NSW Exploration",
     )
     assert share_summary_png_filename(stats) == "north-coast-nsw-exploration-birding-summary.png"
+
+
+def test_share_summary_png_filename_empty_label_falls_back():
+    stats = ShareSummaryStats(period_label="", period_kind="custom")
+    assert share_summary_png_filename(stats) == "birding-summary-birding-summary.png"
+
+
+def test_png_dimensions_rejects_invalid_bytes():
+    with pytest.raises(ValueError, match="Not a valid PNG image"):
+        png_dimensions(b"")
+    with pytest.raises(ValueError, match="Not a valid PNG image"):
+        png_dimensions(b"not a png")
 
 
 @pytest.mark.parametrize(

--- a/tests/explorer/test_share_summary_preview.py
+++ b/tests/explorer/test_share_summary_preview.py
@@ -513,6 +513,34 @@ def test_card_stat_pairs_selected_labels_includes_all_time():
     assert pairs == [("Observed species (%)", "2.9%"), ("Lifers", "47")]
 
 
+def test_stat_pairs_hide_zero_shared_stats_and_geo_scope_countries():
+    from explorer.core.share_summary_compute import ShareSummaryGeoScope
+    from explorer.presentation.share_summary_preview import stat_pairs
+
+    stats = ShareSummaryStats(
+        period_label="June 2025",
+        period_kind="month",
+        species=12,
+        countries=2,
+        shared_checklists=0,
+        days_birding_with_others=0,
+    )
+    world_labels = [label for label, _ in stat_pairs(stats)]
+    assert "Countries" in world_labels
+    assert "Shared checklists" not in world_labels
+    assert "Days birding with others" not in world_labels
+
+    regional_labels = [
+        label
+        for label, _ in stat_pairs(
+            stats,
+            geo_scope=ShareSummaryGeoScope(country_key="AU", region_code="NSW"),
+        )
+    ]
+    assert "Countries" not in regional_labels
+    assert "Total species" in regional_labels
+
+
 def test_trip_title_on_all_layouts():
     from explorer.core.share_summary_defaults import (
         SHARE_SUMMARY_LAYOUT_SUBTITLE_MINIMAL,
@@ -602,6 +630,6 @@ def test_year_layouts_render_layout_subtitles_from_defaults():
     assert SHARE_SUMMARY_LAYOUT_SUBTITLE_MINIMAL in minimal_html
 
 
-def test_portrait_post_export_dimensions():
+def test_portrait_post_preview_dimensions():
     html = render_share_summary_preview_html(sample_share_summary_stats(), fmt="portrait_post")
     assert "1350px" in html

--- a/tests/explorer/test_share_summary_preview.py
+++ b/tests/explorer/test_share_summary_preview.py
@@ -1,10 +1,15 @@
 """Tests for :mod:`explorer.presentation.share_summary_preview`."""
 
-from explorer.core.share_summary_compute import ShareSummaryAllTimeStats, ShareSummaryStats
+from explorer.core.share_summary_compute import (
+    ShareSummaryAllTimeStats,
+    ShareSummaryGeoScope,
+    ShareSummaryStats,
+)
 from explorer.presentation.share_summary_preview import (
     render_share_summary_export_html,
     render_share_summary_preview_html,
     sample_share_summary_stats,
+    stat_pairs,
 )
 
 
@@ -514,9 +519,6 @@ def test_card_stat_pairs_selected_labels_includes_all_time():
 
 
 def test_stat_pairs_hide_zero_shared_stats_and_geo_scope_countries():
-    from explorer.core.share_summary_compute import ShareSummaryGeoScope
-    from explorer.presentation.share_summary_preview import stat_pairs
-
     stats = ShareSummaryStats(
         period_label="June 2025",
         period_kind="month",
@@ -632,4 +634,5 @@ def test_year_layouts_render_layout_subtitles_from_defaults():
 
 def test_portrait_post_preview_dimensions():
     html = render_share_summary_preview_html(sample_share_summary_stats(), fmt="portrait_post")
-    assert "1350px" in html
+    assert "width:1080px" in html
+    assert "height:1350px" in html


### PR DESCRIPTION
## Summary

One-off QA audit of the share-summary test suite on `feat/social-cards`. Replaces smoke-only or count-only assertions with behaviour-focused checks on compute boundaries, stat-pair filtering, circle/hex variant registries, design-app helpers, and PNG export utilities.

## Changes

- **Compute** (`test_share_summary_compute.py`): week-period omissions, empty/missing input, empty-period sparse stats, geo filter identity
- **Preview** (`test_share_summary_preview.py`): `stat_pairs` hide-if-zero and geo-scoped countries; portrait dimension checks; rename misnamed export test
- **Circles** (`test_share_summary_circles_preview.py`): stable variant IDs; story default label/value rendering; square clamp drops seventh stat; remove duplicate clamp test
- **Hex** (`test_share_summary_hex_preview.py`): stable variant ID registry
- **PNG export** (`test_share_summary_png_export.py`): filename fallback and invalid-bytes handling (no Playwright required)
- **Design app** (`test_design_share_summary_app.py`): exact sample-dataset stats, scope tokens, circles slot limits, scope stability

## Testing

- `python3 -m ruff check explorer/` — passed
- `python3 -m pytest tests/explorer/test_share_summary*.py tests/explorer/test_design_share_summary_app.py -q` — 138 passed, 4 skipped (Playwright Chromium not installed locally)

## Notes

- Test-only change; no production behaviour modified
- PNG screenshot tests still skip without Chromium (existing behaviour)
- Follow-up candidates: playground bounds parity, circles PNG export parametrisation, design-app Streamlit picker/session integration tests

Refs #298

Made with [Cursor](https://cursor.com)