### PR TITLE
feat: Add base branch resolution and finish-issue-work command

### DIFF
--- a/.cursor/commands/base-branch-resolution.md
+++ b/.cursor/commands/base-branch-resolution.md
@@ -1,0 +1,63 @@
+# Base branch resolution (shared guidance)
+
+**Not a slash command.** Workflow commands (`/start-issue-work`, `/create-dev-branch`, `/open-pr`, `/merge-pr`, `/finish-issue-work`) use this logic to pick a **development base** and **PR target**.
+
+Default when nothing else applies: **`beta-next`**.
+
+---
+
+## Priority order
+
+Apply in order. Explain your choice briefly before acting. **Never invent** a base branch — when uncertain after reading the issue and git state, **ask once**, concisely.
+
+### 1. Issue body (preferred source of truth)
+
+When an issue number is known, read it with `gh issue view <number> --json title,body,labels` and look for explicit guidance:
+
+- `## Base branch` section
+- `Base branch: feat/social-cards` (inline)
+- `## PR target` (often same as base for feature-line work)
+- Parent/epic issues linked in the body (e.g. #157 → Social Cards line)
+
+If found, **use that branch** as development base and PR target unless the user overrides in the same session.
+
+### 2. Current branch context (when issue is silent)
+
+If the issue does **not** specify a base branch, consider the **currently checked-out branch**:
+
+- If it looks like a **feature integration line** (e.g. `feat/*`, or a long-lived branch with clear feature purpose from name and recent commits), **pause and ask** whether new issue work should branch from **the current branch** rather than `beta-next`. Example: “You’re on `feat/social-cards`; issue #NNN doesn’t specify a base — should I branch from here?”
+- If the current branch is an **issue branch** (e.g. `293-audit-grid-stat-min-max`), infer its likely base from merge history or `git merge-base` against known integration branches (`beta-next`, `feat/social-cards`, …) and **confirm** with the user if unclear.
+- If the current branch is **`main`**, **`beta-next`**, or otherwise **not** a feature line, **do not assume** the current branch is the base. State that **`beta-next` is the default** and ask only if something in the issue or conversation suggests otherwise.
+
+### 3. Default: `beta-next`
+
+When the issue is silent and current-branch context does not suggest a feature line, use **`beta-next`** without unnecessary prompts — but mention the default in the summary (“Using `beta-next`; say if you need another base”).
+
+### 4. Nuanced inference (optional — ask, don’t guess)
+
+If a quick check suggests an alternative base — e.g. issue labels (`social-cards`), open PRs on the same issue targeting `feat/social-cards`, or parent issue #157 in the body — **surface that as a question** rather than silently switching away from `beta-next`.
+
+Example phrasing:
+
+> Issue #NNN doesn’t name a base branch. You’re on `feat/social-cards`, and the issue has the `social-cards` label. Should I create the dev branch from **`feat/social-cards`** (recommended) or **`beta-next`**?
+
+---
+
+## PR target
+
+For most work, **PR target = development base**. When an issue names both `## Base branch` and `## PR target`, honour both; if only base is named, use it for the PR base too.
+
+---
+
+## Feature-line pointers
+
+When resolved base is **`feat/social-cards`** (or the issue/body references Social Cards / #157):
+
+- Point at `docs/explorer/social-cards-workflow.md` when that file exists on the base branch.
+- PRs target the feature integration branch, not `beta-next`, until a milestone merge.
+
+---
+
+## User override
+
+A explicit override in the same chat session always wins (e.g. “branch from beta-next not from the feature branch currently in focus”).

--- a/.cursor/commands/base-branch-resolution.md
+++ b/.cursor/commands/base-branch-resolution.md
@@ -60,4 +60,4 @@ When resolved base is **`feat/social-cards`** (or the issue/body references Soci
 
 ## User override
 
-A explicit override in the same chat session always wins (e.g. “branch from beta-next not from the feature branch currently in focus”).
+An explicit override in the same chat session always wins (e.g. “branch from beta-next not from the feature branch currently in focus”).

--- a/.cursor/commands/commit-work.md
+++ b/.cursor/commands/commit-work.md
@@ -5,8 +5,8 @@ You are creating a git commit for **myebirdstuff** following this repo’s workf
 ## Branching model (important)
 
 - `main` = stable / current beta (live)
-- `beta-next` = integration branch for upcoming release
-- Feature/bug branches are normally created from `beta-next`
+- `beta-next` = default integration branch for upcoming release
+- Feature/bug branches are normally created from `beta-next`; other bases (e.g. feature lines) — see **[base branch resolution](base-branch-resolution.md)**
 - Most work should be committed on an issue/feature branch, not directly on `main` or `beta-next`
 
 If the current branch is `main` or `beta-next`, stop and ask before committing unless the user explicitly says this is intentional.

--- a/.cursor/commands/create-dev-branch.md
+++ b/.cursor/commands/create-dev-branch.md
@@ -5,20 +5,23 @@ You are creating a new local development branch for **myebirdstuff**, following 
 ## Branching model (important)
 
 - `main` = stable / current beta (live)
-- `beta-next` = integration branch for the upcoming release
-- New feature/fix work should branch from **`beta-next`** unless the user explicitly names another base (e.g. a hotfix from `main`)
+- `beta-next` = default integration branch for the upcoming release
+- **Feature integration lines** (e.g. `feat/social-cards`) are valid bases when an issue or workflow says so
+- New feature/fix work branches from the **resolved base** — see **[base branch resolution](base-branch-resolution.md)**
 
-This matches **Commit work**, **Open PR**, and **Merge PR** in this repo.
+This matches **Start issue work**, **Open PR**, **Merge PR**, and **Finish issue work** in this repo.
 
 ---
 
 ## Step 1 — Confirm inputs
 
-From the user (or infer only when obvious, e.g. from an open issue in context):
+From the user (or infer from an open issue in context):
 
 1. **GitHub issue number** (optional)
 2. **Short description** — slug-style: lowercase words separated by hyphens
-3. **Base branch** (optional) — default **`beta-next`**
+3. **Base branch** — resolve using **[base branch resolution](base-branch-resolution.md)** when an issue number is known; default **`beta-next`** only when no issue and no override
+
+If `/start-issue-work` (or the user) already resolved the base, **use that value** — do not reset to `beta-next`.
 
 If there is no issue number, omit it from the branch name (do not invent a number).
 

--- a/.cursor/commands/finish-issue-work.md
+++ b/.cursor/commands/finish-issue-work.md
@@ -1,0 +1,105 @@
+# Finish issue work (myebirdstuff)
+
+You are closing the loop after implementation — from “code done” to “PR ready” — following this repo’s workflow.
+
+## Purpose
+
+Automate the handoff users currently do manually: confirm state → quality gate → push → open PR → optional review.
+
+Be **conservative**: ask before push, before opening a PR, and before review subcommands.
+
+---
+
+## Step 1 — Confirm state
+
+1. Confirm **current branch** and that it is an issue/feature branch (not `main` or `beta-next`).
+2. Identify the **linked issue** from branch name (e.g. `312-issue-workflow-commands` → #312), commit messages, or ask the user.
+3. Review `git status` — note staged, unstaged, and untracked files.
+4. If there are **uncommitted changes**, ask whether to run `/commit-work` now or stop.
+
+---
+
+## Step 2 — Resolve PR target
+
+Apply **[base branch resolution](base-branch-resolution.md)** using the linked issue number.
+
+Summarise before continuing:
+
+- linked issue and goal (one line)
+- **resolved PR base / target**
+- whether the user overrode the default
+
+---
+
+## Step 3 — Quality gate
+
+If Python code was touched in this branch, run from repo root:
+
+```bash
+python3 -m ruff check explorer/
+python3 -m pytest tests/ -q
+```
+
+Use the same proportionality as `/open-pr` — skip or narrow scope only for markdown-only command/doc changes.
+
+If checks fail: fix if trivial; otherwise stop and report clearly.
+
+---
+
+## Step 4 — Push (ask first)
+
+Check whether the branch exists on origin:
+
+```bash
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || true
+git ls-remote --heads origin <branch-name>
+```
+
+If not pushed or behind remote, **ask** before:
+
+```bash
+git push -u origin HEAD
+```
+
+Do not force-push.
+
+---
+
+## Step 5 — Open PR
+
+Use `/open-pr` logic or `gh pr create` directly:
+
+- **Base** = resolved PR target (not always `beta-next`)
+- **Title** — clear, meaningful (sentence case; no “fix stuff”)
+- **Body** — Summary, Changes, Testing, Issues (`Fixes #NNN` or `Refs #NNN` as appropriate)
+- Confirm title, base, and draft vs ready with the user before creating
+
+---
+
+## Step 6 — Optional follow-ups (ask)
+
+After the PR exists, offer (user confirms each):
+
+- `/pr-review` on the new PR
+- **Future:** `/test-integrity-review` when [#310](https://github.com/jimchurches/myebirdstuff/issues/310) is implemented and test files changed
+
+---
+
+## Step 7 — Output summary
+
+Report:
+
+- branch name
+- PR URL (or compare link if create failed)
+- **PR base branch** used
+- checks run (ruff / pytest / none)
+- suggested manual follow-ups (merge target, labelling, etc.)
+
+---
+
+## Do not
+
+- Do not push or open a PR without confirmation
+- Do not commit secrets or unrelated files
+- Do not assume PR base is always `beta-next`
+- Do not merge or delete branches as part of this command

--- a/.cursor/commands/merge-pr.md
+++ b/.cursor/commands/merge-pr.md
@@ -4,8 +4,8 @@ You are merging the current completed feature/bug branch into its target integra
 
 ## Default workflow
 
-- Default target branch: `beta-next`
-- Only use another target branch if explicitly instructed
+- Default target branch: **`beta-next`**
+- Use another target when the issue, PR, or user specifies it (e.g. merge into **`feat/social-cards`** for Social Cards issue branches) — see **[base branch resolution](base-branch-resolution.md)**
 - After merge, switch to the updated target branch
 - Label finalised linked issues `pending-merge` after a clean merge (context-aware; see Step 8)
 - Delete the merged feature branch only if the merge succeeds cleanly
@@ -17,8 +17,7 @@ You are merging the current completed feature/bug branch into its target integra
 Before doing anything:
 
 1. Confirm the current branch name
-2. Confirm the target branch
-   - default to `beta-next`
+2. Confirm the **target branch** — default `beta-next`; resolve from linked issue / open PR / user when not standard (see [base-branch-resolution.md](base-branch-resolution.md))
 3. Confirm there are no uncommitted changes on the current branch
    - if there are, stop and ask what to do
 

--- a/.cursor/commands/open-pr.md
+++ b/.cursor/commands/open-pr.md
@@ -4,13 +4,14 @@ You are creating a pull request for myebirdstuff following this repo’s workflo
 
 ## Branching model (important)
 
-- main = stable / current beta (live)
-- beta-next = integration branch for upcoming release
-- Feature/bug branches are created from beta-next
-- PRs are normally:
-  → feature branch → beta-next
+- `main` = stable / current beta (live)
+- `beta-next` = default integration branch for upcoming release
+- Feature integration lines (e.g. `feat/social-cards`) receive PRs from issue branches on that line
+- PRs are normally: issue branch → **`beta-next`**, unless the issue specifies another **PR target**
 
-Only target main if explicitly instructed.
+Only target `main` if explicitly instructed.
+
+**PR base** must follow **[base branch resolution](base-branch-resolution.md)** — read the linked issue; do not always use `beta-next`.
 
 ---
 
@@ -32,9 +33,11 @@ Before doing anything:
 1. Detect linked issues from:
    - branch name (e.g. 123-fix-map-bug)
    - commit messages
-2. Summarise:
+2. Apply **[base branch resolution](base-branch-resolution.md)** to determine **PR base / target**.
+3. Summarise:
    - what problem is being solved
    - what areas of the code are affected
+   - **resolved PR base**
 
 If unclear, ask before proceeding.
 
@@ -107,10 +110,10 @@ Ask for network permission if required.
 
 Use GitHub CLI if available:
 
-gh pr create --base beta-next --head <branch> --title "..." --body-file ...
+gh pr create --base <resolved-pr-base> --head <branch> --title "..." --body-file ...
 
 Defaults:
-- base = beta-next
+- base = **resolved PR target** from Step 2 (often `beta-next`; may be `feat/social-cards` or other)
 - head = current branch
 
 If CLI fails:

--- a/.cursor/commands/pr-review.md
+++ b/.cursor/commands/pr-review.md
@@ -8,7 +8,7 @@ Every `/pr-review` run includes a **Test Integrity Sentinel** triage. The parent
 
 | | `/pr-review` | `/code-review` |
 |---|---|---|
-| **Scope** | One issue + one PR diff vs `beta-next` | Whole change set; architecture and cross-cutting concerns |
+| **Scope** | One issue + one PR diff vs **merge target** (often `beta-next`; may be a feature line) | Whole change set; architecture and cross-cutting concerns |
 | **When** | Small fixes, pre-merge sanity check | Before opening/updating a large PR, or multi-file behaviour changes |
 | **Fixes during review** | Apply minor, low-risk nits without asking; allow Sentinel to strengthen in-scope tests | Default to listing gaps; only trivial fixes if the author wants them in-session |
 
@@ -32,19 +32,38 @@ For **myebirdstuff**, skim `docs/AI_CONTEXT.md` for repo guardrails (Streamlit v
 
 ---
 
-## Step 2 — Establish the diff (vs `beta-next`)
+## Step 2 — Establish the diff (vs merge target)
 
-Review **only** what the PR changes relative to the merge target.
+Review **only** what the PR changes relative to its **merge target** — not always `beta-next`. On feature-line work (e.g. Social Cards), the target is often `feat/social-cards`; diffing against `beta-next` would include unrelated feature-line history.
+
+### Resolve merge target
+
+1. **PR exists:** read `baseRefName` from `gh pr view <pr-number> --json baseRefName,headRefName,title`.
+2. **No PR yet:** apply **[base branch resolution](base-branch-resolution.md)** from the linked issue (PR target = merge target for review).
+3. **Default:** `beta-next` when nothing else applies.
+
+State the resolved merge target in the review output.
+
+### Get the diff
+
+**Prefer** `gh pr diff` when a PR number is known — it always matches the PR’s base:
 
 ```bash
 git fetch origin
-git diff origin/beta-next...HEAD
-# or, when reviewing a remote PR without checkout:
 gh pr diff <pr-number>
 ```
 
+When there is no PR, or you need a local three-dot diff:
+
+```bash
+git fetch origin
+git diff origin/<merge-target>...HEAD
+```
+
+Replace `<merge-target>` with the resolved base (e.g. `beta-next`, `feat/social-cards`).
+
 - Do **not** expand scope to unrelated files or prior commits on the branch unless they are part of this PR’s diff.
-- If the PR targets a base other than `beta-next`, use that base instead and say so in the output.
+- Do **not** default to `origin/beta-next...HEAD` when the PR targets another base.
 
 ---
 

--- a/.cursor/commands/start-issue-work.md
+++ b/.cursor/commands/start-issue-work.md
@@ -11,13 +11,16 @@ The user will provide a GitHub issue number, for example:
 
 If no issue number is provided, ask for it before continuing.
 
+The user may also specify a **base branch override** (e.g. “branch from `beta-next` even though I’m on `feat/social-cards`”). Honour explicit overrides over inference.
+
 ---
 
 ## Repository workflow
 
 - `main` is the stable/release branch
-- `beta-next` is the integration branch
-- Development work must happen on a new issue branch created from `beta-next`
+- `beta-next` is the default integration branch for most work
+- **Feature integration lines** (e.g. `feat/social-cards`) are the base for issues that say so in the issue body
+- Development happens on a new **issue branch** — not directly on `main`, `beta-next`, or a feature integration branch
 - Do not work directly on `main` or `beta-next`
 
 ---
@@ -25,9 +28,8 @@ If no issue number is provided, ask for it before continuing.
 ## Step 1 — Confirm starting state
 
 1. Confirm the current branch.
-2. If currently on `beta-next`, continue.
-3. If on another branch, check whether there are uncommitted changes.
-4. If there are uncommitted changes, stop and ask what to do.
+2. Check whether there are uncommitted changes.
+3. If there are uncommitted changes, stop and ask what to do (commit, stash, or abort).
 
 ---
 
@@ -35,34 +37,37 @@ If no issue number is provided, ask for it before continuing.
 
 Before coding:
 
-1. Read the GitHub issue.
-2. Explore the repository enough to understand the relevant area.
-3. Focus especially on the `explorer` app.
-4. Read relevant technical documentation, including repo guidance files and docs under `docs/explorer/`.
+1. Read the GitHub issue (`gh issue view`).
+2. Apply **[base branch resolution](base-branch-resolution.md)** — resolve **development base** and **PR target** before creating a branch.
+3. Explore the repository enough to understand the relevant area.
+4. Read relevant technical documentation (`docs/AI_CONTEXT.md`, `docs/explorer/`, issue-linked docs).
 
 Summarise briefly:
 
 - what the issue is asking for
+- **resolved base branch** and **PR target**
 - likely files or areas involved
 - any assumptions or risks
+
+When base is `feat/social-cards`, mention `docs/explorer/social-cards-workflow.md` if present on that base.
 
 ---
 
 ## Step 3 — Create development branch
 
-Use the existing `/create-dev-branch` command for the issue.
+Use the existing `/create-dev-branch` command (or equivalent steps manually).
+
+Pass the **resolved base** from Step 2 — do not hardcode `beta-next` when the issue or user specified another base.
 
 The branch should:
 
-- be based on `beta-next`
+- be based on the **resolved base branch**
 - include the issue number as a prefix
 - use a short descriptive slug
 
 Example:
 
 `254-add-basemap-options`
-
-If `/create-dev-branch` cannot be invoked directly from this command, perform the same steps manually.
 
 ---
 
@@ -85,6 +90,7 @@ Do not:
 Only stop to ask questions if:
 
 - the issue is ambiguous
+- base branch resolution is uncertain (see [base-branch-resolution.md](base-branch-resolution.md))
 - the implementation has meaningful design choices
 - the requested change conflicts with existing behaviour
 - there is risk of unintended regression
@@ -97,10 +103,11 @@ Otherwise, make reasonable, conservative choices and continue.
 
 Provide a summary of:
 
-- branch created
+- branch created (name + base)
+- resolved PR target
 - files changed
 - behaviour implemented
 - tests run
 - any follow-up concerns
 
-If tests were not run, say so clearly.
+If tests were not run, say so clearly. When implementation is complete, the user can run `/finish-issue-work` to push and open a PR.

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,23 @@ For AI-assisted coding, see **[AI_CONTEXT.md](AI_CONTEXT.md)** and follow those 
 
 ---
 
+# Cursor workflow commands
+
+Slash commands in `.cursor/commands/` automate git and GitHub workflow. Key commands:
+
+| Command | Purpose |
+|---------|---------|
+| `/start-issue-work` | Read issue, resolve base branch, create dev branch |
+| `/create-dev-branch` | Create issue branch from resolved base (default `beta-next`) |
+| `/commit-work` | Stage, lint, commit with repo message format |
+| `/finish-issue-work` | Post-implementation: quality gate → push → open PR |
+| `/open-pr` | Push and open PR with correct **PR target** |
+| `/merge-pr` | Merge feature branch into target integration branch |
+
+**Base branch resolution:** Commands share logic in [`.cursor/commands/base-branch-resolution.md`](../.cursor/commands/base-branch-resolution.md). When a GitHub issue includes `## Base branch` / `## PR target`, commands read the issue via `gh issue view` instead of defaulting to `beta-next`. Feature-line work (e.g. Social Cards on `feat/social-cards`) is documented in `docs/explorer/social-cards-workflow.md` when present on that branch.
+
+---
+
 # Overview
 
 This repository contains:


### PR DESCRIPTION
## Summary

Workflow commands no longer hardcode `beta-next` for every issue. They read GitHub issue context (and ask when ambiguous) to resolve development base and PR target. Adds `/finish-issue-work` to close the post-implementation handoff loop.

Fixes #312

## Changes

- Add `.cursor/commands/base-branch-resolution.md` — shared resolution rules (issue body → branch context → ask → default `beta-next`)
- Add `.cursor/commands/finish-issue-work.md` — confirm state → quality gate → push → open PR → optional review
- Update `/start-issue-work`, `/create-dev-branch`, `/open-pr`, `/merge-pr` to use shared resolution logic
- Document Cursor workflow commands in `docs/development.md`

## Testing

- Markdown/command files only — no Python changes
- Manual verification per issue acceptance criteria:
  - Issue with `Base branch: feat/social-cards` → correct dev branch and PR target
  - Issue with no base on `beta-next` → defaults to `beta-next`
  - Issue with no base on `feat/social-cards` → agent asks before assuming

## Notes

Complements #311 (Cursor rules). Hook for `/test-integrity-review` (#310) left as future offer in `/finish-issue-work`.

Made with [Cursor](https://cursor.com)