### PR TITLE
Add Cursor project rules for agent guardrails

### DIFF
--- a/.cursor/rules/map-and-cache.mdc
+++ b/.cursor/rules/map-and-cache.mdc
@@ -1,6 +1,6 @@
 ---
 description: Map stack and caching — Leaflet component, GeoJSON builders, static dataframe assumptions
-globs: explorer/components/all_locations_map/**,explorer/core/*_locations_geojson.py,explorer/core/map_*.py,explorer/app/streamlit/app_prep_map*.py,explorer/presentation/leaflet*.py
+globs: explorer/components/all_locations_map/**,explorer/core/*_locations_geojson.py,explorer/core/map_*.py,explorer/app/streamlit/app_prep_map*.py,explorer/presentation/map_*.py,explorer/presentation/leaflet*.py
 alwaysApply: false
 ---
 

--- a/.cursor/rules/map-and-cache.mdc
+++ b/.cursor/rules/map-and-cache.mdc
@@ -1,0 +1,29 @@
+---
+description: Map stack and caching — Leaflet component, GeoJSON builders, static dataframe assumptions
+globs: explorer/components/all_locations_map/**,explorer/core/*_locations_geojson.py,explorer/core/map_*.py,explorer/app/streamlit/app_prep_map*.py,explorer/presentation/leaflet*.py
+alwaysApply: false
+---
+
+# Map and cache
+
+Production maps use the **Leaflet custom component** (`explorer/components/all_locations_map/`) — not Folium. Read [`docs/AI_CONTEXT.md`](docs/AI_CONTEXT.md) § Architecture and [`docs/development.md`](docs/development.md) § Map architecture.
+
+## Data and caching
+
+- The main dataframe is **static during runtime** — do not mutate it; caching assumes this.
+- Map prep uses session LRU keys (`leaflet_payload_cache_key`, mode `revision_extra` in `app_prep_map_ui.py`). Preserve cache correctness when changing grouping, filtering, or popup generation.
+- Popup payloads are **structured** (`popup_v1` in GeoJSON properties) — not per-pin HTML strings in Python.
+
+## Frontend build assets
+
+After editing TypeScript/CSS in `frontend/src/`:
+
+```bash
+python3 scripts/build_all_locations_map_frontend.py
+```
+
+Committed `frontend/build/` is required at runtime (no Node on users' machines). Do not commit Finder duplicates — CI runs `scripts/prune_finder_duplicates.py --check`.
+
+## Performance instrumentation
+
+`EXPLORER_PERF` tooling is intentional and off by default — keep stage names stable; see `docs/development.md` § Performance Instrumentation Guardrails.

--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -1,0 +1,25 @@
+---
+description: Universal guardrails — read AI_CONTEXT before architectural changes; one issue scope
+alwaysApply: true
+---
+
+# Project context
+
+Before **architectural, cross-cutting, or behavioural** changes, read [`docs/AI_CONTEXT.md`](docs/AI_CONTEXT.md).
+
+## Instincts
+
+- **One issue per session** when possible — do not expand scope beyond what the issue or user asked for.
+- **Small, incremental diffs** — preserve existing behaviour unless the issue requires otherwise.
+- **No drive-by fixes** — do not reformat or ruff-fix unrelated files; improve only lines you touch when safe.
+- **Git discipline** — do not commit or push unless the user explicitly asks (see AI_CONTEXT § Git discipline).
+
+## Workflow vs rules
+
+- **Rules** (this folder) = standing instincts injected automatically.
+- **Commands** (`.cursor/commands/`) = repeatable workflows you invoke with `/…` (commit, PR, start issue).
+- For issue work, prefer `/start-issue-work` — it resolves **base branch** and **PR target** via the issue body and [base-branch-resolution.md](../commands/base-branch-resolution.md).
+
+## Docs are SSOT
+
+Rules are a thin routing layer. Detailed guidance stays in `docs/` — link paths; do not duplicate long sections here.

--- a/.cursor/rules/python-style.mdc
+++ b/.cursor/rules/python-style.mdc
@@ -1,0 +1,21 @@
+---
+description: Python style for explorer/ — naming, comments, docstrings; link to style guide SSOT
+globs: explorer/**/*.py
+alwaysApply: false
+---
+
+# Python style (explorer/)
+
+Follow [`docs/python-style-guide.md`](docs/python-style-guide.md) — **read it before writing or reviewing Python** in this repo. It is the SSOT for naming, comments, docstrings, constants placement, and review expectations.
+
+## When editing
+
+- Prefer **clear names** over abbreviations; constants in `UPPER_SNAKE_CASE` in the right defaults/constants module.
+- **Docstrings** on public functions and modules; comments explain *why*, not *what*.
+- **Do not wholesale-rewrite** pre-existing code for style — improve only touched lines when safe.
+- Lint: `python3 -m ruff check explorer/` (see `ruff.toml`).
+
+## Layering
+
+- Prefer explicit submodule imports in new code (e.g. `from explorer.core.stats import …`).
+- `explorer.core` is a compatibility barrel with lazy imports — import from the defining module when jump-to-definition matters.

