### PR TITLE
ci: Run GitHub Actions on feat/social-cards and add agent-ready issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,9 +6,21 @@ labels: bug
 assignees: ''
 ---
 
-The following is a guide on how to give developer(s) enough information to find, reproduce and fix a reported bug.  Treat this as a guide and not prescriptive; we will understand if not all information is included on a simple bug that is easy to find/explain for example.
+The following is a guide on how to give developer(s) enough information to find, reproduce and fix a reported bug. Treat this as a guide and not prescriptive; we will understand if not all information is included on a simple bug that is easy to find/explain for example.
 
-Feel free to remove text below that is not required.  Clear and consice is better than verbose and cluttered.
+Feel free to remove text below that is not required. Clear and concise is better than verbose and cluttered.
+
+## Base branch
+
+`beta-next` | `feat/social-cards` | other (name it)
+
+Default is **`beta-next`** when this section is left unchanged.
+
+## PR target
+
+Usually the same as base branch. For feature-line work (e.g. Social Cards), both are often `feat/social-cards`.
+
+---
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -30,6 +42,16 @@ If applicable, add screenshots to help explain your problem.
 - OS: [e.g. macOS, Windows]
 - Python version: [e.g. 3.11]
 - Browser: [e.g. Chrome, Safari] (if applicable)
+
+## Acceptance criteria
+
+- [ ] Bug no longer reproduces with steps above
+- [ ] …
+
+## Test plan
+
+- [ ] e.g. `python3 -m pytest tests/path/to/test_module.py -q`
+- [ ] Manual repro verified after fix
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,13 +12,13 @@ Feel free to remove text below that is not required. Clear and concise is better
 
 ## Base branch
 
-`beta-next` | `feat/social-cards` | other (name it)
+`beta-next` (default) | `feat/social-cards` (Social Cards feature line)
 
-Default is **`beta-next`** when this section is left unchanged.
+Only these two integration branches are long-lived; create issue branches from one of them.
 
 ## PR target
 
-Usually the same as base branch. For feature-line work (e.g. Social Cards), both are often `feat/social-cards`.
+Same as base branch unless stated otherwise.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -7,6 +7,18 @@ assignees: ''
 
 ---
 
+## Base branch
+
+`beta-next` | `feat/social-cards` | other (name it)
+
+Default is **`beta-next`** when this section is left unchanged.
+
+## PR target
+
+Usually the same as base branch. For feature-line work (e.g. Social Cards), both are often `feat/social-cards`.
+
+---
+
 ## Summary
 
 Brief description of the improvement.
@@ -22,6 +34,15 @@ What should be improved?
 ## Reason / Benefit
 
 Why is this change useful?
+
+## Acceptance criteria
+
+- [ ] …
+
+## Test plan
+
+- [ ] e.g. `python3 -m pytest tests/path/to/test_module.py -q`
+- [ ] Manual smoke (if UI): …
 
 ## Notes (optional)
 

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -9,13 +9,13 @@ assignees: ''
 
 ## Base branch
 
-`beta-next` | `feat/social-cards` | other (name it)
+`beta-next` (default) | `feat/social-cards` (Social Cards feature line)
 
-Default is **`beta-next`** when this section is left unchanged.
+Only these two integration branches are long-lived; create issue branches from one of them.
 
 ## PR target
 
-Usually the same as base branch. For feature-line work (e.g. Social Cards), both are often `feat/social-cards`.
+Same as base branch unless stated otherwise.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,18 @@ labels: enhancement
 assignees: ''
 ---
 
+## Base branch
+
+`beta-next` | `feat/social-cards` | other (name it)
+
+Default is **`beta-next`** when this section is left unchanged.
+
+## PR target
+
+Usually the same as base branch. For feature-line work (e.g. Social Cards), both are often `feat/social-cards`.
+
+---
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
@@ -14,6 +26,15 @@ A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
+
+## Acceptance criteria
+
+- [ ] …
+
+## Test plan
+
+- [ ] e.g. `python3 -m pytest tests/path/to/test_module.py -q`
+- [ ] Manual smoke (if UI): …
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,13 @@ assignees: ''
 
 ## Base branch
 
