### PR TITLE
Tune single- and two-circle Statistics Tiles typography (#295)

### DIFF
--- a/explorer/presentation/share_summary_circle_layout_playground.py
+++ b/explorer/presentation/share_summary_circle_layout_playground.py
@@ -31,6 +31,7 @@ from explorer.presentation.share_summary_circles_preview import (
     circle_card_template,
     circle_card_template_diameters,
     circle_card_template_positions,
+    hand_tuned_circle_typography_px,
     place_circle_centers,
     tiles_circle_cluster_max,
 )
@@ -68,6 +69,10 @@ _SHADOW_PAD = 12
 _CLUSTER_UP_BIAS = 0.07
 _MIN_CLUSTER_DIAMETER = 96
 _MIN_SPOTLIGHT_DIAMETER = 200
+_TILES_CIRCLE_VALUE_FONT_MIN = 32
+_TILES_CIRCLE_VALUE_FONT_MAX = 200
+_TILES_CIRCLE_LABEL_FONT_MIN = 14
+_TILES_CIRCLE_LABEL_FONT_MAX = 36
 
 PLAYGROUND_TILES_MIN_COUNT = 1
 PLAYGROUND_TILES_DEFAULT_COUNT = TILES_CIRCLE_CLUSTER_DEFAULT
@@ -229,6 +234,40 @@ def _tiles_playground_count_range(fmt: FormatId) -> range:
     return range(PLAYGROUND_TILES_MIN_COUNT, _tiles_playground_max_count(fmt) + 1)
 
 
+def _tiles_circle_typography_config() -> dict[str, int]:
+    """Slider ranges for Statistics Tiles circle typography tuning."""
+    return {
+        "min_value_font_px": _TILES_CIRCLE_VALUE_FONT_MIN,
+        "max_value_font_px": _TILES_CIRCLE_VALUE_FONT_MAX,
+        "min_label_font_px": _TILES_CIRCLE_LABEL_FONT_MIN,
+        "max_label_font_px": _TILES_CIRCLE_LABEL_FONT_MAX,
+    }
+
+
+def _typography_defaults_for_count(
+    count: int,
+    diameter: int,
+    *,
+    bounds: str,
+    fmt: FormatId,
+) -> dict[str, int]:
+    """Match production tier defaults in share_summary_circles_preview."""
+    tuned = hand_tuned_circle_typography_px(fmt, count)
+    if tuned is not None:
+        value_px, label_px = tuned
+        return {"value_font_px": value_px, "label_font_px": label_px}
+    compact_threshold = 10 if bounds == "story" else 7
+    if count >= compact_threshold:
+        value_px, label_px = 40, 16
+    elif diameter >= 260:
+        value_px, label_px = 52, 19
+    elif diameter >= 240:
+        value_px, label_px = 46, 17
+    else:
+        value_px, label_px = 48, 18
+    return {"value_font_px": value_px, "label_font_px": label_px}
+
+
 def _build_tiles_playground_mode(
     frame: dict[str, int],
     fmt: FormatId,
@@ -306,6 +345,16 @@ def _build_tiles_playground_mode(
         "diameters": diameters,
         "auto_diameters": auto_diameters,
         "code_presets": code_presets,
+        "circle_typography": _tiles_circle_typography_config(),
+        "typography_defaults": {
+            str(count): _typography_defaults_for_count(
+                count,
+                diameters.get(str(count), auto_diameters[str(count)]),
+                bounds=bounds,
+                fmt=fmt,
+            )
+            for count in counts
+        },
         **_playground_body_frame("tiles", fmt),
         **export_meta,
     }
@@ -347,7 +396,7 @@ def _build_mode_config(card_type: PlaygroundCardType, fmt: FormatId) -> dict[str
             fmt,
             scope_label="World",
         )
-        diameter = _spotlight_circle_diameter(canvas_w, canvas_h)
+        diameter = _spotlight_circle_diameter(canvas_w, canvas_h, fmt=fmt)
         center_norm = _spotlight_center_norm(canvas_w, canvas_h, diameter=diameter)
         max_diameter = min(
             _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX,
@@ -560,7 +609,8 @@ def render_circle_layout_playground_html(
 <body>
   <p class="hint">
     Dev tuner for circle presentations. Drag to reposition (except Spotlight — centred).
-    Copy output into <code>share_summary_circles_preview.py</code> when tuning layouts.
+    For Statistics Tiles, use the value/label font sliders to tune typography per circle count
+    before copying sizes into <code>share_summary_circles_preview.py</code>.
   </p>
   <div class="toolbar">
     <label>Layout
@@ -580,6 +630,14 @@ def render_circle_layout_playground_html(
       <select id="preset">
         <option value="">Load code preset…</option>
       </select>
+    </label>
+    <label id="value-font-wrap" class="hidden">Value font <span id="value-font-val">48</span>px
+      <input type="range" id="value-font" min="{_TILES_CIRCLE_VALUE_FONT_MIN}"
+        max="{_TILES_CIRCLE_VALUE_FONT_MAX}" value="48"/>
+    </label>
+    <label id="label-font-wrap" class="hidden">Label font <span id="label-font-val">18</span>px
+      <input type="range" id="label-font" min="{_TILES_CIRCLE_LABEL_FONT_MIN}"
+        max="{_TILES_CIRCLE_LABEL_FONT_MAX}" value="18"/>
     </label>
     <button type="button" id="reset-btn">Reset layout</button>
     <button type="button" id="copy-btn">Copy export</button>
@@ -621,6 +679,12 @@ def render_circle_layout_playground_html(
   const diameterVal = document.getElementById("diameter-val");
   const presetWrap = document.getElementById("preset-wrap");
   const presetSelect = document.getElementById("preset");
+  const valueFontWrap = document.getElementById("value-font-wrap");
+  const valueFontInput = document.getElementById("value-font");
+  const valueFontVal = document.getElementById("value-font-val");
+  const labelFontWrap = document.getElementById("label-font-wrap");
+  const labelFontInput = document.getElementById("label-font");
+  const labelFontVal = document.getElementById("label-font-val");
   const exportText = document.getElementById("export-text");
   const metaText = document.getElementById("meta-text");
 
@@ -631,10 +695,53 @@ def render_circle_layout_playground_html(
   let fmt = CFG.fmt;
   let count = CFG.count;
   let diameter = CFG.diameter;
+  let valueFontBasePx = 48;
+  let labelFontPxNum = 18;
   let norms = [];
   let drag = null;
   let applyingDefaults = false;
   const sessionEdits = new Map();
+
+  function circleTypography() {{
+    return mode().circle_typography || null;
+  }}
+
+  function usesTilesCircleFontSliders() {{
+    return cardType === "tiles" && circleTypography() !== null;
+  }}
+
+  function defaultTypographyForCount(n) {{
+    const defaults = mode().typography_defaults[String(n)];
+    if (defaults) {{
+      return {{
+        valueFontPx: defaults.value_font_px,
+        labelFontPx: defaults.label_font_px,
+      }};
+    }}
+    return {{ valueFontPx: 48, labelFontPx: 18 }};
+  }}
+
+  function applyCircleTypographyWithoutSessionSave(valuePx, labelPx) {{
+    applyingDefaults = true;
+    setCircleTypography(valuePx, labelPx);
+    applyingDefaults = false;
+  }}
+
+  function setCircleTypography(valuePx, labelPx) {{
+    const t = circleTypography();
+    if (!t) return;
+    valueFontBasePx = clamp(valuePx, t.min_value_font_px, t.max_value_font_px);
+    labelFontPxNum = clamp(labelPx, t.min_label_font_px, t.max_label_font_px);
+    valueFontInput.min = String(t.min_value_font_px);
+    valueFontInput.max = String(t.max_value_font_px);
+    valueFontInput.value = String(valueFontBasePx);
+    valueFontVal.textContent = String(valueFontBasePx);
+    labelFontInput.min = String(t.min_label_font_px);
+    labelFontInput.max = String(t.max_label_font_px);
+    labelFontInput.value = String(labelFontPxNum);
+    labelFontVal.textContent = String(labelFontPxNum);
+    renderCircles();
+  }}
 
   function layoutKeyFor(ct, format, n) {{
     const slots = ct === "spotlight" ? 1 : n;
@@ -646,10 +753,16 @@ def render_circle_layout_playground_html(
   }}
 
   function codeDefaults(n) {{
-    return {{
+    const defaults = {{
       norms: cloneNorms(layoutForCount(n)),
       diameter: presetDiameter(n),
     }};
+    if (cardType === "tiles") {{
+      const typography = defaultTypographyForCount(n);
+      defaults.valueFontPx = typography.valueFontPx;
+      defaults.labelFontPx = typography.labelFontPx;
+    }}
+    return defaults;
   }}
 
   function cloneNorms(source) {{
@@ -663,10 +776,15 @@ def render_circle_layout_playground_html(
   }}
 
   function saveSessionEdit() {{
-    sessionEdits.set(layoutKey(), {{
+    const edit = {{
       norms: cloneNorms(norms),
       diameter,
-    }});
+    }};
+    if (usesTilesCircleFontSliders()) {{
+      edit.valueFontPx = valueFontBasePx;
+      edit.labelFontPx = labelFontPxNum;
+    }}
+    sessionEdits.set(layoutKey(), edit);
   }}
 
   function clearSessionEdit(key) {{
@@ -723,11 +841,13 @@ def render_circle_layout_playground_html(
   }}
 
   function labelFontPx() {{
+    if (usesTilesCircleFontSliders()) return labelFontPxNum + "px";
     if (cardType === "spotlight") return "24px";
     return count > 6 ? "16px" : "18px";
   }}
 
   function valueFontBase() {{
+    if (usesTilesCircleFontSliders()) return valueFontBasePx;
     if (cardType === "spotlight") return diameter >= 360 ? 160 : 140;
     if (count > 9) return 40;
     if (diameter >= 260) return 52;
@@ -781,6 +901,9 @@ def render_circle_layout_playground_html(
     diameterInput.max = String(m.max_diameter);
     countWrap.classList.toggle("hidden", cardType === "spotlight");
     presetWrap.classList.toggle("hidden", !m.code_presets);
+    const showTypography = usesTilesCircleFontSliders();
+    valueFontWrap.classList.toggle("hidden", !showTypography);
+    labelFontWrap.classList.toggle("hidden", !showTypography);
     refreshPresetOptions();
   }}
 
@@ -922,6 +1045,8 @@ def render_circle_layout_playground_html(
       lines.push(...posLines);
       lines.push("    ),");
       lines.push("diameter_px: " + diameter + ",");
+      lines.push("value_font_px: " + valueFontBasePx + ",");
+      lines.push("label_font_px: " + labelFontPxNum + ",");
     }}
     return lines.join("\\n");
   }}
@@ -934,6 +1059,9 @@ def render_circle_layout_playground_html(
       CARD_LABELS[cardType] + " · " + FORMAT_LABELS[fmt] + " · " +
       "canvas " + m.canvas_w + "×" + m.canvas_h + "px · " +
       "card " + m.card_w + "×" + m.card_h + " · diameter " + diameter + "px · " +
+      (usesTilesCircleFontSliders()
+        ? "value " + valueFontBasePx + "px · label " + labelFontPxNum + "px · "
+        : "") +
       "body x=" + Math.round(b.xMin) + "–" + Math.round(b.xMax) +
       " y=" + Math.round(b.yMin) + "–" + Math.round(b.yMax);
   }}
@@ -949,11 +1077,24 @@ def render_circle_layout_playground_html(
     if (saved) {{
       norms = cloneNorms(saved.norms);
       applyDiameterWithoutSessionSave(saved.diameter);
+      if (cardType === "tiles" && saved.valueFontPx != null) {{
+        applyCircleTypographyWithoutSessionSave(
+          saved.valueFontPx,
+          saved.labelFontPx ?? defaultTypographyForCount(nextCount).labelFontPx,
+        );
+      }}
     }} else {{
       const defaults = codeDefaults(nextCount);
       norms = defaults.norms;
       applyDiameterWithoutSessionSave(defaults.diameter);
+      if (cardType === "tiles") {{
+        applyCircleTypographyWithoutSessionSave(
+          defaults.valueFontPx,
+          defaults.labelFontPx,
+        );
+      }}
     }}
+    applyModeUi();
   }}
 
   function setDiameter(d) {{
@@ -988,6 +1129,14 @@ def render_circle_layout_playground_html(
   countInput.addEventListener("change", () => loadLayoutState(Number(countInput.value)));
   diameterInput.addEventListener("input", () => {{
     setDiameter(Number(diameterInput.value));
+    if (!applyingDefaults) saveSessionEdit();
+  }});
+  valueFontInput.addEventListener("input", () => {{
+    setCircleTypography(Number(valueFontInput.value), labelFontPxNum);
+    if (!applyingDefaults) saveSessionEdit();
+  }});
+  labelFontInput.addEventListener("input", () => {{
+    setCircleTypography(valueFontBasePx, Number(labelFontInput.value));
     if (!applyingDefaults) saveSessionEdit();
   }});
   presetSelect.addEventListener("change", () => {{

--- a/explorer/presentation/share_summary_circle_layout_playground.py
+++ b/explorer/presentation/share_summary_circle_layout_playground.py
@@ -18,6 +18,7 @@ from explorer.core.share_summary_defaults import (
 from explorer.presentation.share_summary_circles_preview import (
     _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX,
     CIRCLE_VARIANT_SPECS,
+    SPOTLIGHT_CIRCLE_LABEL_PX,
     TILES_CIRCLE_CLUSTER_DEFAULT,
     TILES_CIRCLE_CLUSTER_VARIANT,
     TILES_CIRCLE_DIAMETER_SEARCH_START,
@@ -235,13 +236,22 @@ def _tiles_playground_count_range(fmt: FormatId) -> range:
 
 
 def _tiles_circle_typography_config() -> dict[str, int]:
-    """Slider ranges for Statistics Tiles circle typography tuning."""
+    """Slider ranges for circle typography tuning in the playground."""
     return {
         "min_value_font_px": _TILES_CIRCLE_VALUE_FONT_MIN,
         "max_value_font_px": _TILES_CIRCLE_VALUE_FONT_MAX,
         "min_label_font_px": _TILES_CIRCLE_LABEL_FONT_MIN,
         "max_label_font_px": _TILES_CIRCLE_LABEL_FONT_MAX,
     }
+
+
+def _spotlight_playground_value_font_px(fmt: FormatId, diameter: int) -> int:
+    """Match production spotlight circle value sizing."""
+    card_w, card_h = FORMAT_PIXELS[fmt]
+    classic = 200 if card_h > card_w else 160
+    inner_w = max(68, diameter - 44)
+    max_by_width = int(inner_w / 0.58)
+    return min(classic, max_by_width)
 
 
 def _typography_defaults_for_count(
@@ -419,6 +429,13 @@ def _build_mode_config(card_type: PlaygroundCardType, fmt: FormatId) -> dict[str
             "auto_diameters": {"1": diameter},
             "center_norm": center_norm,
             "code_presets": False,
+            "circle_typography": _tiles_circle_typography_config(),
+            "typography_defaults": {
+                "1": {
+                    "value_font_px": _spotlight_playground_value_font_px(fmt, diameter),
+                    "label_font_px": SPOTLIGHT_CIRCLE_LABEL_PX,
+                }
+            },
             **export_meta,
         }
 
@@ -609,7 +626,7 @@ def render_circle_layout_playground_html(
 <body>
   <p class="hint">
     Dev tuner for circle presentations. Drag to reposition (except Spotlight — centred).
-    For Statistics Tiles, use the value/label font sliders to tune typography per circle count
+    For Statistics Tiles and Spotlight, use the value/label font sliders to tune typography
     before copying sizes into <code>share_summary_circles_preview.py</code>.
   </p>
   <div class="toolbar">
@@ -706,8 +723,8 @@ def render_circle_layout_playground_html(
     return mode().circle_typography || null;
   }}
 
-  function usesTilesCircleFontSliders() {{
-    return cardType === "tiles" && circleTypography() !== null;
+  function usesCircleFontSliders() {{
+    return (cardType === "tiles" || cardType === "spotlight") && circleTypography() !== null;
   }}
 
   function defaultTypographyForCount(n) {{
@@ -757,7 +774,7 @@ def render_circle_layout_playground_html(
       norms: cloneNorms(layoutForCount(n)),
       diameter: presetDiameter(n),
     }};
-    if (cardType === "tiles") {{
+    if (cardType === "tiles" || cardType === "spotlight") {{
       const typography = defaultTypographyForCount(n);
       defaults.valueFontPx = typography.valueFontPx;
       defaults.labelFontPx = typography.labelFontPx;
@@ -780,7 +797,7 @@ def render_circle_layout_playground_html(
       norms: cloneNorms(norms),
       diameter,
     }};
-    if (usesTilesCircleFontSliders()) {{
+    if (usesCircleFontSliders()) {{
       edit.valueFontPx = valueFontBasePx;
       edit.labelFontPx = labelFontPxNum;
     }}
@@ -841,14 +858,12 @@ def render_circle_layout_playground_html(
   }}
 
   function labelFontPx() {{
-    if (usesTilesCircleFontSliders()) return labelFontPxNum + "px";
-    if (cardType === "spotlight") return "24px";
+    if (usesCircleFontSliders()) return labelFontPxNum + "px";
     return count > 6 ? "16px" : "18px";
   }}
 
   function valueFontBase() {{
-    if (usesTilesCircleFontSliders()) return valueFontBasePx;
-    if (cardType === "spotlight") return diameter >= 360 ? 160 : 140;
+    if (usesCircleFontSliders()) return valueFontBasePx;
     if (count > 9) return 40;
     if (diameter >= 260) return 52;
     if (diameter >= 240) return 46;
@@ -901,7 +916,7 @@ def render_circle_layout_playground_html(
     diameterInput.max = String(m.max_diameter);
     countWrap.classList.toggle("hidden", cardType === "spotlight");
     presetWrap.classList.toggle("hidden", !m.code_presets);
-    const showTypography = usesTilesCircleFontSliders();
+    const showTypography = usesCircleFontSliders();
     valueFontWrap.classList.toggle("hidden", !showTypography);
     labelFontWrap.classList.toggle("hidden", !showTypography);
     refreshPresetOptions();
@@ -1037,6 +1052,8 @@ def render_circle_layout_playground_html(
     ];
     if (cardType === "spotlight") {{
       lines.push("diameter_px: " + diameter + ",");
+      lines.push("value_font_px: " + valueFontBasePx + ",");
+      lines.push("label_font_px: " + labelFontPxNum + ",");
     }} else {{
       const posLines = norms.slice(0, count).map((p) =>
         "        (" + p[0].toFixed(2) + ", " + p[1].toFixed(2) + "),"
@@ -1059,7 +1076,7 @@ def render_circle_layout_playground_html(
       CARD_LABELS[cardType] + " · " + FORMAT_LABELS[fmt] + " · " +
       "canvas " + m.canvas_w + "×" + m.canvas_h + "px · " +
       "card " + m.card_w + "×" + m.card_h + " · diameter " + diameter + "px · " +
-      (usesTilesCircleFontSliders()
+      (usesCircleFontSliders()
         ? "value " + valueFontBasePx + "px · label " + labelFontPxNum + "px · "
         : "") +
       "body x=" + Math.round(b.xMin) + "–" + Math.round(b.xMax) +
@@ -1077,7 +1094,7 @@ def render_circle_layout_playground_html(
     if (saved) {{
       norms = cloneNorms(saved.norms);
       applyDiameterWithoutSessionSave(saved.diameter);
-      if (cardType === "tiles" && saved.valueFontPx != null) {{
+      if (usesCircleFontSliders() && saved.valueFontPx != null) {{
         applyCircleTypographyWithoutSessionSave(
           saved.valueFontPx,
           saved.labelFontPx ?? defaultTypographyForCount(nextCount).labelFontPx,
@@ -1087,7 +1104,7 @@ def render_circle_layout_playground_html(
       const defaults = codeDefaults(nextCount);
       norms = defaults.norms;
       applyDiameterWithoutSessionSave(defaults.diameter);
-      if (cardType === "tiles") {{
+      if (usesCircleFontSliders()) {{
         applyCircleTypographyWithoutSessionSave(
           defaults.valueFontPx,
           defaults.labelFontPx,

--- a/explorer/presentation/share_summary_circles_preview.py
+++ b/explorer/presentation/share_summary_circles_preview.py
@@ -607,6 +607,7 @@ _SINGLE_CIRCLE_TYPOGRAPHY_BY_FORMAT: dict[FormatId, tuple[int, int]] = {
 }
 _SPOTLIGHT_CIRCLE_EDGE_PAD_PX = _SHADOW_PAD_PX + 12
 _SPOTLIGHT_CIRCLE_MIN_DIAMETER_PX = 240
+SPOTLIGHT_CIRCLE_LABEL_PX = 26
 _HAND_TUNED_CIRCLE_WIDTH_FRACTION = 0.62
 _STORY_CIRCLE_WIDTH_FRACTION = _HAND_TUNED_CIRCLE_WIDTH_FRACTION
 
@@ -1554,7 +1555,7 @@ def layout_spotlight_circle(
         value,
         diameter=diameter,
         value_px=f"{value_base}px",
-        label_px="24px",
+        label_px=f"{SPOTLIGHT_CIRCLE_LABEL_PX}px",
         shadow=True,
     )
     return f"""

--- a/explorer/presentation/share_summary_circles_preview.py
+++ b/explorer/presentation/share_summary_circles_preview.py
@@ -586,11 +586,66 @@ _STORY_CIRCLE_MIN_EDGE_GAP_PX = _HAND_TUNED_CIRCLE_MIN_EDGE_GAP_PX
 _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX = 560
 _STORY_CIRCLE_MAX_DIAMETER_PX = _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX
 _SINGLE_CIRCLE_LAYOUT: tuple[tuple[float, float], ...] = ((0.50, 0.50),)
-_SINGLE_CIRCLE_DIAMETER_PX = 480
+_SINGLE_CIRCLE_DIAMETER_BY_FORMAT: dict[FormatId, int] = {
+    "square": 560,
+    "portrait_post": 560,
+    "story": 560,
+}
+_SINGLE_CIRCLE_DIAMETER_PX = _SINGLE_CIRCLE_DIAMETER_BY_FORMAT["square"]
+_HAND_TUNED_CIRCLE_TYPOGRAPHY: dict[tuple[FormatId, int], tuple[int, int]] = {
+    ("square", 1): (110, 30),
+    ("square", 2): (75, 22),
+    ("portrait_post", 1): (110, 30),
+    ("portrait_post", 2): (80, 24),
+    ("story", 1): (110, 30),
+    ("story", 2): (90, 26),
+}
+_SINGLE_CIRCLE_TYPOGRAPHY_BY_FORMAT: dict[FormatId, tuple[int, int]] = {
+    fmt: typography
+    for (fmt, count), typography in _HAND_TUNED_CIRCLE_TYPOGRAPHY.items()
+    if count == 1
+}
 _SPOTLIGHT_CIRCLE_EDGE_PAD_PX = _SHADOW_PAD_PX + 12
 _SPOTLIGHT_CIRCLE_MIN_DIAMETER_PX = 240
 _HAND_TUNED_CIRCLE_WIDTH_FRACTION = 0.62
 _STORY_CIRCLE_WIDTH_FRACTION = _HAND_TUNED_CIRCLE_WIDTH_FRACTION
+
+
+def single_circle_diameter_px(fmt: FormatId) -> int:
+    """Hand-tuned count-1 circle diameter for Statistics Tiles."""
+    return _SINGLE_CIRCLE_DIAMETER_BY_FORMAT.get(fmt, _SINGLE_CIRCLE_DIAMETER_PX)
+
+
+def single_circle_typography_px(fmt: FormatId) -> tuple[int, int] | None:
+    """Hand-tuned count-1 value/label font sizes when set for *fmt*."""
+    return hand_tuned_circle_typography_px(fmt, 1)
+
+
+def hand_tuned_circle_typography_px(
+    fmt: FormatId,
+    count: int,
+) -> tuple[int, int] | None:
+    """Hand-tuned value/label font sizes for one format and circle count."""
+    return _HAND_TUNED_CIRCLE_TYPOGRAPHY.get((fmt, count))
+
+
+def _hand_tuned_circle_typography(
+    template: CircleCardTemplate,
+    count: int,
+    diameter: int,
+) -> tuple[str, str]:
+    """Value and label font sizes for one hand-tuned circle cluster."""
+    tuned = hand_tuned_circle_typography_px(template.fmt, count)
+    if tuned is not None:
+        value_px, label_px = tuned
+        return f"{value_px}px", f"{label_px}px"
+    if count >= _hand_tuned_compact_type_threshold(template):
+        return "40px", "16px"
+    if diameter >= 260:
+        return "52px", "19px"
+    if diameter >= 240:
+        return "46px", "17px"
+    return "48px", "18px"
 
 
 def _build_circle_card_template(
@@ -621,8 +676,8 @@ CIRCLE_CARD_TEMPLATES: dict[tuple[TilesCircleCardType, FormatId], CircleCardTemp
         layouts={
             1: _SINGLE_CIRCLE_LAYOUT,
             2: (
-                (0.29, 0.28),
-                (0.72, 0.73),
+                (0.21, 0.21),
+                (0.77, 0.77),
             ),
             3: (
                 (0.82, 0.50),
@@ -694,8 +749,8 @@ CIRCLE_CARD_TEMPLATES: dict[tuple[TilesCircleCardType, FormatId], CircleCardTemp
             ),
         },
         diameters={
-            1: _SINGLE_CIRCLE_DIAMETER_PX,
-            2: 380,
+            1: single_circle_diameter_px("story"),
+            2: 465,
             3: 380,
             4: 340,
             5: 340,
@@ -713,7 +768,7 @@ CIRCLE_CARD_TEMPLATES: dict[tuple[TilesCircleCardType, FormatId], CircleCardTemp
             1: _SINGLE_CIRCLE_LAYOUT,
             2: (
                 (0.15, 0.19),
-                (0.85, 0.73),
+                (0.86, 0.79),
             ),
             3: (
                 (0.73, 0.24),
@@ -762,8 +817,8 @@ CIRCLE_CARD_TEMPLATES: dict[tuple[TilesCircleCardType, FormatId], CircleCardTemp
             ),
         },
         diameters={
-            1: _SINGLE_CIRCLE_DIAMETER_PX,
-            2: 340,
+            1: single_circle_diameter_px("portrait_post"),
+            2: 400,
             3: 310,
             4: 285,
             5: 268,
@@ -778,8 +833,8 @@ CIRCLE_CARD_TEMPLATES: dict[tuple[TilesCircleCardType, FormatId], CircleCardTemp
         layouts={
             1: _SINGLE_CIRCLE_LAYOUT,
             2: (
-                (0.14, 0.38),
-                (0.89, 0.62),
+                (0.12, 0.22),
+                (0.89, 0.75),
             ),
             3: (
                 (0.59, 0.28),
@@ -809,8 +864,8 @@ CIRCLE_CARD_TEMPLATES: dict[tuple[TilesCircleCardType, FormatId], CircleCardTemp
             ),
         },
         diameters={
-            1: _SINGLE_CIRCLE_DIAMETER_PX,
-            2: 360,
+            1: single_circle_diameter_px("square"),
+            2: 365,
             3: 285,
             4: 275,
             5: 265,
@@ -1070,14 +1125,7 @@ def _hand_tuned_template_canvas_html(
         diameter=diameter,
     )
     centres = _centres_in_grid_reading_order(centres)
-    if count >= _hand_tuned_compact_type_threshold(template):
-        value_px, label_px = "40px", "16px"
-    elif diameter >= 260:
-        value_px, label_px = "52px", "19px"
-    elif diameter >= 240:
-        value_px, label_px = "46px", "17px"
-    else:
-        value_px, label_px = "48px", "18px"
+    value_px, label_px = _hand_tuned_circle_typography(template, count, diameter)
     shadow = spec.shadow
     tiles = []
     for (label, value), (x, y) in zip(pairs, centres, strict=False):
@@ -1435,12 +1483,18 @@ def _spotlight_circle_max_fit_diameter(canvas_w: int, canvas_h: int) -> int:
     return min(canvas_w - 2 * pad, canvas_h - 2 * pad)
 
 
-def _spotlight_circle_diameter(canvas_w: int, canvas_h: int) -> int:
+def _spotlight_circle_diameter(
+    canvas_w: int,
+    canvas_h: int,
+    *,
+    fmt: FormatId,
+) -> int:
     """Single spotlight circle — same diameter as Statistics Tiles count-1 preset."""
     max_fit = _spotlight_circle_max_fit_diameter(canvas_w, canvas_h)
+    target = single_circle_diameter_px(fmt)
     return max(
         _SPOTLIGHT_CIRCLE_MIN_DIAMETER_PX,
-        min(_SINGLE_CIRCLE_DIAMETER_PX, max_fit),
+        min(target, max_fit),
     )
 
 
@@ -1487,7 +1541,7 @@ def layout_spotlight_circle(
         fmt,
         scope_label=scope_label,
     )
-    diameter = _spotlight_circle_diameter(canvas_w, canvas_h)
+    diameter = _spotlight_circle_diameter(canvas_w, canvas_h, fmt=fmt)
     value_base = _spotlight_circle_value_base_px(
         diameter,
         width=width,

--- a/tests/explorer/test_share_summary_circle_layout_playground.py
+++ b/tests/explorer/test_share_summary_circle_layout_playground.py
@@ -19,6 +19,7 @@ from explorer.presentation.share_summary_circles_preview import (
     TILES_CIRCLE_CLUSTER_SQUARE_MAX,
     TILES_CIRCLE_CLUSTER_STORY_MAX,
     _tiles_circle_canvas_size,
+    single_circle_diameter_px,
 )
 
 
@@ -98,13 +99,13 @@ def test_circle_layout_playground_story_tiles_uses_code_layout():
     )
     assert "CIRCLE_CARD_TEMPLATES" in html
     assert f'"max_diameter": {_HAND_TUNED_CIRCLE_MAX_DIAMETER_PX}' in html
-    assert f'"1": {_SINGLE_CIRCLE_DIAMETER_PX}' in html
-    assert '"2": 380' in html
+    assert f'"1": {single_circle_diameter_px("story")}' in html
+    assert '"2": 465' in html
     assert '"3": 380' in html
     assert '"6": 340' in html
     assert '"7": 295' in html
     assert '"canvas_h": 1490' in html
-    assert "0.29" in html
+    assert "0.21" in html
 
 
 def test_circle_layout_playground_portrait_tiles_uses_code_layout():
@@ -114,7 +115,8 @@ def test_circle_layout_playground_portrait_tiles_uses_code_layout():
     )
     assert "CIRCLE_CARD_TEMPLATES" in html
     assert "portrait_post" in html
-    assert f'"1": {_SINGLE_CIRCLE_DIAMETER_PX}' in html
+    assert f'"1": {single_circle_diameter_px("portrait_post")}' in html
+    assert '"2": 400' in html
     assert '"6": 255' in html
     assert '"7": 255' in html
     assert '"8": 245' in html
@@ -130,7 +132,7 @@ def test_circle_layout_playground_square_tiles_uses_code_layout():
     assert "CIRCLE_CARD_TEMPLATES" in html
     assert f'"max_diameter": {_HAND_TUNED_CIRCLE_MAX_DIAMETER_PX}' in html
     assert f'"1": {_SINGLE_CIRCLE_DIAMETER_PX}' in html
-    assert '"2": 360' in html
+    assert '"2": 365' in html
     assert '"3": 285' in html
     assert '"4": 275' in html
     assert '"5": 265' in html
@@ -146,6 +148,57 @@ def test_circle_card_templates_registry_has_story_and_portrait():
     assert CIRCLE_CARD_TEMPLATES[("tiles", "story")].bounds == "story"
     assert CIRCLE_CARD_TEMPLATES[("tiles", "portrait_post")].bounds == "cluster"
     assert CIRCLE_CARD_TEMPLATES[("tiles", "square")].bounds == "cluster"
+
+
+def test_circle_layout_playground_tiles_includes_circle_font_sliders():
+    html = render_circle_layout_playground_html(
+        initial_card_type="tiles",
+        initial_fmt="square",
+    )
+    assert "circle_typography" in html
+    assert "typography_defaults" in html
+    assert '"1": {"value_font_px": 110, "label_font_px": 30}' in html
+    assert '"6": {"value_font_px": 46, "label_font_px": 17}' in html
+    assert 'id="value-font"' in html
+    assert 'id="label-font"' in html
+    assert "value_font_px:" in html
+    assert "usesTilesCircleFontSliders()" in html
+
+
+def test_circle_layout_playground_story_single_circle_typography_defaults():
+    html = render_circle_layout_playground_html(
+        initial_card_type="tiles",
+        initial_fmt="story",
+    )
+    assert '"1": {"value_font_px": 110, "label_font_px": 30}' in html
+    assert f'"1": {single_circle_diameter_px("story")}' in html
+
+
+def test_circle_layout_playground_square_single_circle_typography_defaults():
+    html = render_circle_layout_playground_html(
+        initial_card_type="tiles",
+        initial_fmt="square",
+    )
+    assert '"1": {"value_font_px": 110, "label_font_px": 30}' in html
+    assert f'"1": {single_circle_diameter_px("square")}' in html
+
+
+def test_circle_layout_playground_square_two_circle_typography_defaults():
+    html = render_circle_layout_playground_html(
+        initial_card_type="tiles",
+        initial_fmt="square",
+    )
+    assert '"2": {"value_font_px": 75, "label_font_px": 22}' in html
+
+
+def test_circle_layout_playground_spotlight_omits_circle_font_sliders():
+    html = render_circle_layout_playground_html(
+        initial_card_type="spotlight",
+        initial_fmt="square",
+    )
+    spotlight_section = html.split('"spotlight"')[1].split('"tiles"')[0]
+    assert "circle_typography" not in spotlight_section
+    assert "typography_defaults" not in spotlight_section
 
 
 def test_story_circle_body_bounds_for_playground_matches_preview():

--- a/tests/explorer/test_share_summary_circle_layout_playground.py
+++ b/tests/explorer/test_share_summary_circle_layout_playground.py
@@ -14,6 +14,7 @@ from explorer.presentation.share_summary_circles_preview import (
     _HAND_TUNED_CIRCLE_MAX_DIAMETER_PX,
     _SINGLE_CIRCLE_DIAMETER_PX,
     CIRCLE_CARD_TEMPLATES,
+    SPOTLIGHT_CIRCLE_LABEL_PX,
     STORY_CIRCLE_LAYOUTS,
     TILES_CIRCLE_CLUSTER_PORTRAIT_MAX,
     TILES_CIRCLE_CLUSTER_SQUARE_MAX,
@@ -162,7 +163,7 @@ def test_circle_layout_playground_tiles_includes_circle_font_sliders():
     assert 'id="value-font"' in html
     assert 'id="label-font"' in html
     assert "value_font_px:" in html
-    assert "usesTilesCircleFontSliders()" in html
+    assert "usesCircleFontSliders()" in html
 
 
 def test_circle_layout_playground_story_single_circle_typography_defaults():
@@ -191,14 +192,26 @@ def test_circle_layout_playground_square_two_circle_typography_defaults():
     assert '"2": {"value_font_px": 75, "label_font_px": 22}' in html
 
 
-def test_circle_layout_playground_spotlight_omits_circle_font_sliders():
+def test_circle_layout_playground_spotlight_includes_circle_font_sliders():
     html = render_circle_layout_playground_html(
         initial_card_type="spotlight",
         initial_fmt="square",
     )
-    spotlight_section = html.split('"spotlight"')[1].split('"tiles"')[0]
-    assert "circle_typography" not in spotlight_section
-    assert "typography_defaults" not in spotlight_section
+    assert "circle_typography" in html
+    assert f'"1": {{"value_font_px": 160, "label_font_px": {SPOTLIGHT_CIRCLE_LABEL_PX}}}' in html
+    assert 'id="value-font"' in html
+    assert 'id="label-font"' in html
+    assert "usesCircleFontSliders()" in html
+    assert 'cardType === "tiles" || cardType === "spotlight"' in html
+
+
+def test_circle_layout_playground_spotlight_story_value_font_default():
+    html = render_circle_layout_playground_html(
+        initial_card_type="spotlight",
+        initial_fmt="story",
+    )
+    assert f'"label_font_px": {SPOTLIGHT_CIRCLE_LABEL_PX}' in html
+    assert '"1": {"value_font_px": 200, "label_font_px": 26}' in html
 
 
 def test_story_circle_body_bounds_for_playground_matches_preview():

--- a/tests/explorer/test_share_summary_circles_preview.py
+++ b/tests/explorer/test_share_summary_circles_preview.py
@@ -7,6 +7,7 @@ import pytest
 from explorer.presentation.share_summary_circles_preview import (
     _SINGLE_CIRCLE_DIAMETER_PX,
     CIRCLE_CARD_TEMPLATES,
+    SPOTLIGHT_CIRCLE_LABEL_PX,
     CIRCLE_VARIANT_IDS,
     CIRCLE_VARIANT_SPECS,
     STORY_CIRCLE_LAYOUT_DIAMETERS,
@@ -962,5 +963,6 @@ def test_layout_spotlight_circle_renders():
     )
     assert "border-radius:50%" in html
     assert "47" in html
+    assert f'font-size:{SPOTLIGHT_CIRCLE_LABEL_PX}px;color:' in html
     sizes = re.findall(r"width:(\d+)px;height:\1px;border-radius:50%", html)
     assert sizes == [str(_SINGLE_CIRCLE_DIAMETER_PX)]

--- a/tests/explorer/test_share_summary_circles_preview.py
+++ b/tests/explorer/test_share_summary_circles_preview.py
@@ -35,6 +35,7 @@ from explorer.presentation.share_summary_circles_preview import (
     layout_spotlight_circle,
     layout_tiles_circle_cluster,
     place_circle_centers,
+    single_circle_diameter_px,
 )
 from explorer.presentation.share_summary_preview import (
     FormatId,
@@ -589,6 +590,7 @@ def test_layout_tiles_circle_cluster_single_circle_centred_all_formats():
         ("story", 1080, 1920),
     )
     for fmt, card_w, card_h in cases:
+        expected_diameter = single_circle_diameter_px(fmt)
         html = layout_tiles_circle_cluster(
             stats,
             card_w,
@@ -600,7 +602,7 @@ def test_layout_tiles_circle_cluster_single_circle_centred_all_formats():
         assert html.count("border-radius:50%") == 1
         sizes = re.findall(r"width:(\d+)px;height:\1px;border-radius:50%", html)
         assert len(sizes) == 1
-        assert int(sizes[0]) == _SINGLE_CIRCLE_DIAMETER_PX
+        assert int(sizes[0]) == expected_diameter
         canvas = re.search(
             r"position:relative;width:(\d+)px;height:(\d+)px;margin:0 auto;overflow:hidden",
             html,
@@ -614,7 +616,7 @@ def test_layout_tiles_circle_cluster_single_circle_centred_all_formats():
             1,
             canvas_w=canvas_w,
             canvas_h=canvas_h,
-            diameter=_SINGLE_CIRCLE_DIAMETER_PX,
+            diameter=expected_diameter,
         )[0]
         centre = re.search(
             r"position:absolute;left:([\d.]+)px;top:([\d.]+)px;\s*transform:translate\(-50%,-50%\)",
@@ -623,6 +625,60 @@ def test_layout_tiles_circle_cluster_single_circle_centred_all_formats():
         assert centre is not None
         assert float(centre.group(1)) == pytest.approx(expected_x, abs=1.0)
         assert float(centre.group(2)) == pytest.approx(expected_y, abs=1.0)
+
+
+@pytest.mark.parametrize(
+    "fmt",
+    ["square", "story", "portrait_post"],
+)
+def test_layout_tiles_circle_cluster_single_circle_typography(fmt):
+    stats = sample_share_summary_stats()
+    card_sizes = {
+        "square": (1080, 1080),
+        "story": (1080, 1920),
+        "portrait_post": (1080, 1350),
+    }
+    card_w, card_h = card_sizes[fmt]
+    html = layout_tiles_circle_cluster(
+        stats,
+        card_w,
+        card_h,
+        fmt,
+        scope_label="World",
+        card_stat_labels=("Total species",),
+    )
+    assert 'font-size:110px;font-weight:700' in html
+    assert 'font-size:30px;color:' in html
+    assert 'font-size:52px;font-weight:700' not in html
+
+
+@pytest.mark.parametrize(
+    ("fmt", "value_px", "label_px"),
+    [
+        ("square", 75, 22),
+        ("portrait_post", 80, 24),
+        ("story", 90, 26),
+    ],
+)
+def test_layout_tiles_circle_cluster_two_circle_typography(fmt, value_px, label_px):
+    stats = sample_share_summary_stats()
+    card_sizes = {
+        "square": (1080, 1080),
+        "portrait_post": (1080, 1350),
+        "story": (1080, 1920),
+    }
+    card_w, card_h = card_sizes[fmt]
+    html = layout_tiles_circle_cluster(
+        stats,
+        card_w,
+        card_h,
+        fmt,
+        scope_label="World",
+        card_stat_labels=("Total species", "Lifers"),
+    )
+    assert html.count("border-radius:50%") == 2
+    assert f"font-size:{value_px}px;font-weight:700" in html
+    assert f"font-size:{label_px}px;color:" in html
 
 
 def test_hand_tuned_template_assigns_stats_in_reading_order():
@@ -649,7 +705,7 @@ def test_square_circle_template_covers_counts_one_through_six():
     assert set(template.counts) == {1, 2, 3, 4, 5, 6}
     assert circle_card_template_diameters(template) == {
         1: _SINGLE_CIRCLE_DIAMETER_PX,
-        2: 360,
+        2: 365,
         3: 285,
         4: 275,
         5: 265,
@@ -660,7 +716,7 @@ def test_square_circle_template_covers_counts_one_through_six():
 @pytest.mark.parametrize(
     ("labels", "expected_count", "expected_diameter"),
     [
-        (("Total species", "Lifers"), 2, 360),
+        (("Total species", "Lifers"), 2, 365),
         (
             ("Total species", "Lifers", "Total checklists"),
             3,
@@ -855,19 +911,21 @@ def test_spotlight_circle_matches_single_tiles_circle_diameter_all_formats():
             fmt,
             scope_label="World",
         )
-        assert _spotlight_circle_diameter(canvas_w, canvas_h) == _SINGLE_CIRCLE_DIAMETER_PX
+        assert _spotlight_circle_diameter(canvas_w, canvas_h, fmt=fmt) == (
+            single_circle_diameter_px(fmt)
+        )
 
 
 def test_spotlight_circle_is_larger_than_six_stat_tiles_cluster():
     canvas_w, canvas_h = _circle_canvas_size(1080, 1080, "square", scope_label="World")
     tiles_d = _placed_diameter(6, canvas_w, canvas_h, TILES_CIRCLE_CLUSTER_VARIANT)
-    spotlight_d = _spotlight_circle_diameter(canvas_w, canvas_h)
+    spotlight_d = _spotlight_circle_diameter(canvas_w, canvas_h, fmt="square")
     assert spotlight_d > tiles_d * 1.5
 
 
 def test_spotlight_circle_value_font_matches_classic_for_short_numbers():
     canvas_w, canvas_h = _circle_canvas_size(1080, 1080, "square", scope_label="World")
-    diameter = _spotlight_circle_diameter(canvas_w, canvas_h)
+    diameter = _spotlight_circle_diameter(canvas_w, canvas_h, fmt="square")
     base = _spotlight_circle_value_base_px(diameter, width=1080, height=1080)
     assert base == 160
     assert _circle_value_font_px("47", base, diameter=diameter) == 160


### PR DESCRIPTION
## Summary

Adds circle typography tuning to the design-studio playground and ships hand-tuned font sizes and diameters for Statistics Tiles count-1 and count-2 layouts across square, portrait, and story formats. Also bumps Spotlight circle label typography and wires the playground font sliders for Spotlight.

## Changes

- **Circle layout playground:** value/label font sliders for Statistics Tiles (all circle counts) and Spotlight; session persistence per format/count; export includes `value_font_px` and `label_font_px`
- **Production renderer:** per-format/count typography map (`_HAND_TUNED_CIRCLE_TYPOGRAPHY`) used by `_hand_tuned_template_canvas_html`; multi-circle tier logic unchanged for untuned counts
- **Count 1 (all formats):** 560px diameter, 110px value / 30px label
- **Count 2 layouts + typography:**
  - Story: positions (0.21, 0.21)/(0.77, 0.77), 465px, 90/26
  - Portrait: positions (0.15, 0.19)/(0.86, 0.79), 400px, 80/24
  - Square: positions (0.12, 0.22)/(0.89, 0.75), 365px, 75/22
- **Spotlight circle:** diameter follows per-format count-1 preset; label bumped 24px → 26px (`SPOTLIGHT_CIRCLE_LABEL_PX`); playground sliders now drive preview, meta, and export (classic rectangular Spotlight unchanged)

## Test plan

- [x] `python3 -m ruff check explorer/`
- [x] `python3 -m pytest tests/ -q` — 806 passed, 11 skipped
- [x] Visual QA: Social Cards tab — single-stat and two-stat circle cards on square, portrait, story
- [x] Confirm multi-circle counts 3+ unchanged
- [x] Circle layout playground: sliders + export round-trip for counts 1–2 and Spotlight

## Notes

Count-2 tuning was done in the same playground pass as count-1. Classic rectangular Spotlight presentation is unchanged.

Refs #157

Fixes #295