--- a/.cursor/rules/streamlit-ui-thin.mdc
+++ b/.cursor/rules/streamlit-ui-thin.mdc
@@ -1,0 +1,34 @@
+---
+description: Streamlit app layer — UI only; logic in core/presentation; design apps are playgrounds
+globs: explorer/app/**/*.py
+alwaysApply: false
+---
+
+# Streamlit UI layer
+
+Streamlit under `explorer/app/` is **UI only**. Business logic belongs in `explorer/core/`, `explorer/presentation/`, and helpers — not in Streamlit callbacks or render paths.
+
+## Before adding behaviour
+
+1. Can it live in **core** or **presentation** with a thin Streamlit wrapper? If yes, do that.
+2. Add or update **tests** under `tests/explorer/` for the logic — not Streamlit wiring snapshots.
+3. Read [`explorer/app/streamlit/README.md`](explorer/app/streamlit/README.md) for UI patterns and [`docs/AI_CONTEXT.md`](docs/AI_CONTEXT.md) § Keep logic out of the UI.
+
+## Constants and tweakables
+
+**Before adding a literal number, colour, size, bound, or layout knob** in Streamlit or map UI code, ask: would a developer or technical end user want to tune this without reading implementation? If yes → put it in **`explorer/app/streamlit/defaults.py`** (named `UPPER_SNAKE_CASE` constant), then import it.
+
+There is no rigid taxonomy — use judgement. Typical `defaults.py` contents: map pin geometry, colours, opacities, cluster options, legend sizes, zoom/slider bounds, layout widths, debug toggles, active colour-scheme index. Feature-specific card/layout tunables may live in a `explorer/core/*_defaults.py` module (re-exported from `defaults.py` when Streamlit needs them).
+
+| Kind | Location |
+|------|----------|
+| **Developer / technical-user tweakables** | `explorer/app/streamlit/defaults.py` |
+| Fixed product copy, tab labels, URLs | `explorer/app/streamlit/streamlit_ui_constants.py` |
+| Persisted settings schema (YAML-backed) | `explorer/core/settings_schema_defaults.py` |
+| Feature tunables (e.g. share summary) | `explorer/core/*_defaults.py` → often re-exported via `defaults.py` |
+
+Do not scatter magic numbers in `explorer/app/` — centralise tunables in `defaults.py` (or the matching `*_defaults.py`). See [`docs/AI_CONTEXT.md`](docs/AI_CONTEXT.md) § Configuration and [`docs/python-style-guide.md`](docs/python-style-guide.md) § Constants.
+
+## Design / playground apps
+
+Files like `design_map_app.py` and `design_share_summary_app.py` are **developer playgrounds**. Visual tuning flows: playground → export → constants → tests (see area docs when working on Social Cards / share summary).

