### PR TITLE
Raise single-circle diameter to 480px and playground max to 560

### DIFF
--- a/explorer/presentation/share_summary_circle_layout_playground.py
+++ b/explorer/presentation/share_summary_circle_layout_playground.py
@@ -16,6 +16,7 @@ from explorer.core.share_summary_defaults import (
     SHARE_SUMMARY_LAYOUT_LABELS,
 )
 from explorer.presentation.share_summary_circles_preview import (
+    _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX,
     CIRCLE_VARIANT_SPECS,
     TILES_CIRCLE_CLUSTER_DEFAULT,
     TILES_CIRCLE_CLUSTER_VARIANT,
@@ -65,9 +66,7 @@ _STORY_BOTTOM_CLEARANCE = 52
 _SHADOW_PAD = 12
 _CLUSTER_UP_BIAS = 0.07
 _MIN_CLUSTER_DIAMETER = 96
-_MAX_CLUSTER_DIAMETER = 400
 _MIN_SPOTLIGHT_DIAMETER = 200
-_MAX_SPOTLIGHT_DIAMETER = 520
 
 PLAYGROUND_TILES_MIN_COUNT = 1
 PLAYGROUND_TILES_DEFAULT_COUNT = TILES_CIRCLE_CLUSTER_DEFAULT
@@ -297,7 +296,7 @@ def _build_tiles_playground_mode(
         "max_count": max_count,
         "default_count": default_count,
         "min_diameter": _MIN_CLUSTER_DIAMETER,
-        "max_diameter": _MAX_CLUSTER_DIAMETER,
+        "max_diameter": _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX,
         "default_diameter": diameters.get(
             str(default_count),
             auto_diameters[str(default_count)],
@@ -350,7 +349,7 @@ def _build_mode_config(card_type: PlaygroundCardType, fmt: FormatId) -> dict[str
         diameter = _spotlight_circle_diameter(canvas_w, canvas_h, fmt)
         center_norm = _spotlight_center_norm(canvas_w, canvas_h, diameter=diameter)
         max_diameter = min(
-            _MAX_SPOTLIGHT_DIAMETER,
+            _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX,
             min(canvas_w, canvas_h) - 2 * (_SHADOW_PAD + 12),
         )
         return {

--- a/explorer/presentation/share_summary_circle_layout_playground.py
+++ b/explorer/presentation/share_summary_circle_layout_playground.py
@@ -25,6 +25,7 @@ from explorer.presentation.share_summary_circles_preview import (
     _hand_tuned_body_bounds,
     _hand_tuned_template_diameter,
     _spotlight_circle_diameter,
+    _spotlight_circle_max_fit_diameter,
     _tiles_circle_body_insets,
     _tiles_circle_canvas_size,
     circle_card_template,
@@ -323,7 +324,7 @@ def _export_meta(card_type: PlaygroundCardType, fmt: FormatId) -> dict[str, str]
             target = "tiles circle cluster (algorithm today — add CIRCLE_CARD_TEMPLATES entry)"
         presentation_key = "tiles_presentation"
     else:
-        target = "_spotlight_circle_diameter (or per-format diameter dict if tuning)"
+        target = "_SINGLE_CIRCLE_DIAMETER_PX"
         presentation_key = "spotlight_presentation"
     return {
         "layout_id": card_type,
@@ -346,11 +347,11 @@ def _build_mode_config(card_type: PlaygroundCardType, fmt: FormatId) -> dict[str
             fmt,
             scope_label="World",
         )
-        diameter = _spotlight_circle_diameter(canvas_w, canvas_h, fmt)
+        diameter = _spotlight_circle_diameter(canvas_w, canvas_h)
         center_norm = _spotlight_center_norm(canvas_w, canvas_h, diameter=diameter)
         max_diameter = min(
             _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX,
-            min(canvas_w, canvas_h) - 2 * (_SHADOW_PAD + 12),
+            _spotlight_circle_max_fit_diameter(canvas_w, canvas_h),
         )
         return {
             **frame,

--- a/explorer/presentation/share_summary_circles_preview.py
+++ b/explorer/presentation/share_summary_circles_preview.py
@@ -578,10 +578,10 @@ _STORY_CIRCLE_TOP_CLEARANCE = _HAND_TUNED_CIRCLE_TOP_CLEARANCE
 _STORY_CIRCLE_BOTTOM_CLEARANCE = _HAND_TUNED_CIRCLE_BOTTOM_CLEARANCE
 _HAND_TUNED_CIRCLE_MIN_EDGE_GAP_PX = 20
 _STORY_CIRCLE_MIN_EDGE_GAP_PX = _HAND_TUNED_CIRCLE_MIN_EDGE_GAP_PX
-_HAND_TUNED_CIRCLE_MAX_DIAMETER_PX = 400
+_HAND_TUNED_CIRCLE_MAX_DIAMETER_PX = 560
 _STORY_CIRCLE_MAX_DIAMETER_PX = _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX
 _SINGLE_CIRCLE_LAYOUT: tuple[tuple[float, float], ...] = ((0.50, 0.50),)
-_SINGLE_CIRCLE_DIAMETER_PX = 400
+_SINGLE_CIRCLE_DIAMETER_PX = 480
 _HAND_TUNED_CIRCLE_WIDTH_FRACTION = 0.62
 _STORY_CIRCLE_WIDTH_FRACTION = _HAND_TUNED_CIRCLE_WIDTH_FRACTION
 
@@ -1423,18 +1423,11 @@ def layout_tiles_circle_cluster(
 
 
 def _spotlight_circle_diameter(canvas_w: int, canvas_h: int, fmt: FormatId) -> int:
-    """Single spotlight circle — much larger than Statistics Tiles cluster circles."""
+    """Single spotlight circle — same diameter as Statistics Tiles count-1 preset."""
+    del fmt
     pad = _SHADOW_PAD_PX + 12
-    avail = min(canvas_w, canvas_h) - 2 * pad
     max_fit = min(canvas_w - 2 * pad, canvas_h - 2 * pad)
-    if fmt == "story":
-        cap, ratio = 460, 0.56
-    elif fmt == "portrait_post":
-        cap, ratio = 420, 0.54
-    else:
-        cap, ratio = 380, 0.52
-    base = min(int(avail * ratio), cap)
-    return max(240, min(int(base * 1.5), max_fit))
+    return max(240, min(_SINGLE_CIRCLE_DIAMETER_PX, max_fit))
 
 
 def _spotlight_circle_value_base_px(

--- a/explorer/presentation/share_summary_circles_preview.py
+++ b/explorer/presentation/share_summary_circles_preview.py
@@ -582,6 +582,8 @@ _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX = 560
 _STORY_CIRCLE_MAX_DIAMETER_PX = _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX
 _SINGLE_CIRCLE_LAYOUT: tuple[tuple[float, float], ...] = ((0.50, 0.50),)
 _SINGLE_CIRCLE_DIAMETER_PX = 480
+_SPOTLIGHT_CIRCLE_EDGE_PAD_PX = _SHADOW_PAD_PX + 12
+_SPOTLIGHT_CIRCLE_MIN_DIAMETER_PX = 240
 _HAND_TUNED_CIRCLE_WIDTH_FRACTION = 0.62
 _STORY_CIRCLE_WIDTH_FRACTION = _HAND_TUNED_CIRCLE_WIDTH_FRACTION
 
@@ -1422,12 +1424,19 @@ def layout_tiles_circle_cluster(
 </div>"""
 
 
-def _spotlight_circle_diameter(canvas_w: int, canvas_h: int, fmt: FormatId) -> int:
+def _spotlight_circle_max_fit_diameter(canvas_w: int, canvas_h: int) -> int:
+    """Largest circle diameter that fits the spotlight body canvas."""
+    pad = _SPOTLIGHT_CIRCLE_EDGE_PAD_PX
+    return min(canvas_w - 2 * pad, canvas_h - 2 * pad)
+
+
+def _spotlight_circle_diameter(canvas_w: int, canvas_h: int) -> int:
     """Single spotlight circle — same diameter as Statistics Tiles count-1 preset."""
-    del fmt
-    pad = _SHADOW_PAD_PX + 12
-    max_fit = min(canvas_w - 2 * pad, canvas_h - 2 * pad)
-    return max(240, min(_SINGLE_CIRCLE_DIAMETER_PX, max_fit))
+    max_fit = _spotlight_circle_max_fit_diameter(canvas_w, canvas_h)
+    return max(
+        _SPOTLIGHT_CIRCLE_MIN_DIAMETER_PX,
+        min(_SINGLE_CIRCLE_DIAMETER_PX, max_fit),
+    )
 
 
 def _spotlight_circle_value_base_px(
@@ -1473,7 +1482,7 @@ def layout_spotlight_circle(
         fmt,
         scope_label=scope_label,
     )
-    diameter = _spotlight_circle_diameter(canvas_w, canvas_h, fmt)
+    diameter = _spotlight_circle_diameter(canvas_w, canvas_h)
     value_base = _spotlight_circle_value_base_px(
         diameter,
         width=width,

--- a/tests/explorer/test_share_summary_circle_layout_playground.py
+++ b/tests/explorer/test_share_summary_circle_layout_playground.py
@@ -95,8 +95,8 @@ def test_circle_layout_playground_story_tiles_uses_code_layout():
         initial_fmt="story",
     )
     assert "CIRCLE_CARD_TEMPLATES" in html
-    assert '"max_diameter": 400' in html
-    assert '"1": 400' in html
+    assert '"max_diameter": 560' in html
+    assert '"1": 480' in html
     assert '"2": 380' in html
     assert '"3": 380' in html
     assert '"6": 340' in html
@@ -112,7 +112,7 @@ def test_circle_layout_playground_portrait_tiles_uses_code_layout():
     )
     assert "CIRCLE_CARD_TEMPLATES" in html
     assert "portrait_post" in html
-    assert '"1": 400' in html
+    assert '"1": 480' in html
     assert '"6": 255' in html
     assert '"7": 255' in html
     assert '"8": 245' in html

--- a/tests/explorer/test_share_summary_circle_layout_playground.py
+++ b/tests/explorer/test_share_summary_circle_layout_playground.py
@@ -11,6 +11,8 @@ from explorer.presentation.share_summary_circle_layout_playground import (
     story_circle_body_bounds_for_playground,
 )
 from explorer.presentation.share_summary_circles_preview import (
+    _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX,
+    _SINGLE_CIRCLE_DIAMETER_PX,
     CIRCLE_CARD_TEMPLATES,
     STORY_CIRCLE_LAYOUTS,
     TILES_CIRCLE_CLUSTER_PORTRAIT_MAX,
@@ -95,8 +97,8 @@ def test_circle_layout_playground_story_tiles_uses_code_layout():
         initial_fmt="story",
     )
     assert "CIRCLE_CARD_TEMPLATES" in html
-    assert '"max_diameter": 560' in html
-    assert '"1": 480' in html
+    assert f'"max_diameter": {_HAND_TUNED_CIRCLE_MAX_DIAMETER_PX}' in html
+    assert f'"1": {_SINGLE_CIRCLE_DIAMETER_PX}' in html
     assert '"2": 380' in html
     assert '"3": 380' in html
     assert '"6": 340' in html
@@ -112,7 +114,7 @@ def test_circle_layout_playground_portrait_tiles_uses_code_layout():
     )
     assert "CIRCLE_CARD_TEMPLATES" in html
     assert "portrait_post" in html
-    assert '"1": 480' in html
+    assert f'"1": {_SINGLE_CIRCLE_DIAMETER_PX}' in html
     assert '"6": 255' in html
     assert '"7": 255' in html
     assert '"8": 245' in html
@@ -126,6 +128,8 @@ def test_circle_layout_playground_square_tiles_uses_code_layout():
         initial_fmt="square",
     )
     assert "CIRCLE_CARD_TEMPLATES" in html
+    assert f'"max_diameter": {_HAND_TUNED_CIRCLE_MAX_DIAMETER_PX}' in html
+    assert f'"1": {_SINGLE_CIRCLE_DIAMETER_PX}' in html
     assert '"2": 360' in html
     assert '"3": 285' in html
     assert '"4": 275' in html

--- a/tests/explorer/test_share_summary_circles_preview.py
+++ b/tests/explorer/test_share_summary_circles_preview.py
@@ -598,7 +598,7 @@ def test_layout_tiles_circle_cluster_single_circle_centred_all_formats():
         assert html.count("border-radius:50%") == 1
         sizes = re.findall(r"width:(\d+)px;height:\1px;border-radius:50%", html)
         assert len(sizes) == 1
-        assert int(sizes[0]) == 400
+        assert int(sizes[0]) == 480
         canvas = re.search(
             r"position:relative;width:(\d+)px;height:(\d+)px;margin:0 auto;overflow:hidden",
             html,
@@ -612,7 +612,7 @@ def test_layout_tiles_circle_cluster_single_circle_centred_all_formats():
             1,
             canvas_w=canvas_w,
             canvas_h=canvas_h,
-            diameter=400,
+            diameter=480,
         )[0]
         centre = re.search(
             r"position:absolute;left:([\d.]+)px;top:([\d.]+)px;\s*transform:translate\(-50%,-50%\)",
@@ -646,7 +646,7 @@ def test_square_circle_template_covers_counts_one_through_six():
     template = CIRCLE_CARD_TEMPLATES[("tiles", "square")]
     assert set(template.counts) == {1, 2, 3, 4, 5, 6}
     assert circle_card_template_diameters(template) == {
-        1: 400,
+        1: 480,
         2: 360,
         3: 285,
         4: 275,
@@ -840,6 +840,26 @@ def test_share_summary_preview_tiles_circle_cluster():
     assert html.count("border-radius:50%") == 6
 
 
+def test_spotlight_circle_matches_single_tiles_circle_diameter_all_formats():
+    from explorer.presentation.share_summary_circles_preview import (
+        _SINGLE_CIRCLE_DIAMETER_PX,
+    )
+
+    cases = (
+        ("square", 1080, 1080),
+        ("portrait_post", 1080, 1350),
+        ("story", 1080, 1920),
+    )
+    for fmt, card_w, card_h in cases:
+        canvas_w, canvas_h = _circle_canvas_size(
+            card_w,
+            card_h,
+            fmt,
+            scope_label="World",
+        )
+        assert _spotlight_circle_diameter(canvas_w, canvas_h, fmt) == _SINGLE_CIRCLE_DIAMETER_PX
+
+
 def test_spotlight_circle_is_larger_than_tiles_cluster_circle():
     canvas_w, canvas_h = _circle_canvas_size(1080, 1080, "square", scope_label="World")
     tiles_d = _placed_diameter(6, canvas_w, canvas_h, TILES_CIRCLE_CLUSTER_VARIANT)
@@ -890,3 +910,5 @@ def test_layout_spotlight_circle_renders():
     )
     assert "border-radius:50%" in html
     assert "47" in html
+    sizes = re.findall(r"width:(\d+)px;height:\1px;border-radius:50%", html)
+    assert sizes == ["480"]

--- a/tests/explorer/test_share_summary_circles_preview.py
+++ b/tests/explorer/test_share_summary_circles_preview.py
@@ -5,6 +5,7 @@ import re
 import pytest
 
 from explorer.presentation.share_summary_circles_preview import (
+    _SINGLE_CIRCLE_DIAMETER_PX,
     CIRCLE_CARD_TEMPLATES,
     CIRCLE_VARIANT_IDS,
     CIRCLE_VARIANT_SPECS,
@@ -20,6 +21,7 @@ from explorer.presentation.share_summary_circles_preview import (
     _hand_tuned_template_centres,
     _hand_tuned_template_within_canvas,
     _spotlight_circle_diameter,
+    _spotlight_circle_value_base_px,
     _story_circle_diameter,
     _story_circle_fits,
     _story_circle_template_centres,
@@ -598,7 +600,7 @@ def test_layout_tiles_circle_cluster_single_circle_centred_all_formats():
         assert html.count("border-radius:50%") == 1
         sizes = re.findall(r"width:(\d+)px;height:\1px;border-radius:50%", html)
         assert len(sizes) == 1
-        assert int(sizes[0]) == 480
+        assert int(sizes[0]) == _SINGLE_CIRCLE_DIAMETER_PX
         canvas = re.search(
             r"position:relative;width:(\d+)px;height:(\d+)px;margin:0 auto;overflow:hidden",
             html,
@@ -612,7 +614,7 @@ def test_layout_tiles_circle_cluster_single_circle_centred_all_formats():
             1,
             canvas_w=canvas_w,
             canvas_h=canvas_h,
-            diameter=480,
+            diameter=_SINGLE_CIRCLE_DIAMETER_PX,
         )[0]
         centre = re.search(
             r"position:absolute;left:([\d.]+)px;top:([\d.]+)px;\s*transform:translate\(-50%,-50%\)",
@@ -646,7 +648,7 @@ def test_square_circle_template_covers_counts_one_through_six():
     template = CIRCLE_CARD_TEMPLATES[("tiles", "square")]
     assert set(template.counts) == {1, 2, 3, 4, 5, 6}
     assert circle_card_template_diameters(template) == {
-        1: 480,
+        1: _SINGLE_CIRCLE_DIAMETER_PX,
         2: 360,
         3: 285,
         4: 275,
@@ -841,10 +843,6 @@ def test_share_summary_preview_tiles_circle_cluster():
 
 
 def test_spotlight_circle_matches_single_tiles_circle_diameter_all_formats():
-    from explorer.presentation.share_summary_circles_preview import (
-        _SINGLE_CIRCLE_DIAMETER_PX,
-    )
-
     cases = (
         ("square", 1080, 1080),
         ("portrait_post", 1080, 1350),
@@ -857,23 +855,19 @@ def test_spotlight_circle_matches_single_tiles_circle_diameter_all_formats():
             fmt,
             scope_label="World",
         )
-        assert _spotlight_circle_diameter(canvas_w, canvas_h, fmt) == _SINGLE_CIRCLE_DIAMETER_PX
+        assert _spotlight_circle_diameter(canvas_w, canvas_h) == _SINGLE_CIRCLE_DIAMETER_PX
 
 
-def test_spotlight_circle_is_larger_than_tiles_cluster_circle():
+def test_spotlight_circle_is_larger_than_six_stat_tiles_cluster():
     canvas_w, canvas_h = _circle_canvas_size(1080, 1080, "square", scope_label="World")
     tiles_d = _placed_diameter(6, canvas_w, canvas_h, TILES_CIRCLE_CLUSTER_VARIANT)
-    spotlight_d = _spotlight_circle_diameter(canvas_w, canvas_h, "square")
+    spotlight_d = _spotlight_circle_diameter(canvas_w, canvas_h)
     assert spotlight_d > tiles_d * 1.5
 
 
 def test_spotlight_circle_value_font_matches_classic_for_short_numbers():
-    from explorer.presentation.share_summary_circles_preview import (
-        _spotlight_circle_value_base_px,
-    )
-
     canvas_w, canvas_h = _circle_canvas_size(1080, 1080, "square", scope_label="World")
-    diameter = _spotlight_circle_diameter(canvas_w, canvas_h, "square")
+    diameter = _spotlight_circle_diameter(canvas_w, canvas_h)
     base = _spotlight_circle_value_base_px(diameter, width=1080, height=1080)
     assert base == 160
     assert _circle_value_font_px("47", base, diameter=diameter) == 160
@@ -911,4 +905,4 @@ def test_layout_spotlight_circle_renders():
     assert "border-radius:50%" in html
     assert "47" in html
     sizes = re.findall(r"width:(\d+)px;height:\1px;border-radius:50%", html)
-    assert sizes == ["480"]
+    assert sizes == [str(_SINGLE_CIRCLE_DIAMETER_PX)]


### PR DESCRIPTION
## Summary

Experiment from #300: bump the single-stat circle preset from 400px to 480px so one circle fills the square card body with usable whitespace, and raise the design playground slider ceiling to 560px for further tuning. Spotlight single-circle cards now use the same 480px diameter as Statistics Tiles count-1 layouts.

## Changes

- Set `_SINGLE_CIRCLE_DIAMETER_PX` to 480 for square, portrait, and story Statistics Tiles templates
- Raise `_HAND_TUNED_CIRCLE_MAX_DIAMETER_PX` to 560 and wire playground tiles/spotlight slider max to that shared cap
- Align `_spotlight_circle_diameter` with the shared single-circle preset (replacing format-specific formula)
- Update playground and renderer tests for new diameters

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` — 784 passed, 11 skipped
- Manual visual QA in design app Circle layout playground and card preview (confirmed by author)

## Notes

- Spotlight typography still differs from Statistics Tiles; font sizing is tracked separately (#295)
- Playground max of 560px retained for future design experiments

## Issues

Refs #300

Made with [Cursor](https://cursor.com)