### PR TITLE
docs: Add Nit-Fixer command and pre-merge review workflow

### DIFF
--- a/.cursor/commands/code-review.md
+++ b/.cursor/commands/code-review.md
@@ -57,7 +57,7 @@ For **myebirdstuff**, read **`docs/AI_CONTEXT.md`** for repo guardrails (Streaml
 ### Security & Safety
 
 - [ ] No obvious security vulnerabilities introduced
-- [ ] Inputs validated and outputs sanitized
+- [ ] Inputs validated and outputs sanitised
 - [ ] Sensitive data handled correctly
 
 ## Nit-Fixer (always — final step)

--- a/.cursor/commands/code-review.md
+++ b/.cursor/commands/code-review.md
@@ -20,7 +20,7 @@ For **myebirdstuff**, read **`docs/AI_CONTEXT.md`** for repo guardrails (Streaml
     - Identify the scope of files and features impacted
     - Note any assumptions or questions to clarify with the author
 2. **Validate functionality**
-    - Confirm the code delivers the intended behavior
+    - Confirm the code delivers the intended behaviour
     - Exercise edge cases or guard conditions mentally or by running locally
     - Check error handling paths and logging for clarity
 3. **Assess quality**
@@ -36,18 +36,12 @@ For **myebirdstuff**, read **`docs/AI_CONTEXT.md`** for repo guardrails (Streaml
     - Look for unfinished work (`TODO`, `FIXME`, commented-out code paths, missing tests for new behaviour)
     - **Review-first:** list gaps and suggested follow-ups for architecture and behaviour concerns
     - If the unfinished work is not minor or is deliberately left for later, ask how to proceed and suggest a GitHub issue so it is not lost
-6. **Nit-Fixer (always)**
-    - After the review checklist, **always** run **[Nit-Fixer](nit-fixer.md)** on the change set vs merge target
-    - Nit-Fixer fixes mechanical and readability nits in touched files (see it, fix it within caps)
-    - Architecture findings and design recommendations stay in the review output — Nit-Fixer does **not** implement them
-    - Nit-Fixer does **not** edit test files; note missing tests in the review, do not ask Nit-Fixer to add them
-    - Fixes stay unstaged; author runs `/commit-work`
 
 ## Review Checklist
 
 ### Functionality
 
-- [ ] Intended behavior works and matches requirements
+- [ ] Intended behaviour works and matches requirements
 - [ ] Edge cases handled gracefully
 - [ ] Error handling is appropriate and informative
 
@@ -66,6 +60,22 @@ For **myebirdstuff**, read **`docs/AI_CONTEXT.md`** for repo guardrails (Streaml
 - [ ] Inputs validated and outputs sanitized
 - [ ] Sensitive data handled correctly
 
+## Nit-Fixer (always — final step)
+
+After steps 0–5 and the Review Checklist above, **always** run **[Nit-Fixer](nit-fixer.md)** on the change set vs merge target:
+
+- Nit-Fixer fixes mechanical and readability nits in touched files (see it, fix it within caps)
+- Architecture findings and design recommendations stay in the review output — Nit-Fixer does **not** implement them
+- Nit-Fixer does **not** edit test files; note missing tests in the review, do not ask Nit-Fixer to add them
+- Fixes stay unstaged; author runs `/commit-work`
+
+Include in your review summary:
+
+- Verdict and fixes applied (or skipped reason)
+- Remaining out-of-scope nits
+- Checks rerun after Nit-Fixer
+- Reminder: review `git diff`, then `/commit-work`
+
 ## Additional Review Notes
 
 - Architecture and design decisions considered
@@ -80,15 +90,6 @@ For **myebirdstuff**, read **`docs/AI_CONTEXT.md`** for repo guardrails (Streaml
 - Not a substitute for CI or human reviewers when policy requires them
 - Not an instruction to rewrite large areas unless the review explicitly recommends it and the author agrees
 - Not a replacement for Test Integrity Sentinel — use `/pr-review` Step 4 when test honesty is the primary concern
-
-## Nit-Fixer output (include in review summary)
-
-When Nit-Fixer runs, append to your review:
-
-- Verdict and fixes applied (or skipped reason)
-- Remaining out-of-scope nits
-- Checks rerun after Nit-Fixer
-- Reminder: review `git diff`, then `/commit-work`
 
 Provide constructive feedback with concrete examples and actionable guidance for
 the author.

--- a/.cursor/commands/code-review.md
+++ b/.cursor/commands/code-review.md
@@ -34,8 +34,14 @@ For **myebirdstuff**, read **`docs/AI_CONTEXT.md`** for repo guardrails (Streaml
     - Evaluate performance or scalability impacts of the change
 5. **Identify in-scope TODO and other unfinished work**
     - Look for unfinished work (`TODO`, `FIXME`, commented-out code paths, missing tests for new behaviour)
-    - **Review-first:** default to listing gaps and suggested follow-ups; only apply trivial fixes in-repo if the author clearly wants that in the same session
+    - **Review-first:** list gaps and suggested follow-ups for architecture and behaviour concerns
     - If the unfinished work is not minor or is deliberately left for later, ask how to proceed and suggest a GitHub issue so it is not lost
+6. **Nit-Fixer (always)**
+    - After the review checklist, **always** run **[Nit-Fixer](nit-fixer.md)** on the change set vs merge target
+    - Nit-Fixer fixes mechanical and readability nits in touched files (see it, fix it within caps)
+    - Architecture findings and design recommendations stay in the review output — Nit-Fixer does **not** implement them
+    - Nit-Fixer does **not** edit test files; note missing tests in the review, do not ask Nit-Fixer to add them
+    - Fixes stay unstaged; author runs `/commit-work`
 
 ## Review Checklist
 
@@ -73,6 +79,16 @@ For **myebirdstuff**, read **`docs/AI_CONTEXT.md`** for repo guardrails (Streaml
 
 - Not a substitute for CI or human reviewers when policy requires them
 - Not an instruction to rewrite large areas unless the review explicitly recommends it and the author agrees
+- Not a replacement for Test Integrity Sentinel — use `/pr-review` Step 4 when test honesty is the primary concern
+
+## Nit-Fixer output (include in review summary)
+
+When Nit-Fixer runs, append to your review:
+
+- Verdict and fixes applied (or skipped reason)
+- Remaining out-of-scope nits
+- Checks rerun after Nit-Fixer
+- Reminder: review `git diff`, then `/commit-work`
 
 Provide constructive feedback with concrete examples and actionable guidance for
 the author.

--- a/.cursor/commands/finish-issue-work.md
+++ b/.cursor/commands/finish-issue-work.md
@@ -80,7 +80,8 @@ Use `/open-pr` logic or `gh pr create` directly:
 
 After the PR exists, offer (user confirms each):
 
-- `/pr-review` on the new PR
+- `/pr-review` on the new PR (includes Sentinel + Nit-Fixer)
+- `/nit-fixer` for a standalone nit pass without full review
 - **Future:** `/test-integrity-review` when [#310](https://github.com/jimchurches/myebirdstuff/issues/310) is implemented and test files changed
 
 ---

--- a/.cursor/commands/nit-fixer.md
+++ b/.cursor/commands/nit-fixer.md
@@ -1,0 +1,207 @@
+# Nit-Fixer (myebirdstuff)
+
+**When to use:** Pre-merge polish on a PR or local branch — aggressive **see it, fix it** for mechanical and readability nits in **PR-touched files**. Also invoked automatically from `/pr-review` (Step 4b) and `/code-review` (final step).
+
+**When not to use alone:** Full architecture review — use `/code-review`. Test honesty / assertion quality — use Test Integrity Sentinel in `/pr-review` (Step 4), not Nit-Fixer.
+
+Fixes are applied **in the working tree only** — do **not** commit. The author reviews and runs `/commit-work`.
+
+For **myebirdstuff**, skim `docs/AI_CONTEXT.md` when touching production code under `explorer/`.
+
+---
+
+## Relationship to CI, Sentinel, and `/pr-review`
+
+| Actor | Role |
+|-------|------|
+| **CI** (`tests.yml`, ruff, hygiene) | Authoritative pass/fail gate — Nit-Fixer does not replace it |
+| **Test Integrity Sentinel** (`/pr-review` Step 4) | Test *honesty* — assertions, mocks, fixtures, missing regression tests |
+| **Nit-Fixer (this command)** | Mechanical + readability fixes in touched production/docs/command/frontend source; **never** edits test files |
+
+**Ordering when combined with `/pr-review`:** Sentinel first (when triage launches it), then Nit-Fixer. Nit-Fixer must not edit paths Sentinel just changed under `tests/`.
+
+---
+
+## Step 1 — Resolve diff scope
+
+1. Identify **PR** and **merge target**:
+   - `gh pr view` on current branch when a PR exists — read `baseRefName`.
+   - No PR: apply **[base branch resolution](base-branch-resolution.md)** from linked issue or default `beta-next`.
+2. Build **touched file list** (files in the PR diff, not only diff hunks):
+
+```bash
+git fetch origin
+# With PR:
+gh pr diff <pr-number> --name-only
+# Without PR:
+git diff --name-only origin/<merge-target>...HEAD
+```
+
+3. Summarise in one line: branch/PR, merge target, file count.
+
+State the resolved merge target in the output.
+
+---
+
+## Step 2 — Triage (skip when nothing to fix)
+
+Classify touched files:
+
+- **Nit-Fixer surface** — production/runtime code (`explorer/`, scripts), Cursor command/rule files, docs, map frontend **source** under `explorer/components/all_locations_map/frontend/src/`.
+- **Sentinel-only surface** — `tests/**`, `conftest.py`, fixtures, snapshots, golden outputs, UI.Vision macros, committed test assets.
+- **Neither / skip** — CI/workflow-only changes with no files on Nit-Fixer surface (e.g. pure `.github/workflows` edit with no companion doc).
+
+**Skip Nit-Fixer** when the touched file list has **no** Nit-Fixer surface files. Record `Nit-Fixer: not applicable — [reason]` and stop (unless the parent command requires a one-line confirmation).
+
+When **only** test paths changed, skip Nit-Fixer — Sentinel owns that surface in `/pr-review`.
+
+---
+
+## Step 3 — Quality gate (proportionate)
+
+Run before launching the subagent. Fold failures into context passed to Nit-Fixer.
+
+**Python (when `explorer/` or Python scripts touched):**
+
+```bash
+python3 -m ruff check explorer/
+python3 -m pytest tests/ -q -m "not e2e"
+```
+
+Prefer a **narrower** pytest path when the diff is clearly isolated.
+
+**Map frontend source** (when any path under `explorer/components/all_locations_map/frontend/src/` is touched):
+
+```bash
+cd explorer/components/all_locations_map/frontend
+npm test -- --watchAll=false
+npx tsc --noEmit
+```
+
+**Docs / commands only:** skip pytest/npm unless the change affects runtime behaviour.
+
+---
+
+## Step 4 — Nit-Fixer subagent
+
+When triage selects **run**, start exactly one subagent. Parent waits for result before reporting; use background only if the session requires it.
+
+```text
+description: Nit-Fixer
+subagent_type: generalPurpose
+model: composer-2.5-fast
+readonly: false
+run_in_background: false
+```
+
+### Parent preparation
+
+Collect before launching:
+
+- Repository absolute path
+- Issue/PR summary (if known)
+- Merge target and **full touched file list** from Step 1
+- Quality-gate command output (pass/fail, tracebacks)
+- Sentinel summary if `/pr-review` Step 4 ran (verdict, files Sentinel edited)
+
+### Task prompt
+
+Fill bracketed fields from the current run:
+
+```text
+You are the Nit-Fixer for the myebirdstuff repository.
+
+Full repository path: [absolute repository path]
+Issue / PR: [number, title, one-line summary, or "standalone /nit-fixer"]
+Base branch: [merge target]
+Touched files (whole-file scope — you may edit anywhere in these files):
+[list paths]
+
+Quality-gate results: [commands run and pass/fail summary]
+Sentinel already ran: [yes/no — if yes, summary and test files Sentinel edited]
+
+Philosophy: see it, fix it. Within guardrails, fix mechanical and readability nits
+in touched files without asking. Prefer fixing over listing deferrable nits.
+
+In scope (fix without asking):
+- Broken/missing imports, typos, syntax errors
+- ruff-fixable lint — run `python3 -m ruff check <paths> --fix` and `python3 -m ruff format <paths>` on in-scope Python files
+- Readability in touched files: unclear names, weak comments, small docstring gaps
+- Trivial TS/lint issues in touched map frontend source
+- Whole-file polish within each touched file (not only diff hunks)
+
+Out of scope (do NOT edit — report to parent instead):
+- tests/**, conftest.py, fixtures, snapshots, golden outputs, UI.Vision macros
+- Adding, weakening, or rewriting tests (Sentinel owns test integrity)
+- Behaviour, API, or architecture changes beyond trivial typo-level fixes
+- Files not in the touched file list
+- Committed frontend/build/ assets unless the PR changes TS/CSS source
+- Secrets, config templates, generated assets
+- Fixes requiring more than ~3 lines of behavioural change
+
+Hard caps:
+- Maximum ~10 files edited and ~150 lines changed per run — if you would exceed, stop and report remaining nits
+- Maximum 2 fix attempts if pytest/tsc/ruff still fail after edits — then revert your edits and report
+
+Project notes:
+- Streamlit UI stays thin; prefer readability fixes that do not move logic into app layer
+- Do not drive-by refactor unrelated modules
+
+After edits:
+- Re-run the narrowest relevant checks (ruff, pytest, npm test, tsc) yourself when feasible
+- Do NOT commit — leave changes unstaged for the author
+
+Output format:
+1. Verdict: `No nits found` | `Nits fixed` | `Stopped — out of scope or cap exceeded`
+2. `Fixes applied` — bullet list with file paths (or "None")
+3. `Remaining nits` — only items truly out of scope or blocked (or "None")
+4. `Checks run` — pass/fail
+5. Approximate files/lines touched
+```
+
+### Parent follow-up
+
+After the subagent returns:
+
+- Inspect edits before reporting.
+- Re-run Step 3 quality gate if Nit-Fixer changed production or frontend source.
+- Do **not** commit.
+
+---
+
+## Step 5 — Report (standard output)
+
+### Scope
+
+- **PR / branch:** …
+- **Base:** `beta-next` (or other)
+- **Touched files:** N files
+
+### Nit-Fixer
+
+- Triage: **ran** | **skipped** (reason)
+- Verdict from subagent
+- Fixes applied (bullets) or "None"
+- Remaining out-of-scope nits or "None"
+- Approx files/lines touched
+
+### Checks run
+
+- Commands before and after Nit-Fixer, with pass/fail
+
+### Next step
+
+- Remind author: review `git diff`, then `/commit-work` if satisfied
+
+---
+
+## Do not
+
+- Commit or push fixes
+- Edit test files, fixtures, or snapshots
+- Replace CI, Sentinel, or full `/pr-review`
+- Leave fixable in-scope nits as suggestions only — fix them when within caps
+- Expand scope beyond the touched file list
+- Force-push or amend commits
+
+Provide a concise report. Fixes stay in the working tree for human review.

--- a/.cursor/commands/nit-fixer.md
+++ b/.cursor/commands/nit-fixer.md
@@ -1,6 +1,6 @@
 # Nit-Fixer (myebirdstuff)
 
-**When to use:** Pre-merge polish on a PR or local branch — aggressive **see it, fix it** for mechanical and readability nits in **PR-touched files**. Also invoked automatically from `/pr-review` (Step 4b) and `/code-review` (final step).
+**When to use:** Pre-merge polish on a PR or local branch — aggressive **see it, fix it** for mechanical and readability nits in **PR-touched files**. Also invoked from `/pr-review` (Step 4b) and `/code-review` (final step after the checklist). Refs [#299](https://github.com/jimchurches/myebirdstuff/issues/299).
 
 **When not to use alone:** Full architecture review — use `/code-review`. Test honesty / assertion quality — use Test Integrity Sentinel in `/pr-review` (Step 4), not Nit-Fixer.
 

--- a/.cursor/commands/nit-fixer.md
+++ b/.cursor/commands/nit-fixer.md
@@ -13,7 +13,7 @@ For **myebirdstuff**, skim `docs/AI_CONTEXT.md` when touching production code un
 ## Relationship to CI, Sentinel, and `/pr-review`
 
 | Actor | Role |
-|-------|------|
+| --- | --- |
 | **CI** (`tests.yml`, ruff, hygiene) | Authoritative pass/fail gate — Nit-Fixer does not replace it |
 | **Test Integrity Sentinel** (`/pr-review` Step 4) | Test *honesty* — assertions, mocks, fixtures, missing regression tests |
 | **Nit-Fixer (this command)** | Mechanical + readability fixes in touched production/docs/command/frontend source; **never** edits test files |

--- a/.cursor/commands/pr-review.md
+++ b/.cursor/commands/pr-review.md
@@ -10,7 +10,7 @@ Every `/pr-review` run includes **Test Integrity Sentinel** triage (Step 4) and 
 |---|---|---|
 | **Scope** | One issue + one PR diff vs **merge target** (often `beta-next`; may be a feature line) | Whole change set; architecture and cross-cutting concerns |
 | **When** | Small fixes, pre-merge sanity check | Before opening/updating a large PR, or multi-file behaviour changes |
-| **Fixes during review** | Sentinel strengthens in-scope tests; Nit-Fixer fixes mechanical/readability nits in touched files (see Step 4b) | Architecture review first; **always** runs Nit-Fixer at the end for in-scope nits |
+| **Fixes during review** | Sentinel strengthens in-scope tests; Nit-Fixer fixes mechanical/readability nits in touched files (Step 4b) | Architecture review first; **always** runs Nit-Fixer last (see [code-review.md](code-review.md)) |
 
 This command **does not replace or rewrite** `/code-review`. It reuses the same quality bar and checklist items, but constrains scope and workflow for targeted PR reviews.
 
@@ -222,7 +222,7 @@ Every `/pr-review` runs **Nit-Fixer triage** after Step 4 (whether Sentinel laun
 ### Sentinel vs Nit-Fixer
 
 | | Sentinel (Step 4) | Nit-Fixer (Step 4b) |
-|---|---|---|
+| --- | --- | --- |
 | **Focus** | Test honesty, assertions, mocks, fixtures | Imports, lint, format, typos, readability |
 | **Edits tests?** | Yes, when justified | **Never** |
 | **Model** | `gpt-5.5-medium` | `composer-2.5-fast` |

--- a/.cursor/commands/pr-review.md
+++ b/.cursor/commands/pr-review.md
@@ -2,7 +2,7 @@
 
 **When to use:** Pre-merge review of a **single** linked issue and its PR — e.g. a focused bug fix or small feature. For larger or multi-area changes, use `/code-review` instead.
 
-Every `/pr-review` run includes a **Test Integrity Sentinel** triage. The parent agent resolves the PR context and local checks, then — when the diff has a test or behaviour surface (see Step 4) — delegates a focused test-integrity review to a pinned reviewer subagent so tests are reviewed by a different model from the authoring flow. The reviewer model is defined once in the Step 4 invocation block.
+Every `/pr-review` run includes **Test Integrity Sentinel** triage (Step 4) and **Nit-Fixer** (Step 4b). The parent agent resolves PR context and local checks, then — when the diff warrants it — delegates to pinned subagents: Sentinel for test honesty (`gpt-5.5-medium`), Nit-Fixer for mechanical and readability nits in touched files (`composer-2.5-fast`). See **[nit-fixer.md](nit-fixer.md)** for Nit-Fixer guardrails and prompt.
 
 ## Relationship to `/code-review`
 
@@ -10,7 +10,7 @@ Every `/pr-review` run includes a **Test Integrity Sentinel** triage. The parent
 |---|---|---|
 | **Scope** | One issue + one PR diff vs **merge target** (often `beta-next`; may be a feature line) | Whole change set; architecture and cross-cutting concerns |
 | **When** | Small fixes, pre-merge sanity check | Before opening/updating a large PR, or multi-file behaviour changes |
-| **Fixes during review** | Apply minor, low-risk nits without asking; allow Sentinel to strengthen in-scope tests | Default to listing gaps; only trivial fixes if the author wants them in-session |
+| **Fixes during review** | Sentinel strengthens in-scope tests; Nit-Fixer fixes mechanical/readability nits in touched files (see Step 4b) | Architecture review first; **always** runs Nit-Fixer at the end for in-scope nits |
 
 This command **does not replace or rewrite** `/code-review`. It reuses the same quality bar and checklist items, but constrains scope and workflow for targeted PR reviews.
 
@@ -78,7 +78,7 @@ python3 -m ruff check explorer/
 python3 -m pytest tests/ -q -m "not e2e"
 ```
 
-Prefer a **narrower** pytest path when the diff is clearly isolated (e.g. `tests/path/to/test_module.py`). Fold failures into the review; fix trivial ones under Step 6.
+Prefer a **narrower** pytest path when the diff is clearly isolated (e.g. `tests/path/to/test_module.py`). Fold failures into the review; Nit-Fixer addresses mechanical failures in Step 4b.
 
 **Docs / config only:** skip pytest unless the change affects runtime behaviour.
 
@@ -104,7 +104,7 @@ Decide using the **first** matching rule:
 
 If you are unsure whether a changed file affects behaviour, treat it as the behaviour surface and **launch** (fail safe toward review).
 
-When triage selects **skip**, go straight to Step 5. The remainder of Step 4 applies only when launching.
+When triage selects **skip**, go straight to Step 4b. The remainder of Step 4 applies only when launching.
 
 ### Parent preparation
 
@@ -215,6 +215,55 @@ After the subagent returns:
 
 ---
 
+## Step 4b — Nit-Fixer
+
+Every `/pr-review` runs **Nit-Fixer triage** after Step 4 (whether Sentinel launched or skipped). Nit-Fixer fixes mechanical and readability nits in **PR-touched files** (whole-file scope). It does **not** edit test files — Sentinel owns test integrity.
+
+### Sentinel vs Nit-Fixer
+
+| | Sentinel (Step 4) | Nit-Fixer (Step 4b) |
+|---|---|---|
+| **Focus** | Test honesty, assertions, mocks, fixtures | Imports, lint, format, typos, readability |
+| **Edits tests?** | Yes, when justified | **Never** |
+| **Model** | `gpt-5.5-medium` | `composer-2.5-fast` |
+| **Philosophy** | Strengthen confidence in tests | See it, fix it in touched files |
+
+### Triage — decide whether to launch Nit-Fixer
+
+Use the **touched file list** from Step 2 (`gh pr diff --name-only` or `git diff --name-only origin/<base>...HEAD`).
+
+**Run Nit-Fixer** when any touched file is on the **Nit-Fixer surface**: `explorer/`, scripts, Cursor commands/rules, docs, or map frontend source under `explorer/components/all_locations_map/frontend/src/`.
+
+**Skip Nit-Fixer** when the diff touches **only** Sentinel-only paths (`tests/**`, fixtures, snapshots, etc.) or CI/workflow-only paths with no Nit-Fixer surface files. Record `Nit-Fixer: not applicable — [reason]` in the Step 7 report.
+
+When triage selects **skip**, go to Step 5.
+
+### Subagent invocation
+
+When triage selects **run**, follow **[nit-fixer.md](nit-fixer.md)** Steps 3–4: run the proportionate quality gate, then launch exactly one Nit-Fixer subagent.
+
+Pass the Sentinel summary (if Step 4 ran) in the subagent prompt so Nit-Fixer does not conflict with test edits.
+
+```text
+description: Nit-Fixer
+subagent_type: generalPurpose
+model: composer-2.5-fast
+readonly: false
+run_in_background: false
+```
+
+Use the task prompt and guardrails from **nit-fixer.md** (caps: ~10 files / ~150 lines; no commits).
+
+### Parent follow-up
+
+After the subagent returns:
+
+- Inspect edits; re-run Step 3 checks if production or frontend source changed.
+- Do **not** commit — author runs `/commit-work`.
+- Fold Nit-Fixer verdict, fixes, and rerun checks into the Step 7 report.
+
+---
+
 ## Step 5 — Scoped review checklist
 
 Apply the checklist **only to files in the PR diff**. Do not audit the rest of the repo.
@@ -246,26 +295,30 @@ Apply the checklist **only to files in the PR diff**. Do not audit the rest of t
 
 ---
 
-## Step 6 — In-review fixes
+## Step 6 — Fix policy (orchestration only)
 
-There are two fix policies in this command:
+The parent **does not** apply nits directly during `/pr-review`. Fixing is delegated:
 
-- **Parent review fixes:** minor only, as described below.
-- **Sentinel test-integrity fixes:** more assertive within tests and fixtures, but only under Step 4's scope and guardrails.
+| Actor | Fixes |
+|-------|--------|
+| **Sentinel (Step 4)** | Test integrity — assertions, fixtures, mocks, missing regression tests |
+| **Nit-Fixer (Step 4b)** | Mechanical and readability nits in touched production/docs/command/frontend source |
+| **Parent** | Blockers requiring author decision; verdict and report only |
 
-**Do fix without asking** when all of these hold:
+**Parent may fix without asking** only when:
 
-- Clearly within the PR diff (or directly required to make the diff correct)
-- Low risk (typos, lint, tiny readability, missing import, obvious test gap for the same behaviour)
-- No behaviour change beyond what the issue/PR already intends
+- Nit-Fixer or Sentinel failed to run (tooling error) **and** the fix is a single trivial typo clearly blocking the review report
+- The fix is required to complete the review workflow itself (not general code polish)
 
 **Do not fix without asking** when:
 
-- The fix changes behaviour, API, or architecture
+- The fix changes behaviour, API, or architecture beyond Nit-Fixer guardrails
 - It expands scope beyond the linked issue
-- It would be better as a follow-up issue
+- Nit-Fixer reported the item as out of scope or cap-exceeded — list it for author decision instead
 
-After fixes: re-run the relevant checks from Step 3 and note what changed in the output.
+Prefer **Ready to merge** over **Ready with nits** when Nit-Fixer fixed all in-scope items. Do not list nits Nit-Fixer could have fixed within caps.
+
+All fixes stay **unstaged** — author runs `/commit-work`.
 
 ---
 
@@ -303,14 +356,23 @@ Use concrete file/line references where helpful.
 - Remaining test-integrity concerns, or “None”
 - Any tests/checks it ran directly
 
+### Nit-Fixer
+
+- Triage decision: **launched** or **skipped** (with the reason)
+- Verdict from the Nit-Fixer subagent (omit if skipped)
+- Fixes it applied, or “None”
+- Remaining out-of-scope nits, or “None”
+- Approx files/lines touched
+- Reminder: fixes unstaged — author runs `/commit-work`
+
 ### Fixes applied during review
 
-- Bullet list of parent review fixes and Sentinel fixes made in-repo, or “None”
+- Bullet list of Sentinel and Nit-Fixer fixes made in-repo, or “None” (parent fixes, if any)
 
 ### Checks run
 
 - Commands executed and pass/fail (e.g. `ruff`, `pytest …`)
-- Include parent quality-gate commands, Sentinel-run commands, and any reruns after fixes
+- Include parent quality-gate commands, Sentinel-run commands, Nit-Fixer reruns, and any reruns after fixes
 
 ### Follow-ups (optional)
 
@@ -322,9 +384,12 @@ Use concrete file/line references where helpful.
 
 - Treat this as a full-project or architecture review — use `/code-review` for that
 - Rewrite large areas without author agreement
-- Block on nits that you could safely fix under Step 6
+- Block on nits that Nit-Fixer could safely fix in scope — launch Nit-Fixer instead of listing them
+- Apply mechanical/readability nits directly on the parent when Step 4b triage says to launch Nit-Fixer — launch the subagent instead
+- Let Nit-Fixer edit test files — Sentinel owns tests
 - Self-review test integrity on the parent model when Step 4 triage says to launch the subagent — launch it instead
 - Spawn the Sentinel subagent for a diff with no test or behaviour surface (e.g. docs/command/config-only) — record it as not applicable per Step 4 triage
+- Commit Nit-Fixer or Sentinel fixes during `/pr-review`
 - Substitute for CI or required human reviewers when policy applies
 
 Provide constructive, actionable feedback scoped to the linked issue and PR.

--- a/.cursor/commands/pr-review.md
+++ b/.cursor/commands/pr-review.md
@@ -2,7 +2,7 @@
 
 **When to use:** Pre-merge review of a **single** linked issue and its PR — e.g. a focused bug fix or small feature. For larger or multi-area changes, use `/code-review` instead.
 
-Every `/pr-review` run includes **Test Integrity Sentinel** triage (Step 4) and **Nit-Fixer** (Step 4b). The parent agent resolves PR context and local checks, then — when the diff warrants it — delegates to pinned subagents: Sentinel for test honesty (`gpt-5.5-medium`), Nit-Fixer for mechanical and readability nits in touched files (`composer-2.5-fast`). See **[nit-fixer.md](nit-fixer.md)** for Nit-Fixer guardrails and prompt.
+Every `/pr-review` run includes **Test Integrity Sentinel** triage (Step 4) and **Nit-Fixer** triage (Step 4b). The parent agent resolves PR context and local checks, then delegates to pinned subagents when triage selects launch: Sentinel for test honesty (`gpt-5.5-medium`), Nit-Fixer for mechanical and readability nits in touched files (`composer-2.5-fast`). See **[nit-fixer.md](nit-fixer.md)** for Nit-Fixer guardrails and prompt.
 
 ## Relationship to `/code-review`
 
@@ -221,7 +221,7 @@ Every `/pr-review` runs **Nit-Fixer triage** after Step 4 (whether Sentinel laun
 
 ### Sentinel vs Nit-Fixer
 
-| | Sentinel (Step 4) | Nit-Fixer (Step 4b) |
+| Aspect | Sentinel (Step 4) | Nit-Fixer (Step 4b) |
 | --- | --- | --- |
 | **Focus** | Test honesty, assertions, mocks, fixtures | Imports, lint, format, typos, readability |
 | **Edits tests?** | Yes, when justified | **Never** |

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,7 +22,7 @@ Slash commands in `.cursor/commands/` automate git and GitHub workflow. Key comm
 | `/merge-pr` | Merge feature branch into target integration branch |
 | `/pr-review` | Pre-merge review: Sentinel (when needed) + Nit-Fixer + verdict |
 | `/nit-fixer` | Standalone aggressive nit pass on PR-touched files |
-| `/code-review` | Large-change review; always runs Nit-Fixer at the end |
+| `/code-review` | Large-change review; Nit-Fixer as final step after checklist |
 
 **Base branch resolution:** Commands share logic in [`.cursor/commands/base-branch-resolution.md`](../.cursor/commands/base-branch-resolution.md). When a GitHub issue includes `## Base branch` / `## PR target`, commands read the issue via `gh issue view` instead of defaulting to `beta-next`. Feature-line work (e.g. Social Cards on `feat/social-cards`) is documented in `docs/explorer/social-cards-workflow.md` when present on that branch.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ Manual, command-driven pre-merge polish ([#299](https://github.com/jimchurches/m
 |-------|------|
 | **CI** | Authoritative pass/fail gate (`tests.yml`, ruff, hygiene) |
 | **Test Integrity Sentinel** (`/pr-review` Step 4) | Test honesty on changed tests and behaviour |
-| **Nit-Fixer** (`/nit-fixer`, `/pr-review` Step 4b, `/code-review` Step 6) | See-it-fix-it mechanical and readability fixes in PR-touched files; leaves changes unstaged for `/commit-work`; never edits test files |
+| **Nit-Fixer** (`/nit-fixer`, `/pr-review` Step 4b, `/code-review` final step) | See-it-fix-it mechanical and readability fixes in PR-touched files; leaves changes unstaged for `/commit-work`; never edits test files |
 
 Full guardrails: [`.cursor/commands/nit-fixer.md`](../.cursor/commands/nit-fixer.md).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,8 +20,25 @@ Slash commands in `.cursor/commands/` automate git and GitHub workflow. Key comm
 | `/finish-issue-work` | Post-implementation: quality gate → push → open PR |
 | `/open-pr` | Push and open PR with correct **PR target** |
 | `/merge-pr` | Merge feature branch into target integration branch |
+| `/pr-review` | Pre-merge review: Sentinel (when needed) + Nit-Fixer + verdict |
+| `/nit-fixer` | Standalone aggressive nit pass on PR-touched files |
+| `/code-review` | Large-change review; always runs Nit-Fixer at the end |
 
 **Base branch resolution:** Commands share logic in [`.cursor/commands/base-branch-resolution.md`](../.cursor/commands/base-branch-resolution.md). When a GitHub issue includes `## Base branch` / `## PR target`, commands read the issue via `gh issue view` instead of defaulting to `beta-next`. Feature-line work (e.g. Social Cards on `feat/social-cards`) is documented in `docs/explorer/social-cards-workflow.md` when present on that branch.
+
+### Nit-Fixer vs CI vs Sentinel
+
+Manual, command-driven pre-merge polish ([#299](https://github.com/jimchurches/myebirdstuff/issues/299)) — not a PR-triggered bot.
+
+| Actor | Role |
+|-------|------|
+| **CI** | Authoritative pass/fail gate (`tests.yml`, ruff, hygiene) |
+| **Test Integrity Sentinel** (`/pr-review` Step 4) | Test honesty on changed tests and behaviour |
+| **Nit-Fixer** (`/nit-fixer`, `/pr-review` Step 4b, `/code-review` Step 6) | See-it-fix-it mechanical and readability fixes in PR-touched files; leaves changes unstaged for `/commit-work`; never edits test files |
+
+Full guardrails: [`.cursor/commands/nit-fixer.md`](../.cursor/commands/nit-fixer.md).
+
+**Trial after merge:** run `/nit-fixer` or `/pr-review` on 2–3 real PRs; tune prompt caps if needed ([#299](https://github.com/jimchurches/myebirdstuff/issues/299)).
 
 ## Cursor project rules
 


### PR DESCRIPTION
## Summary

- Add `/nit-fixer` command — command-based see-it-fix-it sub-agent for pre-merge polish in PR-touched files
- Wire Nit-Fixer into `/pr-review` (Step 4b, after Sentinel) and `/code-review` (final step after checklist)
- Document Nit-Fixer vs CI vs Sentinel in `docs/development.md`
- Update `/finish-issue-work` to offer `/nit-fixer` alongside `/pr-review`

Command-only approach per #299 design — no PR-triggered Cursor Automation.

## Changes

| File | Change |
|------|--------|
| `.cursor/commands/nit-fixer.md` | New — guardrails, quality gate, `composer-2.5-fast` subagent prompt |
| `.cursor/commands/pr-review.md` | Step 4b Nit-Fixer; Step 6 orchestration-only |
| `.cursor/commands/code-review.md` | Nit-Fixer as final step after checklist |
| `.cursor/commands/finish-issue-work.md` | Optional `/nit-fixer` follow-up |
| `docs/development.md` | Commands table + Nit-Fixer vs CI vs Sentinel |

## Testing

- [ ] Markdown/command docs only — no ruff/pytest required for this PR
- [ ] **Post-merge trial:** run `/nit-fixer` or `/pr-review` on 2–3 real PRs; tune caps if needed

## Issues

Refs #299

Made with [Cursor](https://cursor.com)