--- a/.cursor/rules/tests.mdc
+++ b/.cursor/rules/tests.mdc
@@ -1,0 +1,26 @@
+---
+description: Test conventions — behaviour over trivia; markers; when to add tests for bug fixes
+globs: tests/**/*.py
+alwaysApply: false
+---
+
+# Tests
+
+See [`tests/README.md`](tests/README.md) for venv setup, markers, and run commands. Policy summary in [`docs/development.md`](docs/development.md) § Testing.
+
+## Principles
+
+- Assert **behaviour**, not implementation trivia or private attribute names.
+- When fixing a production bug, **add or strengthen** a test in the same change when practical.
+- Prefer focused, table-driven tests for fragile logic (taxonomy, grouping, colour resolution).
+- Avoid broad Streamlit wiring or HTML snapshot tests that inflate coverage without signal.
+
+## Markers and layers
+
+- Default: `pytest tests/ -v` (unit/integration — same core path as CI).
+- Browser E2E: `@pytest.mark.e2e` — opt-in (`pytest -m e2e`).
+- Map component frontend: Jest in `explorer/components/all_locations_map/frontend/` (see `tests/README.md`).
+
+## Environment
+
+Use repo-root `.venv/` (Python 3.12). CI matches `requirements.txt`.

--- a/docs/cursor-rules.md
+++ b/docs/cursor-rules.md
@@ -1,0 +1,55 @@
+# Cursor project rules
+
+Persistent instructions for Cursor Agent/Chat in this repository.
+
+**Location:** `.cursor/rules/*.mdc`
+
+Rules inject context **automatically** (by `alwaysApply` or matching `globs`). They complement **slash commands** in `.cursor/commands/` — rules are instincts; commands are workflows (`/start-issue-work`, `/commit-work`, `/finish-issue-work`, …).
+
+Design principle: rules are a **thin routing layer**. Detailed guidance stays in existing docs (`docs/AI_CONTEXT.md`, `docs/python-style-guide.md`, area-specific docs). Rules say **when** to read them and **what not to do**.
+
+---
+
+## Rule set (v1)
+
+| File | Scope | Purpose |
+|------|--------|---------|
+| `project-context.mdc` | **Always** (`alwaysApply: true`) | Read `AI_CONTEXT` before architectural changes; one-issue scope; no drive-by fixes; rules vs commands |
+| `python-style.mdc` | `explorer/**/*.py` | Link to `docs/python-style-guide.md`; touch-only style improvements |
+| `streamlit-ui-thin.mdc` | `explorer/app/**/*.py` | UI layer only; **`defaults.py` for tunables**; constants locations; tests in core not Streamlit |
+| `map-and-cache.mdc` | Map component, GeoJSON, prep, Leaflet export | Static dataframe, LRU cache, committed frontend build, no Folium |
+| `tests.mdc` | `tests/**/*.py` | Behaviour-focused tests; markers; venv/CI parity |
+
+---
+
+## Rule file format
+
+```yaml
+---
+description: Shown in Cursor rule picker
+globs: path/to/**/*.py    # optional — apply when matching files are in context
+alwaysApply: false        # true = every session (use sparingly)
+---
+
+# Title
+
+Markdown body — keep short; link to docs.
+```
+
+---
+
+## When to add more rules
+
+Add a new rule when the **same agent mistake happens twice**, or when a feature area needs repeated “read doc X first” routing (e.g. share-summary slot limits on the Social Cards line).
+
+Prefer **`globs`** over **`alwaysApply`** — always-on rules consume context budget. Reserve `alwaysApply: true` for universal guardrails (currently only `project-context.mdc`).
+
+**Social Cards / feature lines:** base branch and PR target are resolved by `/start-issue-work` and [base-branch-resolution.md](../.cursor/commands/base-branch-resolution.md), not by rules (rules cannot read git branch). File-scoped rules for share-summary paths may be added on `feat/social-cards` when that work is active.
+
+---
+
+## Related
+
+- Issue [#311](https://github.com/jimchurches/myebirdstuff/issues/311) — implemented this set (supersedes [#289](https://github.com/jimchurches/myebirdstuff/issues/289))
+- [`docs/development.md`](development.md) — Cursor workflow commands and dev guide
+- [`docs/AI_CONTEXT.md`](AI_CONTEXT.md) — project guardrails SSOT

--- a/docs/cursor-rules.md
+++ b/docs/cursor-rules.md
@@ -17,7 +17,7 @@ Design principle: rules are a **thin routing layer**. Detailed guidance stays in
 | `project-context.mdc` | **Always** (`alwaysApply: true`) | Read `AI_CONTEXT` before architectural changes; one-issue scope; no drive-by fixes; rules vs commands |
 | `python-style.mdc` | `explorer/**/*.py` | Link to `docs/python-style-guide.md`; touch-only style improvements |
 | `streamlit-ui-thin.mdc` | `explorer/app/**/*.py` | UI layer only; **`defaults.py` for tunables**; constants locations; tests in core not Streamlit |
-| `map-and-cache.mdc` | Map component, GeoJSON, prep, Leaflet export | Static dataframe, LRU cache, committed frontend build, no Folium |
+| `map-and-cache.mdc` | Map component, GeoJSON, prep, map presentation, Leaflet export | Static dataframe, LRU cache, committed frontend build, no Folium |
 | `tests.mdc` | `tests/**/*.py` | Behaviour-focused tests; markers; venv/CI parity |
 
 ---

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,6 +23,12 @@ Slash commands in `.cursor/commands/` automate git and GitHub workflow. Key comm
 
 **Base branch resolution:** Commands share logic in [`.cursor/commands/base-branch-resolution.md`](../.cursor/commands/base-branch-resolution.md). When a GitHub issue includes `## Base branch` / `## PR target`, commands read the issue via `gh issue view` instead of defaulting to `beta-next`. Feature-line work (e.g. Social Cards on `feat/social-cards`) is documented in `docs/explorer/social-cards-workflow.md` when present on that branch.
 
+## Cursor project rules
+
+**Rules** in [`.cursor/rules/`](../.cursor/rules/) are persistent instructions injected automatically into Agent/Chat (by file `globs` or `alwaysApply`). They complement commands above: rules = instincts, commands = workflows.
+
+See **[cursor-rules.md](cursor-rules.md)** for the v1 rule set, format, and when to add more.
+
 ---
 
 # Overview


### PR DESCRIPTION
## Summary

- Adds a v1 set of Cursor project rules (`.cursor/rules/*.mdc`) as a thin routing layer to existing docs — rules inject standing instincts automatically; commands remain the workflow layer.
- Documents the rule set in `docs/cursor-rules.md` and links from `docs/development.md`.

## Changes

| Rule | Scope | Purpose |
|------|--------|---------|
| `project-context.mdc` | Always | Route to `AI_CONTEXT`; one-issue scope; rules vs commands |
| `python-style.mdc` | `explorer/**/*.py` | SSOT: `docs/python-style-guide.md` |
| `streamlit-ui-thin.mdc` | `explorer/app/**/*.py` | UI-only layer; **`defaults.py` for tunables** |
| `map-and-cache.mdc` | Map component, GeoJSON, prep, map presentation, Leaflet export | Static dataframe, LRU cache, Leaflet build |
| `tests.mdc` | `tests/**/*.py` | Behaviour-focused tests, markers |

Design choices:
- One `alwaysApply: true` rule only (`project-context`)
- Four file-scoped rules via `globs`
- No duplication of long doc sections — links only
- Share-summary / Social Cards–specific rule deferred (can cherry-pick to `feat/social-cards` later)

## Testing

- `python3 -m ruff check explorer/` — passed
- `python3 -m pytest tests/ -q` — 670 passed, 7 skipped
- **Human smoke tests (author):** rules exercised in Agent sessions — Streamlit/design-app edits respected UI-thin + `defaults.py` routing; rules complement existing `/start-issue-work` and `/commit-work` commands without conflict. Share-summary–specific rule validation deferred to `feat/social-cards` line as designed.

## Issues

Fixes #311

Closes #289 (superseded by this work)

Made with [Cursor](https://cursor.com)