-`beta-next` | `feat/social-cards` | other (name it)
+`beta-next` (default) | `feat/social-cards` (Social Cards feature line)
 
-Default is **`beta-next`** when this section is left unchanged.
+Only these two integration branches are long-lived; create issue branches from one of them.
 
 ## PR target
 
-Usually the same as base branch. For feature-line work (e.g. Social Cards), both are often `feat/social-cards`.
+Same as base branch unless stated otherwise.
 
 ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,9 @@ concurrency:
 
 on:
   push:
-    branches: [main, beta-next]
+    branches: [main, beta-next, feat/social-cards]
   pull_request:
-    branches: [main, beta-next]
+    branches: [main, beta-next, feat/social-cards]
   workflow_dispatch:
     inputs:
       run_e2e:

--- a/docs/explorer/social-cards-workflow.md
+++ b/docs/explorer/social-cards-workflow.md
@@ -63,8 +63,8 @@ Open **one PR**: `feat/social-cards` → `beta-next`, with test plan and tracker
 
 ## CI / automations
 
-- **GitHub Actions** (`.github/workflows/tests.yml`): runs on push/PR to `main`, `beta-next`, and **`feat/social-cards`**.
-- **Test Integrity Sentinel** (Cursor automation): targets PRs to `beta-next`. For PRs to **`feat/social-cards`**, duplicate or extend the automation — [#297](https://github.com/jimchurches/myebirdstuff/issues/297). GitHub Actions unit tests still run on push/PR per `.github/workflows/tests.yml`.
+- **GitHub Actions** (`.github/workflows/tests.yml`): unit tests on push/PR to `main`, `beta-next`, and **`feat/social-cards`**.
+- **Test Integrity Sentinel** (Cursor automation): test-integrity PR comments for targets to `beta-next`. For **`feat/social-cards`** PRs, duplicate or extend — [#297](https://github.com/jimchurches/myebirdstuff/issues/297).
 
 ---
 

--- a/docs/explorer/social-cards-workflow.md
+++ b/docs/explorer/social-cards-workflow.md
@@ -63,6 +63,7 @@ Open **one PR**: `feat/social-cards` → `beta-next`, with test plan and tracker
 
 ## CI / automations
 
+- **GitHub Actions** (`.github/workflows/tests.yml`): runs on push/PR to `main`, `beta-next`, and **`feat/social-cards`**.
 - **Test Integrity Sentinel** (Cursor automation): targets PRs to `beta-next`. For PRs to **`feat/social-cards`**, duplicate or extend the automation — [#297](https://github.com/jimchurches/myebirdstuff/issues/297). GitHub Actions unit tests still run on push/PR per `.github/workflows/tests.yml`.
 
 ---


### PR DESCRIPTION
## Summary

Close the CI gap for Social Cards feature-line work: GitHub Actions now runs on push and pull requests targeting **`feat/social-cards`**, not only `main` and `beta-next`. Standardize issue templates with agent-parseable **Base branch**, **PR target**, **Acceptance criteria**, and **Test plan** sections.

## Changes

- **`.github/workflows/tests.yml`** — add `feat/social-cards` to `push` and `pull_request` branch filters
- **Issue templates** (`bug_report`, `enhancement_request`, `feature_request`) — structured fields for workflow commands / agents ([#312](https://github.com/jimchurches/myebirdstuff/issues/312))
- **`docs/explorer/social-cards-workflow.md`** — document CI coverage for the feature branch

## Testing

- No Python/runtime changes; YAML and markdown only
- After merge: PRs into `feat/social-cards` should trigger the existing Python CI workflow

## Notes

- Default base branch in templates remains **`beta-next`** when sections are unchanged
- `push` to `feat/social-cards` also triggers CI (parity with `main` / `beta-next`)

## Issues

Refs #312


Made with [Cursor](https://cursor.com)