### PR TITLE
docs: Add share-summary Cursor rule for Social Cards line

### DIFF
--- a/.cursor/rules/share-summary.mdc
+++ b/.cursor/rules/share-summary.mdc
@@ -1,0 +1,40 @@
+---
+description: Share-summary cards — layout slot limits, defaults, design playground workflow
+globs: **/share_summary*.py,**/design_share_summary_app.py
+alwaysApply: false
+---
+
+# Share summary (Social Cards)
+
+File-scoped rule for share-summary work on the Social Cards line. Read linked docs before changing layouts, stats, colours, or export.
+
+## Where things live
+
+| Topic | Location |
+|-------|----------|
+| Colour schemes, default stat labels | [`explorer/core/share_summary_defaults.py`](explorer/core/share_summary_defaults.py) |
+| Re-exports for Streamlit tuning | [`explorer/app/streamlit/defaults.py`](explorer/app/streamlit/defaults.py) (`SHARE_SUMMARY_*`) |
+| Layout HTML / slot limits | [`explorer/presentation/share_summary_preview.py`](explorer/presentation/share_summary_preview.py) |
+| Stat computation | [`explorer/core/share_summary_compute.py`](explorer/core/share_summary_compute.py) |
+| Design playground | `streamlit run explorer/app/streamlit/design_share_summary_app.py` |
+| Feature status / roadmap | [`docs/explorer/issue-157-share-summary-tracker.md`](docs/explorer/issue-157-share-summary-tracker.md) |
+| Feature-line workflow | [`docs/explorer/social-cards-workflow.md`](docs/explorer/social-cards-workflow.md) |
+
+## Layout slot limits (not one-size-fits-all)
+
+Use `layout_card_stat_max()` in `share_summary_preview.py` — limits depend on **layout** and **format** (square / portrait / story).
+
+| Layout | Stat slots |
+|--------|------------|
+| **tiles** | Format-dependent grid caps (e.g. square ≤ 6; story up to 14) — see `SHARE_SUMMARY_GRID_*` in defaults |
+| **minimal** | Story up to 18 (min of available); other formats typically 6 |
+| **spotlight** | **One** highlighted stat (`SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT`) |
+| **insight** | Fact-driven — `SHARE_SUMMARY_INSIGHT_FACT_DEFAULT`; not a multi-stat picker |
+
+Default stat **label order** (four-stat vs six-stat): `SHARE_SUMMARY_FOUR_STAT_DEFAULT_STATS`, `SHARE_SUMMARY_TILES_DEFAULT_STATS`, and geo/lifetime variants in `share_summary_defaults.py`.
+
+## Instincts
+
+- **Logic stays out of Streamlit** — compute in `explorer/core/`, HTML in `explorer/presentation/`; `design_share_summary_app.py` is a playground only.
+- **Tunables** go in `share_summary_defaults.py` (re-exported via `defaults.py`), not magic numbers in the design app.
+- **Visual tuning workflow:** design app → export/constants → tests (`tests/explorer/test_share_summary_preview.py`, `test_share_summary_compute.py`).

--- a/docs/cursor-rules.md
+++ b/docs/cursor-rules.md
@@ -19,6 +19,7 @@ Design principle: rules are a **thin routing layer**. Detailed guidance stays in
 | `streamlit-ui-thin.mdc` | `explorer/app/**/*.py` | UI layer only; **`defaults.py` for tunables**; constants locations; tests in core not Streamlit |
 | `map-and-cache.mdc` | Map component, GeoJSON, prep, map presentation, Leaflet export | Static dataframe, LRU cache, committed frontend build, no Folium |
 | `tests.mdc` | `tests/**/*.py` | Behaviour-focused tests; markers; venv/CI parity |
+| `share-summary.mdc` | `**/share_summary*.py`, `design_share_summary_app.py` | Layout slot limits, defaults routing, design-app workflow — **Social Cards / feature-line** (on `feat/social-cards`, not part of the minimal `beta-next` v1 set) |
 
 ---
 
@@ -40,11 +41,13 @@ Markdown body — keep short; link to docs.
 
 ## When to add more rules
 
-Add a new rule when the **same agent mistake happens twice**, or when a feature area needs repeated “read doc X first” routing (e.g. share-summary slot limits on the Social Cards line).
+Add a new rule when the **same agent mistake happens twice**, or when a feature area needs repeated “read doc X first” routing.
+
+**`share-summary.mdc`** is the example: added on `feat/social-cards` for active Social Cards work; merge to `beta-next` when that line lands if the rule should persist repo-wide.
 
 Prefer **`globs`** over **`alwaysApply`** — always-on rules consume context budget. Reserve `alwaysApply: true` for universal guardrails (currently only `project-context.mdc`).
 
-**Social Cards / feature lines:** base branch and PR target are resolved by `/start-issue-work` and [base-branch-resolution.md](../.cursor/commands/base-branch-resolution.md), not by rules (rules cannot read git branch). File-scoped rules for share-summary paths may be added on `feat/social-cards` when that work is active.
+**Social Cards / feature lines:** base branch and PR target are resolved by `/start-issue-work` and [base-branch-resolution.md](../.cursor/commands/base-branch-resolution.md), not by rules (rules cannot read git branch). File-scoped rules such as `share-summary.mdc` live on the feature line until Social Cards merges to `beta-next`.
 
 ---
 


### PR DESCRIPTION
## Summary

Completes the #311 follow-up on the Social Cards feature line: adds a file-scoped `share-summary.mdc` rule and documents it in `docs/cursor-rules.md`.

## Changes

- Add `.cursor/rules/share-summary.mdc` — routes agents to share-summary defaults, preview/compute modules, design app, and tracker docs; encodes layout-specific stat slot limits
- Update `docs/cursor-rules.md` — include the rule in the v1 table and note it is feature-line scoped (not part of the minimal `beta-next` v1 set)

## Testing

- Docs-only change; no Python code touched
- Manual smoke test: edit `design_share_summary_app.py` or `share_summary_preview.py` and confirm agent mentions slot limits / `share_summary_defaults.py` without prompting

## Issues

Refs #311

Made with [Cursor](https://cursor.com)