### PR TITLE
refactor: Extract shared Social Cards UI from design studio

### DIFF
--- a/explorer/app/streamlit/design_share_summary_app.py
+++ b/explorer/app/streamlit/design_share_summary_app.py
@@ -16,7 +16,9 @@ import os
 import sys
 from datetime import date
 
-_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+_REPO_ROOT = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..")
+)
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
@@ -193,7 +195,9 @@ geo_scope = ShareSummaryGeoScope()
 with st.sidebar:
     st.header("Data")
     use_sample = st.toggle("Use sample data", value=True)
-    uploaded = None if use_sample else st.file_uploader("eBird CSV export", type=["csv"])
+    uploaded = (
+        None if use_sample else st.file_uploader("eBird CSV export", type=["csv"])
+    )
     if use_sample:
         df = _design_sample_dataset(date.today().year)
     elif uploaded is not None:
@@ -302,20 +306,28 @@ if df is not None:
         if period_anchor is not None:
             period = resolve_period("month", anchor=period_anchor, reference=reference)
         else:
-            month_options = sorted({(int(r.year), int(r.month)) for r in dates.dt.to_pydatetime()})
+            month_options = sorted(
+                {(int(r.year), int(r.month)) for r in dates.dt.to_pydatetime()}
+            )
             labels = [date(y, m, 1).strftime("%B %Y") for y, m in month_options]
-            pick = st.sidebar.selectbox("Month", options=range(len(labels)), format_func=lambda i: labels[i])
+            pick = st.sidebar.selectbox(
+                "Month", options=range(len(labels)), format_func=lambda i: labels[i]
+            )
             y, m = month_options[pick]
             period = period_for_month(y, m)
     elif period_mode == "week":
         if period_anchor is not None:
             period = resolve_period("week", anchor=period_anchor, reference=reference)
         else:
-            week_starts = sorted({period_for_week_containing(d).start for d in dates.dt.date})
-            week_labels = [
-                period_for_week_containing(ws).label for ws in week_starts
-            ]
-            pick = st.sidebar.selectbox("Week", options=range(len(week_labels)), format_func=lambda i: week_labels[i])
+            week_starts = sorted(
+                {period_for_week_containing(d).start for d in dates.dt.date}
+            )
+            week_labels = [period_for_week_containing(ws).label for ws in week_starts]
+            pick = st.sidebar.selectbox(
+                "Week",
+                options=range(len(week_labels)),
+                format_func=lambda i: week_labels[i],
+            )
             period = period_for_week_containing(week_starts[pick])
     elif period_mode == "lifetime":
         period = period_for_lifetime(min_d, max_d)
@@ -353,7 +365,9 @@ if df is not None:
                 placeholder=_CARD_HEADING_PLACEHOLDER,
                 key="design_csv_card_heading",
             )
-            period = period_for_custom(start, end, trip_title=_card_heading_or_none(card_heading))
+            period = period_for_custom(
+                start, end, trip_title=_card_heading_or_none(card_heading)
+            )
 
     resolved_period = period
     lifer_ref = df if not geo_scope.is_world else None
@@ -365,7 +379,9 @@ if df is not None:
         st.stop()
     stats = computed
     all_time = (
-        compute_share_summary_all_time_stats(df_scoped, taxonomy_locale=TAXONOMY_LOCALE_DEFAULT)
+        compute_share_summary_all_time_stats(
+            df_scoped, taxonomy_locale=TAXONOMY_LOCALE_DEFAULT
+        )
         if geo_scope.is_world
         else None
     )
@@ -411,7 +427,10 @@ hex_card_stat_labels = default_card_stat_labels(
     period_kind=stats.period_kind,
     geo_scope=geo_scope,
 )
-if sidebar_selection.fmt == "story" and len(hex_card_stat_labels) < SHARE_SUMMARY_STORY_MAX_STATS:
+if (
+    sidebar_selection.fmt == "story"
+    and len(hex_card_stat_labels) < SHARE_SUMMARY_STORY_MAX_STATS
+):
     picked = set(hex_card_stat_labels)
     extra: list[str] = []
     for label, _ in status_metrics:

--- a/explorer/app/streamlit/design_share_summary_app.py
+++ b/explorer/app/streamlit/design_share_summary_app.py
@@ -23,20 +23,29 @@ if _REPO_ROOT not in sys.path:
 import pandas as pd
 import streamlit as st
 
+from explorer.app.streamlit.social_cards_session_keys import DESIGN_SOCIAL_CARDS_KEYS
+from explorer.app.streamlit.social_cards_sidebar_ui import (
+    render_sidebar_card_controls,
+    render_sidebar_geo_scope_controls,
+)
+from explorer.app.streamlit.social_cards_streamlit_helpers import (
+    card_stat_data_scope_from_design_source,
+    period_has_checklist_data,
+)
+from explorer.app.streamlit.social_cards_streamlit_ui import (
+    SOCIAL_CARDS_CURRENT_CARD_LABEL,
+    render_current_card_fragment,
+)
 from explorer.core.data_loader import add_datetime_column, load_dataset
-from explorer.core.region_display import map_focus_key_for_display
 from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
 from explorer.core.share_summary_compute import (
     PeriodAnchor,
-    PeriodKind,
     ShareSummaryAllTimeStats,
     ShareSummaryGeoScope,
     ShareSummaryStats,
     compute_share_summary_all_time_stats,
     compute_share_summary_stats,
     filter_df_by_geo_scope,
-    geo_country_keys_from_df,
-    geo_region_options_for_country,
     geo_scope_display_label,
     period_for_custom,
     period_for_lifetime,
@@ -47,32 +56,18 @@ from explorer.core.share_summary_compute import (
     suggest_period_anchor,
 )
 from explorer.core.share_summary_defaults import (
-    SHARE_SUMMARY_COLOR_SCHEME_IDS,
     SHARE_SUMMARY_INSIGHT_FACT_DEFAULT,
     SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT,
     SHARE_SUMMARY_STORY_MAX_STATS,
-    share_summary_color_scheme_fingerprint,
-    share_summary_color_scheme_index,
-    share_summary_color_scheme_label,
-    share_summary_layout_label,
-    share_summary_spotlight_presentation_label,
-    share_summary_tiles_presentation_label,
 )
 from explorer.core.share_summary_insight_facts import (
-    INSIGHT_FACT_PICKER_LABELS,
-    InsightFactId,
     ShareSummaryInsightFact,
     compute_insight_facts,
-    insight_fact_requires_species,
     species_common_names_in_period,
 )
 from explorer.presentation.share_summary_circle_layout_playground import (
     CIRCLE_LAYOUT_PLAYGROUND_IFRAME_HEIGHT_PX,
     render_circle_layout_playground_html,
-)
-from explorer.presentation.share_summary_circles_preview import (
-    TILES_CIRCLE_CLUSTER_DEFAULT,
-    tiles_circle_cluster_max,
 )
 from explorer.presentation.share_summary_hex_preview import (
     HEX_GRID_EXPERIMENTAL_NOTICE,
@@ -81,84 +76,19 @@ from explorer.presentation.share_summary_hex_preview import (
     HexVariantId,
     render_hex_grid_preview_html,
 )
-from explorer.presentation.share_summary_png_export import (
-    share_summary_png_filename,
-    share_summary_to_png_bytes,
-)
 from explorer.presentation.share_summary_preview import (
-    FORMAT_LABELS,
-    FORMAT_PIXELS,
-    FormatId,
-    LayoutId,
-    SpotlightPresentationId,
-    TilesPresentationId,
     default_card_stat_labels,
-    layout_card_stat_max,
-    layout_card_stat_storage_max,
-    layout_grid_slot_limits_caption,
-    layout_grid_stat_default_count,
-    layout_grid_stat_min,
-    render_share_summary_preview_html,
-    resolve_insight_fact,
     sample_share_summary_stats,
     summary_status_metrics,
 )
-
-
-@st.cache_data(show_spinner="Generating PNG…")
-def _cached_share_summary_png(
-    stats: ShareSummaryStats,
-    layout: LayoutId,
-    fmt: FormatId,
-    card_stat_labels: tuple[str, ...],
-    spotlight_label: str,
-    all_time: ShareSummaryAllTimeStats | None,
-    color_scheme_index: int,
-    color_scheme_fingerprint: tuple[tuple[str, str], ...],
-    scope_label: str | None,
-    geo_scope: ShareSummaryGeoScope,
-    tiles_presentation: TilesPresentationId = "grid",
-    spotlight_presentation: SpotlightPresentationId = "classic",
-    insight_fact: ShareSummaryInsightFact | None = None,
-) -> bytes:
-    del color_scheme_fingerprint  # cache key only — render reads live scheme by index
-    return share_summary_to_png_bytes(
-        stats,
-        layout=layout,
-        fmt=fmt,
-        spotlight_label=spotlight_label,
-        insight_fact=insight_fact,
-        card_stat_labels=card_stat_labels,
-        all_time=all_time,
-        color_scheme_index=color_scheme_index,
-        scope_label=scope_label,
-        geo_scope=geo_scope,
-        tiles_presentation=tiles_presentation,
-        spotlight_presentation=spotlight_presentation,
-    )
 
 _DESIGN_STUDIO_TITLE = "Social sharing design studio"
 _SOCIAL_CARDS_TAB_LABEL = "Social Cards"
 _HEX_EXPERIMENTS_TAB_LABEL = "Hex grid experiments (experimental)"
 _CIRCLE_LAYOUT_TAB_LABEL = "Circle layout"
-_PREVIEW_SCALE_DEFAULT = 0.42
-_PREVIEW_SCALE_FULL = 1.0
-_TILES_PRESENTATION_KEY = "design_tiles_presentation"
-_SPOTLIGHT_PRESENTATION_KEY = "design_spotlight_presentation"
-_INSIGHT_FACT_KEY = "design_insight_fact"
-_INSIGHT_SPECIES_KEY = "design_insight_species"
-_COLOR_THEME_KEY = "design_color_theme"
-_STATISTICS_LABEL = "Card statistics"
-_CARD_STATS_SLOT_COUNT_PREFIX = "design_card_stat_slot_count_"
-_CARD_STATS_PICKS_PREFIX = "design_card_stat_picks_"
-_CARD_STATS_SCOPE_PREFIX = "design_card_stat_scope_"
-_SPOTLIGHT_LABEL_KEY = "design_spotlight_label"
-_CURRENT_CARD_LABEL = "Current card"
 _CARD_HEADING_LABEL = "Card Heading (optional)"
 _CARD_HEADING_PLACEHOLDER = "e.g. North Coast NSW Exploration"
-_GEO_WORLD_OPTION = ""
-_GEO_COUNTRY_SELECT_KEY = "design_geo_country"
-_GEO_REGION_SELECT_KEY = "design_geo_region"
+_DESIGN_HEX_SELECTED_KEY = "design_hex_selected_variant"
 
 
 def _card_heading_or_none(text: str) -> str | None:
@@ -250,1008 +180,13 @@ def _design_sample_dataset(sample_year: int) -> pd.DataFrame:
     return add_datetime_column(pd.DataFrame(records))
 
 
-def _geo_country_select_label(country_key: str) -> str:
-    if not country_key:
-        return "World"
-    return map_focus_key_for_display(country_key)
-
-
-def _sidebar_geo_scope_controls(df: pd.DataFrame) -> ShareSummaryGeoScope:
-    """Country and region pickers; World is the default (no filter)."""
-    country_keys = geo_country_keys_from_df(df)
-    country_options = [_GEO_WORLD_OPTION, *country_keys]
-    country_key = st.selectbox(
-        "Country",
-        options=country_options,
-        format_func=_geo_country_select_label,
-        key=_GEO_COUNTRY_SELECT_KEY,
-    )
-    if not country_key:
-        st.session_state.pop(_GEO_REGION_SELECT_KEY, None)
-        return ShareSummaryGeoScope()
-
-    region_pairs = geo_region_options_for_country(df, country_key)
-    region_options = [_GEO_WORLD_OPTION, *[code for code, _ in region_pairs]]
-    region_labels = {_GEO_WORLD_OPTION: "All regions"}
-    region_labels.update({code: label for code, label in region_pairs})
-    current_region = st.session_state.get(_GEO_REGION_SELECT_KEY, _GEO_WORLD_OPTION)
-    if current_region not in region_options:
-        st.session_state[_GEO_REGION_SELECT_KEY] = _GEO_WORLD_OPTION
-    region_code = st.selectbox(
-        "Region",
-        options=region_options,
-        format_func=lambda code: region_labels[code],
-        key=_GEO_REGION_SELECT_KEY,
-    )
-    return ShareSummaryGeoScope(
-        country_key=country_key,
-        region_code=region_code or None,
-    )
-
-
-def _card_stat_picks_key(layout: LayoutId, period_kind: PeriodKind) -> str:
-    return f"{_CARD_STATS_PICKS_PREFIX}{layout}_{period_kind}"
-
-
-def _card_stat_slot_count_key(layout: LayoutId, period_kind: PeriodKind) -> str:
-    return f"{_CARD_STATS_SLOT_COUNT_PREFIX}{layout}_{period_kind}"
-
-
-def _card_stat_scope_key(layout: LayoutId, period_kind: PeriodKind) -> str:
-    return f"{_CARD_STATS_SCOPE_PREFIX}{layout}_{period_kind}"
-
-
-def _card_stat_data_scope(
-    *,
-    use_sample: bool,
-    period_kind: PeriodKind,
-    period_label: str,
-    upload_name: str | None,
-    geo_scope: ShareSummaryGeoScope | None = None,
-    fmt: FormatId = "square",
-    tiles_presentation: TilesPresentationId = "grid",
-) -> str:
-    """Session scope token — when this changes, card-stat picks re-initialize."""
-    source = "sample" if use_sample else (upload_name or "csv")
-    geo_token = (geo_scope or ShareSummaryGeoScope()).scope_token()
-    return f"{source}|{period_kind}|{period_label}|{geo_token}|{fmt}|{tiles_presentation}"
-
-
-def _period_has_checklist_data(stats: ShareSummaryStats) -> bool:
-    """False when the selected period has no checklists in the loaded export."""
-    return stats.checklists is not None and stats.checklists > 0
-
-
-def _card_stat_selectbox_key(layout: LayoutId, index: int) -> str:
-    return f"design_card_stat_sel_{layout}_{index}"
-
-
-def _clear_card_stat_selectbox_keys(layout: LayoutId) -> None:
-    """Drop stale selectbox widget state so Reset / session picks take effect."""
-    for i in range(layout_card_stat_storage_max(layout)):
-        st.session_state.pop(_card_stat_selectbox_key(layout, i), None)
-
-
-def _resolve_card_stat_selectbox_value(
-    *,
-    session_value: object,
-    desired: str,
-    options: list[str],
-) -> str:
-    """Pick a valid selectbox value, preferring the widget over stale session picks."""
-    if session_value is not None:
-        value = session_value.strip() if isinstance(session_value, str) else str(session_value).strip()
-        if value in options:
-            return value
-    fallback = desired.strip() if isinstance(desired, str) else str(desired).strip()
-    return fallback if fallback in options else ""
-
-
-def _sync_card_stat_selectbox_value(
-    layout: LayoutId,
-    index: int,
-    *,
-    options: list[str],
-    desired: str,
-) -> str:
-    """Align selectbox session state without clobbering a valid user choice."""
-    key = _card_stat_selectbox_key(layout, index)
-    value = _resolve_card_stat_selectbox_value(
-        session_value=st.session_state.get(key),
-        desired=desired,
-        options=options,
-    )
-    st.session_state[key] = value
-    return value
-
-
-def _tiles_circle_cluster_picker(layout: LayoutId, tiles_presentation: TilesPresentationId) -> bool:
-    return layout == "tiles" and tiles_presentation == "circles"
-
-
-# Statistics Grid vs circle-cluster slot limits (see layout_grid_* in preview).
-
-
-def _card_stat_min_slots(
-    layout: LayoutId,
-    fmt: FormatId,
-    *,
-    tiles_presentation: TilesPresentationId = "grid",
-) -> int:
-    if layout == "tiles" and not _tiles_circle_cluster_picker(layout, tiles_presentation):
-        return layout_grid_stat_min(fmt)
-    return 1
-
-
-def _default_card_stat_slot_count(
-    *,
-    circle_cluster: bool,
-    defaults: list[str],
-    max_slots: int,
-    layout: LayoutId,
-    fmt: FormatId,
-    tiles_presentation: TilesPresentationId = "grid",
-) -> int:
-    if circle_cluster:
-        return min(max_slots, TILES_CIRCLE_CLUSTER_DEFAULT)
-    if layout == "tiles" and tiles_presentation == "grid":
-        target = layout_grid_stat_default_count(fmt)
-        return min(max_slots, max(layout_grid_stat_min(fmt), target))
-    return min(max_slots, max(1, len(defaults) if defaults else 1))
-
-
-def _card_stat_max_slots(
-    layout: LayoutId,
-    fmt: FormatId,
-    *,
-    tiles_presentation: TilesPresentationId = "grid",
-    status_metrics: list[tuple[str, str]] | None = None,
-    available_stat_count: int | None = None,
-) -> int:
-    if _tiles_circle_cluster_picker(layout, tiles_presentation):
-        return tiles_circle_cluster_max(fmt)
-    count = available_stat_count
-    if count is None and status_metrics is not None:
-        count = len(status_metrics)
-    return layout_card_stat_max(layout, fmt, available_stat_count=count)
-
-
-def _card_stat_ui_row_count(
-    layout: LayoutId,
-    fmt: FormatId,
-    *,
-    slot_count: int,
-    tiles_presentation: TilesPresentationId = "grid",
-    status_metrics: list[tuple[str, str]] | None = None,
-    available_stat_count: int | None = None,
-) -> int:
-    max_slots = _card_stat_max_slots(
-        layout,
-        fmt,
-        tiles_presentation=tiles_presentation,
-        status_metrics=status_metrics,
-        available_stat_count=available_stat_count,
-    )
-    min_slots = _card_stat_min_slots(layout, fmt, tiles_presentation=tiles_presentation)
-    return min(max(min_slots, slot_count), max_slots)
-
-
-def _effective_card_stat_labels(
-    picks: list[str],
-    layout: LayoutId,
-    fmt: FormatId,
-    *,
-    tiles_presentation: TilesPresentationId = "grid",
-    status_metrics: list[tuple[str, str]] | None = None,
-) -> tuple[str, ...]:
-    max_slots = _card_stat_max_slots(
-        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
-    )
-    return tuple(label for label in picks if label)[:max_slots]
-
-
-def _sanitize_card_stat_picks(
-    picks: list[str],
-    *,
-    available: frozenset[str],
-    max_slots: int,
-) -> list[str]:
-    seen: set[str] = set()
-    out: list[str] = []
-    for raw in picks:
-        label = raw.strip() if isinstance(raw, str) else str(raw).strip()
-        if label and label in available and label not in seen:
-            seen.add(label)
-            out.append(label)
-        if len(out) >= max_slots:
-            break
-    return out
-
-
-def _ensure_card_stat_picks(
-    layout: LayoutId,
-    status_metrics: list[tuple[str, str]],
-    fmt: FormatId,
-    period_kind: PeriodKind,
-    *,
-    data_scope: str,
-    geo_scope: ShareSummaryGeoScope,
-    tiles_presentation: TilesPresentationId = "grid",
-) -> list[str]:
-    """Initialize or sanitize session picks for *layout*; returns UI row values."""
-    circle_cluster = _tiles_circle_cluster_picker(layout, tiles_presentation)
-    max_slots = _card_stat_max_slots(
-        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
-    )
-    storage_max = tiles_circle_cluster_max(fmt) if circle_cluster else layout_card_stat_storage_max(layout)
-    available = frozenset(label for label, _ in status_metrics)
-    picks_key = _card_stat_picks_key(layout, period_kind)
-    count_key = _card_stat_slot_count_key(layout, period_kind)
-    scope_key = _card_stat_scope_key(layout, period_kind)
-    defaults = list(
-        default_card_stat_labels(
-            layout,
-            status_metrics,
-            period_kind=period_kind,
-            geo_scope=geo_scope,
-            fmt=fmt,
-        )
-    )
-
-    if st.session_state.get(scope_key) != data_scope:
-        st.session_state[scope_key] = data_scope
-        st.session_state.pop(picks_key, None)
-        st.session_state.pop(count_key, None)
-        _clear_card_stat_selectbox_keys(layout)
-
-    if picks_key not in st.session_state:
-        st.session_state[picks_key] = defaults
-        st.session_state[count_key] = _default_card_stat_slot_count(
-            circle_cluster=circle_cluster,
-            defaults=defaults,
-            max_slots=max_slots,
-            layout=layout,
-            fmt=fmt,
-            tiles_presentation=tiles_presentation,
-        )
-
-    sanitized = _sanitize_card_stat_picks(
-        list(st.session_state[picks_key]),
-        available=available,
-        max_slots=storage_max,
-    )
-    if not sanitized and defaults:
-        _clear_card_stat_selectbox_keys(layout)
-        st.session_state[picks_key] = defaults
-        st.session_state[count_key] = _default_card_stat_slot_count(
-            circle_cluster=circle_cluster,
-            defaults=defaults,
-            max_slots=max_slots,
-            layout=layout,
-            fmt=fmt,
-            tiles_presentation=tiles_presentation,
-        )
-        sanitized = list(defaults)
-
-    sanitized = _sanitize_card_stat_picks(
-        list(st.session_state[picks_key]),
-        available=available,
-        max_slots=storage_max,
-    )
-    slot_count = int(st.session_state.get(count_key, max(1, len(sanitized))))
-    ui_rows = _card_stat_ui_row_count(
-        layout,
-        fmt,
-        slot_count=slot_count,
-        tiles_presentation=tiles_presentation,
-        status_metrics=status_metrics,
-    )
-
-    raw = list(st.session_state[picks_key])
-    compact = [p for p in raw if p]
-    picks = (compact + [""] * ui_rows)[:ui_rows]
-    st.session_state[count_key] = ui_rows
-
-    st.session_state[picks_key] = picks
-    return picks
-
-
-def _status_metrics_lookup(status_metrics: list[tuple[str, str]]) -> dict[str, str]:
-    return dict(status_metrics)
-
-
-def _stats_on_card(picks: list[str]) -> set[str]:
-    return {label for label in picks if label}
-
-
-def _card_can_accept_stat(
-    layout: LayoutId,
-    fmt: FormatId,
-    picks: list[str],
-    slot_count: int,
-    *,
-    tiles_presentation: TilesPresentationId = "grid",
-    status_metrics: list[tuple[str, str]] | None = None,
-) -> bool:
-    max_slots = _card_stat_max_slots(
-        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
-    )
-    ui_rows = _card_stat_ui_row_count(
-        layout,
-        fmt,
-        slot_count=slot_count,
-        tiles_presentation=tiles_presentation,
-        status_metrics=status_metrics,
-    )
-    active = (picks + [""] * ui_rows)[:ui_rows]
-    if any(not label for label in active):
-        return True
-    return ui_rows < max_slots
-
-
-def _add_stat_to_card(
-    label: str,
-    *,
-    layout: LayoutId,
-    period_kind: PeriodKind,
-    fmt: FormatId,
-    tiles_presentation: TilesPresentationId,
-    available_stat_count: int | None = None,
-) -> None:
-    """Fill the next empty card slot, or append a row when allowed."""
-    picks_key = _card_stat_picks_key(layout, period_kind)
-    count_key = _card_stat_slot_count_key(layout, period_kind)
-    max_slots = _card_stat_max_slots(
-        layout,
-        fmt,
-        tiles_presentation=tiles_presentation,
-        available_stat_count=available_stat_count,
-    )
-    picks = list(st.session_state.get(picks_key, []))
-    slot_count = int(st.session_state.get(count_key, 1))
-    ui_rows = _card_stat_ui_row_count(
-        layout,
-        fmt,
-        slot_count=slot_count,
-        tiles_presentation=tiles_presentation,
-        available_stat_count=available_stat_count,
-    )
-    active = (picks + [""] * ui_rows)[:ui_rows]
-
-    for i in range(ui_rows):
-        if not active[i]:
-            active[i] = label
-            st.session_state[picks_key] = active + picks[ui_rows:]
-            _clear_card_stat_selectbox_keys(layout)
-            return
-
-    if ui_rows < max_slots:
-        active.append(label)
-        st.session_state[count_key] = ui_rows + 1
-        st.session_state[picks_key] = active
-        _clear_card_stat_selectbox_keys(layout)
-
-
-def _add_stat_to_card_on_click(
-    stat_label: str,
-    layout: LayoutId,
-    period_kind: PeriodKind,
-    fmt: FormatId,
-    tiles_presentation: TilesPresentationId,
-    available_stat_count: int,
-) -> None:
-    """Callback — runs before widgets so selectbox keys can be cleared safely."""
-    _add_stat_to_card(
-        stat_label,
-        layout=layout,
-        period_kind=period_kind,
-        fmt=fmt,
-        tiles_presentation=tiles_presentation,
-        available_stat_count=available_stat_count,
-    )
-
-
-_CHIP_STRIP_COLS_PER_ROW = 3
-
-
-def _not_on_card_chip_strip(
-    *,
-    layout: LayoutId,
-    period_kind: PeriodKind,
-    fmt: FormatId,
-    status_metrics: list[tuple[str, str]],
-    picks: list[str],
-    slot_count: int,
-    metrics_lookup: dict[str, str],
-    tiles_presentation: TilesPresentationId = "grid",
-) -> None:
-    """Compact chips for stats not yet on the card; click to add."""
-    on_card = _stats_on_card(picks)
-    not_on_card = [
-        (stat_label, metrics_lookup[stat_label])
-        for stat_label, _ in status_metrics
-        if stat_label not in on_card
-    ]
-    if not not_on_card:
-        st.caption("All available stats are on the card.")
-        return
-
-    can_add = _card_can_accept_stat(
-        layout,
-        fmt,
-        picks,
-        slot_count,
-        tiles_presentation=tiles_presentation,
-        status_metrics=status_metrics,
-    )
-
-    available_stat_count = len(status_metrics)
-    for row_start in range(0, len(not_on_card), _CHIP_STRIP_COLS_PER_ROW):
-        row_items = not_on_card[row_start : row_start + _CHIP_STRIP_COLS_PER_ROW]
-        cols = st.columns(_CHIP_STRIP_COLS_PER_ROW)
-        for col_index in range(_CHIP_STRIP_COLS_PER_ROW):
-            with cols[col_index]:
-                if col_index >= len(row_items):
-                    continue
-                stat_label, value = row_items[col_index]
-                chip_index = row_start + col_index
-                st.button(
-                    f"{stat_label} · {value}",
-                    key=f"design_stat_chip_{layout}_{period_kind}_{chip_index}",
-                    type="tertiary",
-                    use_container_width=False,
-                    disabled=not can_add,
-                    on_click=_add_stat_to_card_on_click,
-                    args=(
-                        stat_label,
-                        layout,
-                        period_kind,
-                        fmt,
-                        tiles_presentation,
-                        available_stat_count,
-                    ),
-                )
-
-
-def _card_stat_picker_ui(
-    layout: LayoutId,
-    status_metrics: list[tuple[str, str]],
-    fmt: FormatId,
-    period_kind: PeriodKind,
-    *,
-    data_scope: str,
-    geo_scope: ShareSummaryGeoScope,
-    tiles_presentation: TilesPresentationId = "grid",
-) -> tuple[str, ...]:
-    """Ordered stat picker for tiles / list; hidden for spotlight."""
-    if layout in ("spotlight", "insight"):
-        return ()
-
-    max_slots = _card_stat_max_slots(
-        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
-    )
-    circle_cluster = _tiles_circle_cluster_picker(layout, tiles_presentation)
-    available_labels = [label for label, _ in status_metrics]
-    metrics_lookup = _status_metrics_lookup(status_metrics)
-    if not available_labels:
-        st.caption("No statistics available for this period.")
-        return ()
-
-    picks_key = _card_stat_picks_key(layout, period_kind)
-    count_key = _card_stat_slot_count_key(layout, period_kind)
-    picks = _ensure_card_stat_picks(
-        layout,
-        status_metrics,
-        fmt,
-        period_kind,
-        data_scope=data_scope,
-        geo_scope=geo_scope,
-        tiles_presentation=tiles_presentation,
-    )
-    ui_rows = _card_stat_ui_row_count(
-        layout,
-        fmt,
-        slot_count=int(st.session_state[count_key]),
-        tiles_presentation=tiles_presentation,
-        status_metrics=status_metrics,
-    )
-
-    if circle_cluster:
-        st.caption(
-            f"Supports up to {max_slots} stats. "
-            f"The default is {TILES_CIRCLE_CLUSTER_DEFAULT} circles."
-        )
-    elif layout == "tiles":
-        min_slots = _card_stat_min_slots(layout, fmt, tiles_presentation=tiles_presentation)
-        st.caption(
-            f"Statistics Grid: {min_slots}–{max_slots} stats "
-            f"({layout_grid_slot_limits_caption()}). "
-            "Use Add stat or the chips below to add more."
-        )
-    else:
-        st.caption(
-            f"Supports up to {max_slots} stats. "
-            "Use Add stat or the chips below to add more."
-        )
-
-    stat_row_cols = [0.5, 6, 1.8, 2.2]
-    min_slots = _card_stat_min_slots(layout, fmt, tiles_presentation=tiles_presentation)
-
-    for i in range(ui_rows):
-        current = picks[i] if i < len(picks) else ""
-        other = {picks[j] for j in range(len(picks)) if j != i and picks[j]}
-        options = [""] + [lab for lab in available_labels if lab not in other]
-        current = _sync_card_stat_selectbox_value(
-            layout, i, options=options, desired=current
-        )
-        picks[i] = current
-        can_up = i > 0
-        can_down = i < ui_rows - 1
-        can_remove = ui_rows > min_slots and (i > 0 or bool(current))
-
-        col_num, col_sel, col_val, col_actions = st.columns(
-            stat_row_cols,
-            vertical_alignment="center",
-        )
-        with col_num:
-            st.markdown(f"**{i + 1}**")
-        with col_sel:
-            choice = st.selectbox(
-                "Stat",
-                options=options,
-                format_func=lambda x: "—" if x == "" else x,
-                key=_card_stat_selectbox_key(layout, i),
-                label_visibility="collapsed",
-            )
-            picks[i] = choice or ""
-        with col_val:
-            value = metrics_lookup.get(picks[i], "") if picks[i] else ""
-            st.markdown(f"**{value}**" if value else "—")
-        with col_actions:
-            btn_up, btn_down, btn_rm = st.columns(3, gap="small")
-            with btn_up:
-                if st.button(
-                    "↑",
-                    key=f"design_card_stat_up_{layout}_{i}",
-                    help="Move up",
-                    disabled=not can_up,
-                    use_container_width=True,
-                ):
-                    picks[i - 1], picks[i] = picks[i], picks[i - 1]
-                    st.session_state[picks_key] = picks[:ui_rows]
-                    _clear_card_stat_selectbox_keys(layout)
-                    st.rerun()
-            with btn_down:
-                if st.button(
-                    "↓",
-                    key=f"design_card_stat_down_{layout}_{i}",
-                    help="Move down",
-                    disabled=not can_down,
-                    use_container_width=True,
-                ):
-                    picks[i + 1], picks[i] = picks[i], picks[i + 1]
-                    st.session_state[picks_key] = picks[:ui_rows]
-                    _clear_card_stat_selectbox_keys(layout)
-                    st.rerun()
-            with btn_rm:
-                if st.button(
-                    "✕",
-                    key=f"design_card_stat_rm_{layout}_{i}",
-                    help="Remove this stat",
-                    disabled=not can_remove,
-                    use_container_width=True,
-                ):
-                    if i == 0 and ui_rows == 1:
-                        picks[0] = ""
-                    elif i == 0:
-                        picks.pop(0)
-                        st.session_state[count_key] = ui_rows - 1
-                    else:
-                        picks.pop(i)
-                        st.session_state[count_key] = ui_rows - 1
-                    st.session_state[picks_key] = picks[:ui_rows]
-                    _clear_card_stat_selectbox_keys(layout)
-                    st.rerun()
-
-    col_num_foot, col_sel_foot, col_val_foot, col_actions_foot = st.columns(
-        stat_row_cols,
-        vertical_alignment="center",
-    )
-    with col_sel_foot:
-        if ui_rows < max_slots and st.button(
-            "Add stat",
-            key=f"design_card_stat_add_{layout}",
-        ):
-            st.session_state[count_key] = ui_rows + 1
-            st.rerun()
-    with col_actions_foot:
-        foot_up, foot_down, foot_rm = st.columns(3, gap="small")
-        with foot_down:
-            if st.button(
-                "Reset",
-                key=f"design_card_stat_reset_{layout}",
-                help="Restore this layout's default stat list",
-                use_container_width=True,
-            ):
-                defaults = list(
-                    default_card_stat_labels(
-                        layout,
-                        status_metrics,
-                        period_kind=period_kind,
-                        geo_scope=geo_scope,
-                        fmt=fmt,
-                    )
-                )
-                _clear_card_stat_selectbox_keys(layout)
-                st.session_state[picks_key] = defaults
-                st.session_state[count_key] = _default_card_stat_slot_count(
-                    circle_cluster=circle_cluster,
-                    defaults=defaults,
-                    max_slots=max_slots,
-                    layout=layout,
-                    fmt=fmt,
-                    tiles_presentation=tiles_presentation,
-                )
-                st.rerun()
-
-    slot_count = int(st.session_state[count_key])
-    can_add_more = _card_can_accept_stat(
-        layout,
-        fmt,
-        picks[:ui_rows],
-        slot_count,
-        tiles_presentation=tiles_presentation,
-        status_metrics=status_metrics,
-    )
-    stats_not_on_card = [
-        label for label in available_labels if label not in _stats_on_card(picks[:ui_rows])
-    ]
-    if stats_not_on_card and not can_add_more:
-        st.info("Card is full.")
-
-    st.session_state[picks_key] = picks[:ui_rows]
-    final = _effective_card_stat_labels(
-        picks,
-        layout,
-        fmt,
-        tiles_presentation=tiles_presentation,
-        status_metrics=status_metrics,
-    )
-    if not final:
-        st.caption("Select at least one stat to show on the card.")
-
-    st.divider()
-    _not_on_card_chip_strip(
-        layout=layout,
-        period_kind=period_kind,
-        fmt=fmt,
-        status_metrics=status_metrics,
-        picks=picks[:ui_rows],
-        slot_count=slot_count,
-        metrics_lookup=metrics_lookup,
-        tiles_presentation=tiles_presentation,
-    )
-    return final
-
-
-def _spotlight_label_from_session(
-    status_metrics: list[tuple[str, str]],
-) -> str:
-    available = {label for label, _ in status_metrics}
-    raw = st.session_state.get(_SPOTLIGHT_LABEL_KEY)
-    if isinstance(raw, str) and raw.strip() in available:
-        return raw.strip()
-    if SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT in available:
-        return SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT
-    if status_metrics:
-        return status_metrics[0][0]
-    return SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT
-
-
-def _select_spotlight_stat(stat_label: str) -> None:
-    """Callback — runs before widgets so the selectbox key can be updated."""
-    st.session_state[_SPOTLIGHT_LABEL_KEY] = stat_label
-
-
-def _spotlight_alternate_chip_strip(
-    status_metrics: list[tuple[str, str]],
-    *,
-    current: str,
-    metrics_lookup: dict[str, str],
-) -> None:
-    """Quick-switch chips for stats not currently spotlighted."""
-    others = [
-        (label, metrics_lookup[label])
-        for label, _ in status_metrics
-        if label != current
-    ]
-    if not others:
-        return
-    count = len(others)
-    st.caption(
-        f"{count} other stat{'s' if count != 1 else ''} available — click to spotlight."
-    )
-    cols_per_row = 3
-    for row_start in range(0, len(others), cols_per_row):
-        row_items = others[row_start : row_start + cols_per_row]
-        cols = st.columns(len(row_items))
-        for col_index, (stat_label, value) in enumerate(row_items):
-            with cols[col_index]:
-                chip_index = row_start + col_index
-                st.button(
-                    f"{stat_label} · {value}",
-                    key=f"design_spotlight_chip_{chip_index}",
-                    use_container_width=True,
-                    help=f"Spotlight {stat_label}",
-                    on_click=_select_spotlight_stat,
-                    args=(stat_label,),
-                )
-
-
-def _spotlight_stat_picker(status_metrics: list[tuple[str, str]]) -> None:
-    labels = [label for label, _ in status_metrics]
-    if not labels:
-        st.caption("No statistics available for this period.")
-        return
-    metrics_lookup = _status_metrics_lookup(status_metrics)
-    current = _spotlight_label_from_session(status_metrics)
-    col_sel, col_val = st.columns([4, 1], vertical_alignment="bottom")
-    with col_sel:
-        st.selectbox(
-            "Spotlight stat",
-            options=labels,
-            index=labels.index(current) if current in labels else 0,
-            key=_SPOTLIGHT_LABEL_KEY,
-            help="Single highlighted stat for the Spotlight layout.",
-        )
-    selected = _spotlight_label_from_session(status_metrics)
-    with col_val:
-        st.markdown(f"**{metrics_lookup.get(selected, '—')}**")
-
-    st.divider()
-    _spotlight_alternate_chip_strip(
-        status_metrics,
-        current=selected,
-        metrics_lookup=metrics_lookup,
-    )
-
-
-def _insight_fact_options(
-    facts: list[ShareSummaryInsightFact],
-    *,
-    species_options: tuple[str, ...] = (),
-) -> list[tuple[InsightFactId, str]]:
-    auto_ids: tuple[InsightFactId, ...] = (
-        "most_common_checklist_species",
-        "most_individuals_species",
-        "biggest_checklist_count",
-    )
-    options: list[tuple[InsightFactId, str]] = []
-    for fact_id in auto_ids:
-        if any(f.fact_id == fact_id for f in facts):
-            options.append((fact_id, INSIGHT_FACT_PICKER_LABELS[fact_id]))
-    if species_options:
-        options.append(("species_individuals", INSIGHT_FACT_PICKER_LABELS["species_individuals"]))
-    return options
-
-
-def _insight_fact_id_from_session(options: list[tuple[InsightFactId, str]]) -> InsightFactId:
-    valid = {fact_id for fact_id, _ in options}
-    raw = st.session_state.get(_INSIGHT_FACT_KEY, SHARE_SUMMARY_INSIGHT_FACT_DEFAULT)
-    if raw in valid:
-        return raw  # type: ignore[return-value]
-    if SHARE_SUMMARY_INSIGHT_FACT_DEFAULT in valid:
-        return SHARE_SUMMARY_INSIGHT_FACT_DEFAULT
-    return options[0][0] if options else SHARE_SUMMARY_INSIGHT_FACT_DEFAULT
-
-
-def _insight_species_from_session(species_options: tuple[str, ...]) -> str:
-    raw = st.session_state.get(_INSIGHT_SPECIES_KEY)
-    if isinstance(raw, str) and raw in species_options:
-        return raw
-    return species_options[0] if species_options else ""
-
-
-def _insight_fact_picker_ui(
-    facts: list[ShareSummaryInsightFact],
-    species_options: tuple[str, ...],
-    *,
-    df: pd.DataFrame,
-    period,
-) -> ShareSummaryInsightFact | None:
-    """Insights fact picker; returns the resolved fact for preview/export."""
-    options = _insight_fact_options(facts, species_options=species_options)
-    if not options:
-        st.caption("No insights available for this period.")
-        return None
-
-    fact_ids = [fact_id for fact_id, _ in options]
-    current_id = _insight_fact_id_from_session(options)
-    st.selectbox(
-        "Insights",
-        options=fact_ids,
-        format_func=lambda fid: INSIGHT_FACT_PICKER_LABELS[fid],
-        index=fact_ids.index(current_id) if current_id in fact_ids else 0,
-        key=_INSIGHT_FACT_KEY,
-        help="Species- and checklist-derived highlights for Interesting Insights cards.",
-    )
-    selected_id = _insight_fact_id_from_session(options)
-
-    species_common = ""
-    if insight_fact_requires_species(selected_id):
-        if not species_options:
-            st.caption("No species in this period for a selected-species fact.")
-            return None
-        species_common = _insight_species_from_session(species_options)
-        st.selectbox(
-            "Species",
-            options=list(species_options),
-            index=list(species_options).index(species_common) if species_common else 0,
-            key=_INSIGHT_SPECIES_KEY,
-        )
-        species_common = _insight_species_from_session(species_options)
-        refreshed = compute_insight_facts(
-            df,
-            period,
-            species_common=species_common,
-        )
-        return resolve_insight_fact(refreshed, selected_id)
-
-    return resolve_insight_fact(facts, selected_id)
-
-
-def _preview_scale_caption(fmt: FormatId, scale: float) -> str | None:
-    """Hint when preview is at or near export pixel size."""
-    if scale < _PREVIEW_SCALE_FULL - 0.005:
-        return None
-    width, height = FORMAT_PIXELS[fmt]
-    return (
-        f"Export size ({width}×{height}px). "
-        "Scroll the page to see the full card — story format is tall."
-        if height > width
-        else f"Export size ({width}×{height}px) — matches the PNG export."
-    )
-
-
-def _sidebar_preview_scale_controls(fmt: FormatId) -> float:
-    """Preview scale slider from compact default up to export pixel size."""
-    scale = st.slider(
-        "Preview scale",
-        min_value=_PREVIEW_SCALE_DEFAULT,
-        max_value=_PREVIEW_SCALE_FULL,
-        value=_PREVIEW_SCALE_DEFAULT,
-        step=0.01,
-        help="Drag right for full export size (100%). Default 0.42 is a compact preview.",
-        key="design_preview_scale",
-    )
-    caption = _preview_scale_caption(fmt, scale)
-    if caption:
-        st.caption(caption)
-    return scale
-
-
-def _centered_card_download_button(
-    *,
-    label: str,
-    data: bytes,
-    file_name: str,
-    mime: str,
-    help_text: str,
-) -> None:
-    """Download control centred under the scaled card preview."""
-    _, btn_col, _ = st.columns([1, 1, 1])
-    with btn_col:
-        st.download_button(
-            label,
-            data=data,
-            file_name=file_name,
-            mime=mime,
-            use_container_width=True,
-            help=help_text,
-        )
-
-
-@st.fragment
-def _current_card_fragment(
-    *,
-    stats: ShareSummaryStats,
-    all_time: ShareSummaryAllTimeStats | None,
-    selected_layout: LayoutId,
-    fmt: FormatId,
-    scale: float,
-    status_metrics: list[tuple[str, str]],
-    color_scheme_index: int,
-    card_stat_data_scope: str,
-    scope_label: str,
-    geo_scope: ShareSummaryGeoScope,
-    tiles_presentation: TilesPresentationId = "grid",
-    spotlight_presentation: SpotlightPresentationId = "classic",
-    insight_facts: list[ShareSummaryInsightFact],
-    insight_species_options: tuple[str, ...],
-    df_scoped: pd.DataFrame,
-    resolved_period,
-) -> None:
-    """Card statistics controls, live preview, and PNG export."""
-    card_stat_labels: tuple[str, ...] = ()
-    resolved_fact: ShareSummaryInsightFact | None = None
-    with st.expander(_STATISTICS_LABEL, expanded=False):
-        if selected_layout == "spotlight":
-            _spotlight_stat_picker(status_metrics)
-        elif selected_layout == "insight":
-            resolved_fact = _insight_fact_picker_ui(
-                insight_facts,
-                insight_species_options,
-                df=df_scoped,
-                period=resolved_period,
-            )
-        else:
-            card_stat_labels = _card_stat_picker_ui(
-                selected_layout,
-                status_metrics,
-                fmt,
-                stats.period_kind,
-                data_scope=card_stat_data_scope,
-                geo_scope=geo_scope,
-                tiles_presentation=tiles_presentation,
-            )
-
-    spotlight_label = _spotlight_label_from_session(status_metrics)
-
-    st.subheader(_CURRENT_CARD_LABEL)
-    st.markdown(
-        render_share_summary_preview_html(
-            stats,
-            layout=selected_layout,
-            fmt=fmt,
-            tiles_presentation=tiles_presentation,
-            spotlight_presentation=spotlight_presentation,
-            scale=scale,
-            spotlight_label=spotlight_label,
-            insight_fact=resolved_fact,
-            card_stat_labels=card_stat_labels,
-            all_time=all_time,
-            color_scheme_index=color_scheme_index,
-            geo_scope=geo_scope,
-            scope_label=scope_label,
-        ),
-        unsafe_allow_html=True,
-    )
-
-    png_filename = share_summary_png_filename(stats, layout=selected_layout, fmt=fmt)
-    try:
-        png_bytes = _cached_share_summary_png(
-            stats,
-            selected_layout,
-            fmt,
-            card_stat_labels,
-            spotlight_label,
-            all_time,
-            color_scheme_index,
-            share_summary_color_scheme_fingerprint(color_scheme_index),
-            scope_label,
-            geo_scope,
-            tiles_presentation,
-            spotlight_presentation,
-            resolved_fact,
-        )
-    except RuntimeError as exc:
-        st.warning(str(exc))
-    else:
-        _centered_card_download_button(
-            label="Export card",
-            data=png_bytes,
-            file_name=png_filename,
-            mime="image/png",
-            help_text="PNG of the current card above.",
-        )
-
-
 st.set_page_config(page_title=_DESIGN_STUDIO_TITLE, layout="wide")
 st.title(_DESIGN_STUDIO_TITLE)
 st.caption(
     "Exploratory tool only. Compare HTML mockups before choosing layouts for the main app."
 )
 
+keys = DESIGN_SOCIAL_CARDS_KEYS
 df: pd.DataFrame | None = None
 geo_scope = ShareSummaryGeoScope()
 
@@ -1325,49 +260,13 @@ with st.sidebar:
         )
 
     if df is not None and not df.empty:
-        geo_scope = _sidebar_geo_scope_controls(df)
+        geo_scope = render_sidebar_geo_scope_controls(df, keys)
     elif not use_sample and uploaded is None:
         st.caption("Upload a CSV to choose country and region.")
     elif df is not None and df.empty:
         st.caption("No data in file.")
 
-    st.header(_CURRENT_CARD_LABEL)
-    selected_layout: LayoutId = st.selectbox(
-        "Layout",
-        options=["tiles", "minimal", "spotlight", "insight"],
-        format_func=share_summary_layout_label,
-    )
-    tiles_presentation: TilesPresentationId = "grid"
-    if selected_layout == "tiles":
-        tiles_presentation = st.radio(
-            "Tiles presentation",
-            options=["grid", "circles"],
-            format_func=share_summary_tiles_presentation_label,
-            key=_TILES_PRESENTATION_KEY,
-            horizontal=True,
-        )
-    spotlight_presentation: SpotlightPresentationId = "classic"
-    if selected_layout == "spotlight":
-        spotlight_presentation = st.radio(
-            "Spotlight presentation",
-            options=["classic", "circle"],
-            format_func=share_summary_spotlight_presentation_label,
-            key=_SPOTLIGHT_PRESENTATION_KEY,
-            horizontal=True,
-        )
-    fmt: FormatId = st.selectbox(
-        "Aspect ratio",
-        options=["square", "portrait_post", "story"],
-        format_func=lambda x: FORMAT_LABELS[x],
-    )
-    color_theme_id = st.selectbox(
-        "Theme",
-        options=list(SHARE_SUMMARY_COLOR_SCHEME_IDS),
-        format_func=share_summary_color_scheme_label,
-        key=_COLOR_THEME_KEY,
-    )
-    color_scheme_index = share_summary_color_scheme_index(color_theme_id)
-    scale = _sidebar_preview_scale_controls(fmt)
+    sidebar_selection = render_sidebar_card_controls(keys)
 
 resolved_period = None
 stats: ShareSummaryStats = sample_share_summary_stats()
@@ -1472,31 +371,31 @@ if df is not None:
     )
 
 upload_name = uploaded.name if uploaded is not None else None
-card_stat_data_scope = _card_stat_data_scope(
+card_stat_data_scope = card_stat_data_scope_from_design_source(
     use_sample=use_sample,
     period_kind=stats.period_kind,
     period_label=stats.period_label,
     upload_name=upload_name,
     geo_scope=geo_scope,
-    fmt=fmt,
-    tiles_presentation=tiles_presentation,
+    fmt=sidebar_selection.fmt,
+    tiles_presentation=sidebar_selection.tiles_presentation,
 )
 scope_label = geo_scope_display_label(geo_scope)
 
 status_metrics = summary_status_metrics(stats, all_time=all_time, geo_scope=geo_scope)
 
-if _SPOTLIGHT_LABEL_KEY not in st.session_state:
-    st.session_state[_SPOTLIGHT_LABEL_KEY] = SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT
-if _INSIGHT_FACT_KEY not in st.session_state:
-    st.session_state[_INSIGHT_FACT_KEY] = SHARE_SUMMARY_INSIGHT_FACT_DEFAULT
+if keys.spotlight_label not in st.session_state:
+    st.session_state[keys.spotlight_label] = SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT
+if keys.insight_fact not in st.session_state:
+    st.session_state[keys.insight_fact] = SHARE_SUMMARY_INSIGHT_FACT_DEFAULT
 
 insight_facts: list[ShareSummaryInsightFact] = []
 insight_species_options: tuple[str, ...] = ()
 if df is not None and resolved_period is not None:
     insight_facts = compute_insight_facts(df_scoped, resolved_period)
     insight_species_options = species_common_names_in_period(df_scoped, resolved_period)
-    if insight_species_options and _INSIGHT_SPECIES_KEY not in st.session_state:
-        st.session_state[_INSIGHT_SPECIES_KEY] = insight_species_options[0]
+    if insight_species_options and keys.insight_species not in st.session_state:
+        st.session_state[keys.insight_species] = insight_species_options[0]
 
 tab_social_cards, tab_hex_experiments, tab_circle_layout = st.tabs(
     [
@@ -1512,7 +411,7 @@ hex_card_stat_labels = default_card_stat_labels(
     period_kind=stats.period_kind,
     geo_scope=geo_scope,
 )
-if fmt == "story" and len(hex_card_stat_labels) < SHARE_SUMMARY_STORY_MAX_STATS:
+if sidebar_selection.fmt == "story" and len(hex_card_stat_labels) < SHARE_SUMMARY_STORY_MAX_STATS:
     picked = set(hex_card_stat_labels)
     extra: list[str] = []
     for label, _ in status_metrics:
@@ -1522,35 +421,35 @@ if fmt == "story" and len(hex_card_stat_labels) < SHARE_SUMMARY_STORY_MAX_STATS:
         if len(hex_card_stat_labels) + len(extra) >= SHARE_SUMMARY_STORY_MAX_STATS:
             break
     hex_card_stat_labels = hex_card_stat_labels + tuple(extra)
-hex_preview_scale = min(scale, 0.32)
+hex_preview_scale = min(sidebar_selection.scale, 0.32)
 
 with tab_social_cards:
-    if not use_sample and not _period_has_checklist_data(stats):
+    if not use_sample and not period_has_checklist_data(stats):
         st.warning(
             f"No checklists in **{stats.period_label}** in this export. "
             "Try **Previous month** (or another range) in the sidebar, or pick a period that includes your data."
         )
 
-    _current_card_fragment(
+    render_current_card_fragment(
         stats=stats,
         all_time=all_time,
-        selected_layout=selected_layout,
-        fmt=fmt,
-        scale=scale,
+        selected_layout=sidebar_selection.layout,
+        fmt=sidebar_selection.fmt,
+        scale=sidebar_selection.scale,
         status_metrics=status_metrics,
-        color_scheme_index=color_scheme_index,
+        color_scheme_index=sidebar_selection.color_scheme_index,
         card_stat_data_scope=card_stat_data_scope,
         scope_label=scope_label,
         geo_scope=geo_scope,
-        tiles_presentation=tiles_presentation,
-        spotlight_presentation=spotlight_presentation,
+        keys=keys,
+        tiles_presentation=sidebar_selection.tiles_presentation,
+        spotlight_presentation=sidebar_selection.spotlight_presentation,
         insight_facts=insight_facts,
         insight_species_options=insight_species_options,
         df_scoped=df_scoped,
         resolved_period=resolved_period,
+        current_card_label=SOCIAL_CARDS_CURRENT_CARD_LABEL,
     )
-
-_DESIGN_HEX_SELECTED_KEY = "design_hex_selected_variant"
 
 with tab_circle_layout:
     st.caption(
@@ -1589,11 +488,11 @@ with tab_hex_experiments:
                 render_hex_grid_preview_html(
                     stats,
                     variant=variant,
-                    fmt=fmt,
+                    fmt=sidebar_selection.fmt,
                     scale=hex_preview_scale,
                     card_stat_labels=hex_card_stat_labels,
                     all_time=all_time,
-                    color_scheme_index=color_scheme_index,
+                    color_scheme_index=sidebar_selection.color_scheme_index,
                     geo_scope=geo_scope,
                     scope_label=scope_label,
                 ),
@@ -1604,17 +503,17 @@ with tab_hex_experiments:
     st.subheader("Selected preview (larger)")
     st.caption(
         f"{HEX_VARIANT_LABELS[selected_hex]} — use **Preview scale** in the sidebar "
-        f"(currently {scale:.0%} of export size)."
+        f"(currently {sidebar_selection.scale:.0%} of export size)."
     )
     st.markdown(
         render_hex_grid_preview_html(
             stats,
             variant=selected_hex,
-            fmt=fmt,
-            scale=scale,
+            fmt=sidebar_selection.fmt,
+            scale=sidebar_selection.scale,
             card_stat_labels=hex_card_stat_labels,
             all_time=all_time,
-            color_scheme_index=color_scheme_index,
+            color_scheme_index=sidebar_selection.color_scheme_index,
             geo_scope=geo_scope,
             scope_label=scope_label,
         ),

--- a/explorer/app/streamlit/social_cards_session_keys.py
+++ b/explorer/app/streamlit/social_cards_session_keys.py
@@ -1,0 +1,87 @@
+"""Session-state key namespaces for Social Cards Streamlit widgets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from explorer.core.share_summary_compute import PeriodKind
+from explorer.presentation.share_summary_preview import LayoutId
+
+
+@dataclass(frozen=True)
+class SocialCardsSessionKeys:
+    """Widget keys for one Social Cards surface (design studio vs main app tab)."""
+
+    prefix: str
+
+    @property
+    def tiles_presentation(self) -> str:
+        return f"{self.prefix}_tiles_presentation"
+
+    @property
+    def spotlight_presentation(self) -> str:
+        return f"{self.prefix}_spotlight_presentation"
+
+    @property
+    def insight_fact(self) -> str:
+        return f"{self.prefix}_insight_fact"
+
+    @property
+    def insight_species(self) -> str:
+        return f"{self.prefix}_insight_species"
+
+    @property
+    def color_theme(self) -> str:
+        return f"{self.prefix}_color_theme"
+
+    @property
+    def spotlight_label(self) -> str:
+        return f"{self.prefix}_spotlight_label"
+
+    @property
+    def geo_country(self) -> str:
+        return f"{self.prefix}_geo_country"
+
+    @property
+    def geo_region(self) -> str:
+        return f"{self.prefix}_geo_region"
+
+    @property
+    def preview_scale(self) -> str:
+        return f"{self.prefix}_preview_scale"
+
+    def card_stat_picks(self, layout: LayoutId, period_kind: PeriodKind) -> str:
+        return f"{self.prefix}_card_stat_picks_{layout}_{period_kind}"
+
+    def card_stat_slot_count(self, layout: LayoutId, period_kind: PeriodKind) -> str:
+        return f"{self.prefix}_card_stat_slot_count_{layout}_{period_kind}"
+
+    def card_stat_scope(self, layout: LayoutId, period_kind: PeriodKind) -> str:
+        return f"{self.prefix}_card_stat_scope_{layout}_{period_kind}"
+
+    def card_stat_selectbox(self, layout: LayoutId, index: int) -> str:
+        return f"{self.prefix}_card_stat_sel_{layout}_{index}"
+
+    def stat_chip(self, layout: LayoutId, period_kind: PeriodKind, chip_index: int) -> str:
+        return f"{self.prefix}_stat_chip_{layout}_{period_kind}_{chip_index}"
+
+    def card_stat_up(self, layout: LayoutId, index: int) -> str:
+        return f"{self.prefix}_card_stat_up_{layout}_{index}"
+
+    def card_stat_down(self, layout: LayoutId, index: int) -> str:
+        return f"{self.prefix}_card_stat_down_{layout}_{index}"
+
+    def card_stat_rm(self, layout: LayoutId, index: int) -> str:
+        return f"{self.prefix}_card_stat_rm_{layout}_{index}"
+
+    def card_stat_add(self, layout: LayoutId) -> str:
+        return f"{self.prefix}_card_stat_add_{layout}"
+
+    def card_stat_reset(self, layout: LayoutId) -> str:
+        return f"{self.prefix}_card_stat_reset_{layout}"
+
+    def spotlight_chip(self, chip_index: int) -> str:
+        return f"{self.prefix}_spotlight_chip_{chip_index}"
+
+
+DESIGN_SOCIAL_CARDS_KEYS = SocialCardsSessionKeys(prefix="design")

--- a/explorer/app/streamlit/social_cards_session_keys.py
+++ b/explorer/app/streamlit/social_cards_session_keys.py
@@ -62,7 +62,9 @@ class SocialCardsSessionKeys:
     def card_stat_selectbox(self, layout: LayoutId, index: int) -> str:
         return f"{self.prefix}_card_stat_sel_{layout}_{index}"
 
-    def stat_chip(self, layout: LayoutId, period_kind: PeriodKind, chip_index: int) -> str:
+    def stat_chip(
+        self, layout: LayoutId, period_kind: PeriodKind, chip_index: int
+    ) -> str:
         return f"{self.prefix}_stat_chip_{layout}_{period_kind}_{chip_index}"
 
     def card_stat_up(self, layout: LayoutId, index: int) -> str:

--- a/explorer/app/streamlit/social_cards_sidebar_ui.py
+++ b/explorer/app/streamlit/social_cards_sidebar_ui.py
@@ -1,0 +1,177 @@
+"""Social Cards sidebar controls — shared by design studio and main app."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+import streamlit as st
+
+from explorer.app.streamlit.social_cards_session_keys import SocialCardsSessionKeys
+from explorer.core.region_display import map_focus_key_for_display
+from explorer.core.share_summary_compute import (
+    ShareSummaryGeoScope,
+    geo_country_keys_from_df,
+    geo_region_options_for_country,
+)
+from explorer.core.share_summary_defaults import (
+    SHARE_SUMMARY_COLOR_SCHEME_IDS,
+    share_summary_color_scheme_index,
+    share_summary_color_scheme_label,
+    share_summary_layout_label,
+    share_summary_spotlight_presentation_label,
+    share_summary_tiles_presentation_label,
+)
+from explorer.presentation.share_summary_preview import (
+    FORMAT_LABELS,
+    FORMAT_PIXELS,
+    FormatId,
+    LayoutId,
+    SpotlightPresentationId,
+    TilesPresentationId,
+)
+
+_GEO_WORLD_OPTION = ""
+_PREVIEW_SCALE_DEFAULT = 0.42
+_PREVIEW_SCALE_FULL = 1.0
+SOCIAL_CARDS_CURRENT_CARD_SIDEBAR_HEADER = "Current card"
+
+
+@dataclass(frozen=True)
+class SocialCardsSidebarSelection:
+    """Card layout and presentation choices from the Social Cards sidebar block."""
+
+    layout: LayoutId
+    fmt: FormatId
+    color_scheme_index: int
+    tiles_presentation: TilesPresentationId
+    spotlight_presentation: SpotlightPresentationId
+    scale: float
+
+
+def _geo_country_select_label(country_key: str) -> str:
+    if not country_key:
+        return "World"
+    return map_focus_key_for_display(country_key)
+
+
+def render_sidebar_geo_scope_controls(
+    df: pd.DataFrame,
+    keys: SocialCardsSessionKeys,
+) -> ShareSummaryGeoScope:
+    """Country and region pickers; World is the default (no filter)."""
+    country_keys = geo_country_keys_from_df(df)
+    country_options = [_GEO_WORLD_OPTION, *country_keys]
+    country_key = st.selectbox(
+        "Country",
+        options=country_options,
+        format_func=_geo_country_select_label,
+        key=keys.geo_country,
+    )
+    if not country_key:
+        st.session_state.pop(keys.geo_region, None)
+        return ShareSummaryGeoScope()
+
+    region_pairs = geo_region_options_for_country(df, country_key)
+    region_options = [_GEO_WORLD_OPTION, *[code for code, _ in region_pairs]]
+    region_labels = {_GEO_WORLD_OPTION: "All regions"}
+    region_labels.update({code: label for code, label in region_pairs})
+    current_region = st.session_state.get(keys.geo_region, _GEO_WORLD_OPTION)
+    if current_region not in region_options:
+        st.session_state[keys.geo_region] = _GEO_WORLD_OPTION
+    region_code = st.selectbox(
+        "Region",
+        options=region_options,
+        format_func=lambda code: region_labels[code],
+        key=keys.geo_region,
+    )
+    return ShareSummaryGeoScope(
+        country_key=country_key,
+        region_code=region_code or None,
+    )
+
+
+def preview_scale_caption(fmt: FormatId, scale: float) -> str | None:
+    """Hint when preview is at or near export pixel size."""
+    if scale < _PREVIEW_SCALE_FULL - 0.005:
+        return None
+    width, height = FORMAT_PIXELS[fmt]
+    return (
+        f"Export size ({width}×{height}px). "
+        "Scroll the page to see the full card — story format is tall."
+        if height > width
+        else f"Export size ({width}×{height}px) — matches the PNG export."
+    )
+
+
+def render_sidebar_preview_scale_controls(
+    fmt: FormatId,
+    keys: SocialCardsSessionKeys,
+) -> float:
+    """Preview scale slider from compact default up to export pixel size."""
+    scale = st.slider(
+        "Preview scale",
+        min_value=_PREVIEW_SCALE_DEFAULT,
+        max_value=_PREVIEW_SCALE_FULL,
+        value=_PREVIEW_SCALE_DEFAULT,
+        step=0.01,
+        help="Drag right for full export size (100%). Default 0.42 is a compact preview.",
+        key=keys.preview_scale,
+    )
+    caption = preview_scale_caption(fmt, scale)
+    if caption:
+        st.caption(caption)
+    return scale
+
+
+def render_sidebar_card_controls(
+    keys: SocialCardsSessionKeys,
+    *,
+    section_header: str = SOCIAL_CARDS_CURRENT_CARD_SIDEBAR_HEADER,
+) -> SocialCardsSidebarSelection:
+    """Layout, format, theme, and preview-scale controls for the current card."""
+    st.header(section_header)
+    selected_layout: LayoutId = st.selectbox(
+        "Layout",
+        options=["tiles", "minimal", "spotlight", "insight"],
+        format_func=share_summary_layout_label,
+    )
+    tiles_presentation: TilesPresentationId = "grid"
+    if selected_layout == "tiles":
+        tiles_presentation = st.radio(
+            "Tiles presentation",
+            options=["grid", "circles"],
+            format_func=share_summary_tiles_presentation_label,
+            key=keys.tiles_presentation,
+            horizontal=True,
+        )
+    spotlight_presentation: SpotlightPresentationId = "classic"
+    if selected_layout == "spotlight":
+        spotlight_presentation = st.radio(
+            "Spotlight presentation",
+            options=["classic", "circle"],
+            format_func=share_summary_spotlight_presentation_label,
+            key=keys.spotlight_presentation,
+            horizontal=True,
+        )
+    fmt: FormatId = st.selectbox(
+        "Aspect ratio",
+        options=["square", "portrait_post", "story"],
+        format_func=lambda x: FORMAT_LABELS[x],
+    )
+    color_theme_id = st.selectbox(
+        "Theme",
+        options=list(SHARE_SUMMARY_COLOR_SCHEME_IDS),
+        format_func=share_summary_color_scheme_label,
+        key=keys.color_theme,
+    )
+    color_scheme_index = share_summary_color_scheme_index(color_theme_id)
+    scale = render_sidebar_preview_scale_controls(fmt, keys)
+    return SocialCardsSidebarSelection(
+        layout=selected_layout,
+        fmt=fmt,
+        color_scheme_index=color_scheme_index,
+        tiles_presentation=tiles_presentation,
+        spotlight_presentation=spotlight_presentation,
+        scale=scale,
+    )

--- a/explorer/app/streamlit/social_cards_streamlit_helpers.py
+++ b/explorer/app/streamlit/social_cards_streamlit_helpers.py
@@ -62,7 +62,10 @@ def period_has_checklist_data(stats: ShareSummaryStats) -> bool:
     return stats.checklists is not None and stats.checklists > 0
 
 
-def tiles_circle_cluster_picker(layout: LayoutId, tiles_presentation: TilesPresentationId) -> bool:
+def tiles_circle_cluster_picker(
+    layout: LayoutId, tiles_presentation: TilesPresentationId
+) -> bool:
+    """True when the tiles layout uses circle-cluster presentation."""
     return layout == "tiles" and tiles_presentation == "circles"
 
 
@@ -72,7 +75,9 @@ def card_stat_min_slots(
     *,
     tiles_presentation: TilesPresentationId = "grid",
 ) -> int:
-    if layout == "tiles" and not tiles_circle_cluster_picker(layout, tiles_presentation):
+    if layout == "tiles" and not tiles_circle_cluster_picker(
+        layout, tiles_presentation
+    ):
         return layout_grid_stat_min(fmt)
     return 1
 
@@ -139,7 +144,10 @@ def effective_card_stat_labels(
     status_metrics: list[tuple[str, str]] | None = None,
 ) -> tuple[str, ...]:
     max_slots = card_stat_max_slots(
-        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
+        layout,
+        fmt,
+        tiles_presentation=tiles_presentation,
+        status_metrics=status_metrics,
     )
     return tuple(label for label in picks if label)[:max_slots]
 
@@ -170,7 +178,11 @@ def resolve_card_stat_selectbox_value(
 ) -> str:
     """Pick a valid selectbox value, preferring the widget over stale session picks."""
     if session_value is not None:
-        value = session_value.strip() if isinstance(session_value, str) else str(session_value).strip()
+        value = (
+            session_value.strip()
+            if isinstance(session_value, str)
+            else str(session_value).strip()
+        )
         if value in options:
             return value
     fallback = desired.strip() if isinstance(desired, str) else str(desired).strip()
@@ -182,6 +194,7 @@ def status_metrics_lookup(status_metrics: list[tuple[str, str]]) -> dict[str, st
 
 
 def stats_on_card(picks: list[str]) -> set[str]:
+    """Non-empty stat labels currently assigned to card slots."""
     return {label for label in picks if label}
 
 
@@ -195,7 +208,10 @@ def card_can_accept_stat(
     status_metrics: list[tuple[str, str]] | None = None,
 ) -> bool:
     max_slots = card_stat_max_slots(
-        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
+        layout,
+        fmt,
+        tiles_presentation=tiles_presentation,
+        status_metrics=status_metrics,
     )
     ui_rows = card_stat_ui_row_count(
         layout,

--- a/explorer/app/streamlit/social_cards_streamlit_helpers.py
+++ b/explorer/app/streamlit/social_cards_streamlit_helpers.py
@@ -1,0 +1,210 @@
+"""Pure helpers for Social Cards Streamlit UI (no widget calls)."""
+
+from __future__ import annotations
+
+from explorer.core.share_summary_compute import (
+    PeriodKind,
+    ShareSummaryGeoScope,
+    ShareSummaryStats,
+)
+from explorer.presentation.share_summary_circles_preview import (
+    TILES_CIRCLE_CLUSTER_DEFAULT,
+    tiles_circle_cluster_max,
+)
+from explorer.presentation.share_summary_preview import (
+    FormatId,
+    LayoutId,
+    TilesPresentationId,
+    layout_card_stat_max,
+    layout_grid_stat_default_count,
+    layout_grid_stat_min,
+)
+
+
+def card_stat_data_scope(
+    *,
+    data_source: str,
+    period_kind: PeriodKind,
+    period_label: str,
+    geo_scope: ShareSummaryGeoScope | None = None,
+    fmt: FormatId = "square",
+    tiles_presentation: TilesPresentationId = "grid",
+) -> str:
+    """Session scope token — when this changes, card-stat picks re-initialize."""
+    geo_token = (geo_scope or ShareSummaryGeoScope()).scope_token()
+    return f"{data_source}|{period_kind}|{period_label}|{geo_token}|{fmt}|{tiles_presentation}"
+
+
+def card_stat_data_scope_from_design_source(
+    *,
+    use_sample: bool,
+    period_kind: PeriodKind,
+    period_label: str,
+    upload_name: str | None,
+    geo_scope: ShareSummaryGeoScope | None = None,
+    fmt: FormatId = "square",
+    tiles_presentation: TilesPresentationId = "grid",
+) -> str:
+    """Design-studio wrapper — maps sample/CSV toggle to a data-source token."""
+    source = "sample" if use_sample else (upload_name or "csv")
+    return card_stat_data_scope(
+        data_source=source,
+        period_kind=period_kind,
+        period_label=period_label,
+        geo_scope=geo_scope,
+        fmt=fmt,
+        tiles_presentation=tiles_presentation,
+    )
+
+
+def period_has_checklist_data(stats: ShareSummaryStats) -> bool:
+    """False when the selected period has no checklists in the loaded export."""
+    return stats.checklists is not None and stats.checklists > 0
+
+
+def tiles_circle_cluster_picker(layout: LayoutId, tiles_presentation: TilesPresentationId) -> bool:
+    return layout == "tiles" and tiles_presentation == "circles"
+
+
+def card_stat_min_slots(
+    layout: LayoutId,
+    fmt: FormatId,
+    *,
+    tiles_presentation: TilesPresentationId = "grid",
+) -> int:
+    if layout == "tiles" and not tiles_circle_cluster_picker(layout, tiles_presentation):
+        return layout_grid_stat_min(fmt)
+    return 1
+
+
+def default_card_stat_slot_count(
+    *,
+    circle_cluster: bool,
+    defaults: list[str],
+    max_slots: int,
+    layout: LayoutId,
+    fmt: FormatId,
+    tiles_presentation: TilesPresentationId = "grid",
+) -> int:
+    if circle_cluster:
+        return min(max_slots, TILES_CIRCLE_CLUSTER_DEFAULT)
+    if layout == "tiles" and tiles_presentation == "grid":
+        target = layout_grid_stat_default_count(fmt)
+        return min(max_slots, max(layout_grid_stat_min(fmt), target))
+    return min(max_slots, max(1, len(defaults) if defaults else 1))
+
+
+def card_stat_max_slots(
+    layout: LayoutId,
+    fmt: FormatId,
+    *,
+    tiles_presentation: TilesPresentationId = "grid",
+    status_metrics: list[tuple[str, str]] | None = None,
+    available_stat_count: int | None = None,
+) -> int:
+    if tiles_circle_cluster_picker(layout, tiles_presentation):
+        return tiles_circle_cluster_max(fmt)
+    count = available_stat_count
+    if count is None and status_metrics is not None:
+        count = len(status_metrics)
+    return layout_card_stat_max(layout, fmt, available_stat_count=count)
+
+
+def card_stat_ui_row_count(
+    layout: LayoutId,
+    fmt: FormatId,
+    *,
+    slot_count: int,
+    tiles_presentation: TilesPresentationId = "grid",
+    status_metrics: list[tuple[str, str]] | None = None,
+    available_stat_count: int | None = None,
+) -> int:
+    max_slots = card_stat_max_slots(
+        layout,
+        fmt,
+        tiles_presentation=tiles_presentation,
+        status_metrics=status_metrics,
+        available_stat_count=available_stat_count,
+    )
+    min_slots = card_stat_min_slots(layout, fmt, tiles_presentation=tiles_presentation)
+    return min(max(min_slots, slot_count), max_slots)
+
+
+def effective_card_stat_labels(
+    picks: list[str],
+    layout: LayoutId,
+    fmt: FormatId,
+    *,
+    tiles_presentation: TilesPresentationId = "grid",
+    status_metrics: list[tuple[str, str]] | None = None,
+) -> tuple[str, ...]:
+    max_slots = card_stat_max_slots(
+        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
+    )
+    return tuple(label for label in picks if label)[:max_slots]
+
+
+def sanitize_card_stat_picks(
+    picks: list[str],
+    *,
+    available: frozenset[str],
+    max_slots: int,
+) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in picks:
+        label = raw.strip() if isinstance(raw, str) else str(raw).strip()
+        if label and label in available and label not in seen:
+            seen.add(label)
+            out.append(label)
+        if len(out) >= max_slots:
+            break
+    return out
+
+
+def resolve_card_stat_selectbox_value(
+    *,
+    session_value: object,
+    desired: str,
+    options: list[str],
+) -> str:
+    """Pick a valid selectbox value, preferring the widget over stale session picks."""
+    if session_value is not None:
+        value = session_value.strip() if isinstance(session_value, str) else str(session_value).strip()
+        if value in options:
+            return value
+    fallback = desired.strip() if isinstance(desired, str) else str(desired).strip()
+    return fallback if fallback in options else ""
+
+
+def status_metrics_lookup(status_metrics: list[tuple[str, str]]) -> dict[str, str]:
+    return dict(status_metrics)
+
+
+def stats_on_card(picks: list[str]) -> set[str]:
+    return {label for label in picks if label}
+
+
+def card_can_accept_stat(
+    layout: LayoutId,
+    fmt: FormatId,
+    picks: list[str],
+    slot_count: int,
+    *,
+    tiles_presentation: TilesPresentationId = "grid",
+    status_metrics: list[tuple[str, str]] | None = None,
+) -> bool:
+    max_slots = card_stat_max_slots(
+        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
+    )
+    ui_rows = card_stat_ui_row_count(
+        layout,
+        fmt,
+        slot_count=slot_count,
+        tiles_presentation=tiles_presentation,
+        status_metrics=status_metrics,
+    )
+    active = (picks + [""] * ui_rows)[:ui_rows]
+    if any(not label for label in active):
+        return True
+    return ui_rows < max_slots

--- a/explorer/app/streamlit/social_cards_streamlit_ui.py
+++ b/explorer/app/streamlit/social_cards_streamlit_ui.py
@@ -1,0 +1,863 @@
+"""Social Cards main-column UI — stat pickers, preview fragment, PNG export."""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from explorer.app.streamlit.social_cards_session_keys import SocialCardsSessionKeys
+from explorer.app.streamlit.social_cards_streamlit_helpers import (
+    card_can_accept_stat,
+    card_stat_max_slots,
+    card_stat_min_slots,
+    card_stat_ui_row_count,
+    default_card_stat_slot_count,
+    effective_card_stat_labels,
+    resolve_card_stat_selectbox_value,
+    sanitize_card_stat_picks,
+    stats_on_card,
+    status_metrics_lookup,
+    tiles_circle_cluster_picker,
+)
+from explorer.core.share_summary_compute import (
+    PeriodKind,
+    ShareSummaryAllTimeStats,
+    ShareSummaryGeoScope,
+    ShareSummaryStats,
+)
+from explorer.core.share_summary_defaults import (
+    SHARE_SUMMARY_INSIGHT_FACT_DEFAULT,
+    SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT,
+    share_summary_color_scheme_fingerprint,
+)
+from explorer.core.share_summary_insight_facts import (
+    INSIGHT_FACT_PICKER_LABELS,
+    InsightFactId,
+    ShareSummaryInsightFact,
+    compute_insight_facts,
+    insight_fact_requires_species,
+)
+from explorer.presentation.share_summary_circles_preview import (
+    TILES_CIRCLE_CLUSTER_DEFAULT,
+)
+from explorer.presentation.share_summary_png_export import (
+    share_summary_png_filename,
+    share_summary_to_png_bytes,
+)
+from explorer.presentation.share_summary_preview import (
+    FormatId,
+    LayoutId,
+    SpotlightPresentationId,
+    TilesPresentationId,
+    default_card_stat_labels,
+    layout_card_stat_storage_max,
+    layout_grid_slot_limits_caption,
+    render_share_summary_preview_html,
+    resolve_insight_fact,
+)
+
+SOCIAL_CARDS_STATISTICS_LABEL = "Card statistics"
+SOCIAL_CARDS_CURRENT_CARD_LABEL = "Current card"
+_CHIP_STRIP_COLS_PER_ROW = 3
+
+
+@st.cache_data(show_spinner="Generating PNG…")
+def cached_share_summary_png(
+    stats: ShareSummaryStats,
+    layout: LayoutId,
+    fmt: FormatId,
+    card_stat_labels: tuple[str, ...],
+    spotlight_label: str,
+    all_time: ShareSummaryAllTimeStats | None,
+    color_scheme_index: int,
+    color_scheme_fingerprint: tuple[tuple[str, str], ...],
+    scope_label: str | None,
+    geo_scope: ShareSummaryGeoScope,
+    tiles_presentation: TilesPresentationId = "grid",
+    spotlight_presentation: SpotlightPresentationId = "classic",
+    insight_fact: ShareSummaryInsightFact | None = None,
+) -> bytes:
+    del color_scheme_fingerprint  # cache key only — render reads live scheme by index
+    return share_summary_to_png_bytes(
+        stats,
+        layout=layout,
+        fmt=fmt,
+        spotlight_label=spotlight_label,
+        insight_fact=insight_fact,
+        card_stat_labels=card_stat_labels,
+        all_time=all_time,
+        color_scheme_index=color_scheme_index,
+        scope_label=scope_label,
+        geo_scope=geo_scope,
+        tiles_presentation=tiles_presentation,
+        spotlight_presentation=spotlight_presentation,
+    )
+
+
+def _clear_card_stat_selectbox_keys(layout: LayoutId, keys: SocialCardsSessionKeys) -> None:
+    """Drop stale selectbox widget state so Reset / session picks take effect."""
+    for i in range(layout_card_stat_storage_max(layout)):
+        st.session_state.pop(keys.card_stat_selectbox(layout, i), None)
+
+
+def _sync_card_stat_selectbox_value(
+    layout: LayoutId,
+    index: int,
+    *,
+    options: list[str],
+    desired: str,
+    keys: SocialCardsSessionKeys,
+) -> str:
+    """Align selectbox session state without clobbering a valid user choice."""
+    key = keys.card_stat_selectbox(layout, index)
+    value = resolve_card_stat_selectbox_value(
+        session_value=st.session_state.get(key),
+        desired=desired,
+        options=options,
+    )
+    st.session_state[key] = value
+    return value
+
+
+def _ensure_card_stat_picks(
+    layout: LayoutId,
+    status_metrics: list[tuple[str, str]],
+    fmt: FormatId,
+    period_kind: PeriodKind,
+    *,
+    data_scope: str,
+    geo_scope: ShareSummaryGeoScope,
+    tiles_presentation: TilesPresentationId,
+    keys: SocialCardsSessionKeys,
+) -> list[str]:
+    """Initialize or sanitize session picks for *layout*; returns UI row values."""
+    from explorer.presentation.share_summary_circles_preview import (
+        tiles_circle_cluster_max,
+    )
+
+    circle_cluster = tiles_circle_cluster_picker(layout, tiles_presentation)
+    max_slots = card_stat_max_slots(
+        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
+    )
+    storage_max = tiles_circle_cluster_max(fmt) if circle_cluster else layout_card_stat_storage_max(layout)
+    available = frozenset(label for label, _ in status_metrics)
+    picks_key = keys.card_stat_picks(layout, period_kind)
+    count_key = keys.card_stat_slot_count(layout, period_kind)
+    scope_key = keys.card_stat_scope(layout, period_kind)
+    defaults = list(
+        default_card_stat_labels(
+            layout,
+            status_metrics,
+            period_kind=period_kind,
+            geo_scope=geo_scope,
+            fmt=fmt,
+        )
+    )
+
+    if st.session_state.get(scope_key) != data_scope:
+        st.session_state[scope_key] = data_scope
+        st.session_state.pop(picks_key, None)
+        st.session_state.pop(count_key, None)
+        _clear_card_stat_selectbox_keys(layout, keys)
+
+    if picks_key not in st.session_state:
+        st.session_state[picks_key] = defaults
+        st.session_state[count_key] = default_card_stat_slot_count(
+            circle_cluster=circle_cluster,
+            defaults=defaults,
+            max_slots=max_slots,
+            layout=layout,
+            fmt=fmt,
+            tiles_presentation=tiles_presentation,
+        )
+
+    sanitized = sanitize_card_stat_picks(
+        list(st.session_state[picks_key]),
+        available=available,
+        max_slots=storage_max,
+    )
+    if not sanitized and defaults:
+        _clear_card_stat_selectbox_keys(layout, keys)
+        st.session_state[picks_key] = defaults
+        st.session_state[count_key] = default_card_stat_slot_count(
+            circle_cluster=circle_cluster,
+            defaults=defaults,
+            max_slots=max_slots,
+            layout=layout,
+            fmt=fmt,
+            tiles_presentation=tiles_presentation,
+        )
+        sanitized = list(defaults)
+
+    sanitized = sanitize_card_stat_picks(
+        list(st.session_state[picks_key]),
+        available=available,
+        max_slots=storage_max,
+    )
+    slot_count = int(st.session_state.get(count_key, max(1, len(sanitized))))
+    ui_rows = card_stat_ui_row_count(
+        layout,
+        fmt,
+        slot_count=slot_count,
+        tiles_presentation=tiles_presentation,
+        status_metrics=status_metrics,
+    )
+
+    raw = list(st.session_state[picks_key])
+    compact = [p for p in raw if p]
+    picks = (compact + [""] * ui_rows)[:ui_rows]
+    st.session_state[count_key] = ui_rows
+
+    st.session_state[picks_key] = picks
+    return picks
+
+
+def _add_stat_to_card(
+    label: str,
+    *,
+    layout: LayoutId,
+    period_kind: PeriodKind,
+    fmt: FormatId,
+    tiles_presentation: TilesPresentationId,
+    keys: SocialCardsSessionKeys,
+    available_stat_count: int | None = None,
+) -> None:
+    """Fill the next empty card slot, or append a row when allowed."""
+    picks_key = keys.card_stat_picks(layout, period_kind)
+    count_key = keys.card_stat_slot_count(layout, period_kind)
+    max_slots = card_stat_max_slots(
+        layout,
+        fmt,
+        tiles_presentation=tiles_presentation,
+        available_stat_count=available_stat_count,
+    )
+    picks = list(st.session_state.get(picks_key, []))
+    slot_count = int(st.session_state.get(count_key, 1))
+    ui_rows = card_stat_ui_row_count(
+        layout,
+        fmt,
+        slot_count=slot_count,
+        tiles_presentation=tiles_presentation,
+        available_stat_count=available_stat_count,
+    )
+    active = (picks + [""] * ui_rows)[:ui_rows]
+
+    for i in range(ui_rows):
+        if not active[i]:
+            active[i] = label
+            st.session_state[picks_key] = active + picks[ui_rows:]
+            _clear_card_stat_selectbox_keys(layout, keys)
+            return
+
+    if ui_rows < max_slots:
+        active.append(label)
+        st.session_state[count_key] = ui_rows + 1
+        st.session_state[picks_key] = active
+        _clear_card_stat_selectbox_keys(layout, keys)
+
+
+def _add_stat_to_card_on_click(
+    stat_label: str,
+    layout: LayoutId,
+    period_kind: PeriodKind,
+    fmt: FormatId,
+    tiles_presentation: TilesPresentationId,
+    keys: SocialCardsSessionKeys,
+    available_stat_count: int,
+) -> None:
+    """Callback — runs before widgets so selectbox keys can be cleared safely."""
+    _add_stat_to_card(
+        stat_label,
+        layout=layout,
+        period_kind=period_kind,
+        fmt=fmt,
+        tiles_presentation=tiles_presentation,
+        keys=keys,
+        available_stat_count=available_stat_count,
+    )
+
+
+def _not_on_card_chip_strip(
+    *,
+    layout: LayoutId,
+    period_kind: PeriodKind,
+    fmt: FormatId,
+    status_metrics: list[tuple[str, str]],
+    picks: list[str],
+    slot_count: int,
+    metrics_lookup: dict[str, str],
+    tiles_presentation: TilesPresentationId,
+    keys: SocialCardsSessionKeys,
+) -> None:
+    """Compact chips for stats not yet on the card; click to add."""
+    on_card = stats_on_card(picks)
+    not_on_card = [
+        (stat_label, metrics_lookup[stat_label])
+        for stat_label, _ in status_metrics
+        if stat_label not in on_card
+    ]
+    if not not_on_card:
+        st.caption("All available stats are on the card.")
+        return
+
+    can_add = card_can_accept_stat(
+        layout,
+        fmt,
+        picks,
+        slot_count,
+        tiles_presentation=tiles_presentation,
+        status_metrics=status_metrics,
+    )
+
+    available_stat_count = len(status_metrics)
+    for row_start in range(0, len(not_on_card), _CHIP_STRIP_COLS_PER_ROW):
+        row_items = not_on_card[row_start : row_start + _CHIP_STRIP_COLS_PER_ROW]
+        cols = st.columns(_CHIP_STRIP_COLS_PER_ROW)
+        for col_index in range(_CHIP_STRIP_COLS_PER_ROW):
+            with cols[col_index]:
+                if col_index >= len(row_items):
+                    continue
+                stat_label, value = row_items[col_index]
+                chip_index = row_start + col_index
+                st.button(
+                    f"{stat_label} · {value}",
+                    key=keys.stat_chip(layout, period_kind, chip_index),
+                    type="tertiary",
+                    use_container_width=False,
+                    disabled=not can_add,
+                    on_click=_add_stat_to_card_on_click,
+                    args=(
+                        stat_label,
+                        layout,
+                        period_kind,
+                        fmt,
+                        tiles_presentation,
+                        keys,
+                        available_stat_count,
+                    ),
+                )
+
+
+def render_card_stat_picker_ui(
+    layout: LayoutId,
+    status_metrics: list[tuple[str, str]],
+    fmt: FormatId,
+    period_kind: PeriodKind,
+    *,
+    data_scope: str,
+    geo_scope: ShareSummaryGeoScope,
+    tiles_presentation: TilesPresentationId,
+    keys: SocialCardsSessionKeys,
+) -> tuple[str, ...]:
+    """Ordered stat picker for tiles / list; hidden for spotlight."""
+    if layout in ("spotlight", "insight"):
+        return ()
+
+    max_slots = card_stat_max_slots(
+        layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
+    )
+    circle_cluster = tiles_circle_cluster_picker(layout, tiles_presentation)
+    available_labels = [label for label, _ in status_metrics]
+    metrics_lookup = status_metrics_lookup(status_metrics)
+    if not available_labels:
+        st.caption("No statistics available for this period.")
+        return ()
+
+    picks_key = keys.card_stat_picks(layout, period_kind)
+    count_key = keys.card_stat_slot_count(layout, period_kind)
+    picks = _ensure_card_stat_picks(
+        layout,
+        status_metrics,
+        fmt,
+        period_kind,
+        data_scope=data_scope,
+        geo_scope=geo_scope,
+        tiles_presentation=tiles_presentation,
+        keys=keys,
+    )
+    ui_rows = card_stat_ui_row_count(
+        layout,
+        fmt,
+        slot_count=int(st.session_state[count_key]),
+        tiles_presentation=tiles_presentation,
+        status_metrics=status_metrics,
+    )
+
+    if circle_cluster:
+        st.caption(
+            f"Supports up to {max_slots} stats. "
+            f"The default is {TILES_CIRCLE_CLUSTER_DEFAULT} circles."
+        )
+    elif layout == "tiles":
+        min_slots = card_stat_min_slots(layout, fmt, tiles_presentation=tiles_presentation)
+        st.caption(
+            f"Statistics Grid: {min_slots}–{max_slots} stats "
+            f"({layout_grid_slot_limits_caption()}). "
+            "Use Add stat or the chips below to add more."
+        )
+    else:
+        st.caption(
+            f"Supports up to {max_slots} stats. "
+            "Use Add stat or the chips below to add more."
+        )
+
+    stat_row_cols = [0.5, 6, 1.8, 2.2]
+    min_slots = card_stat_min_slots(layout, fmt, tiles_presentation=tiles_presentation)
+
+    for i in range(ui_rows):
+        current = picks[i] if i < len(picks) else ""
+        other = {picks[j] for j in range(len(picks)) if j != i and picks[j]}
+        options = [""] + [lab for lab in available_labels if lab not in other]
+        current = _sync_card_stat_selectbox_value(
+            layout, i, options=options, desired=current, keys=keys
+        )
+        picks[i] = current
+        can_up = i > 0
+        can_down = i < ui_rows - 1
+        can_remove = ui_rows > min_slots and (i > 0 or bool(current))
+
+        col_num, col_sel, col_val, col_actions = st.columns(
+            stat_row_cols,
+            vertical_alignment="center",
+        )
+        with col_num:
+            st.markdown(f"**{i + 1}**")
+        with col_sel:
+            choice = st.selectbox(
+                "Stat",
+                options=options,
+                format_func=lambda x: "—" if x == "" else x,
+                key=keys.card_stat_selectbox(layout, i),
+                label_visibility="collapsed",
+            )
+            picks[i] = choice or ""
+        with col_val:
+            value = metrics_lookup.get(picks[i], "") if picks[i] else ""
+            st.markdown(f"**{value}**" if value else "—")
+        with col_actions:
+            btn_up, btn_down, btn_rm = st.columns(3, gap="small")
+            with btn_up:
+                if st.button(
+                    "↑",
+                    key=keys.card_stat_up(layout, i),
+                    help="Move up",
+                    disabled=not can_up,
+                    use_container_width=True,
+                ):
+                    picks[i - 1], picks[i] = picks[i], picks[i - 1]
+                    st.session_state[picks_key] = picks[:ui_rows]
+                    _clear_card_stat_selectbox_keys(layout, keys)
+                    st.rerun()
+            with btn_down:
+                if st.button(
+                    "↓",
+                    key=keys.card_stat_down(layout, i),
+                    help="Move down",
+                    disabled=not can_down,
+                    use_container_width=True,
+                ):
+                    picks[i + 1], picks[i] = picks[i], picks[i + 1]
+                    st.session_state[picks_key] = picks[:ui_rows]
+                    _clear_card_stat_selectbox_keys(layout, keys)
+                    st.rerun()
+            with btn_rm:
+                if st.button(
+                    "✕",
+                    key=keys.card_stat_rm(layout, i),
+                    help="Remove this stat",
+                    disabled=not can_remove,
+                    use_container_width=True,
+                ):
+                    if i == 0 and ui_rows == 1:
+                        picks[0] = ""
+                    elif i == 0:
+                        picks.pop(0)
+                        st.session_state[count_key] = ui_rows - 1
+                    else:
+                        picks.pop(i)
+                        st.session_state[count_key] = ui_rows - 1
+                    st.session_state[picks_key] = picks[:ui_rows]
+                    _clear_card_stat_selectbox_keys(layout, keys)
+                    st.rerun()
+
+    col_num_foot, col_sel_foot, col_val_foot, col_actions_foot = st.columns(
+        stat_row_cols,
+        vertical_alignment="center",
+    )
+    with col_sel_foot:
+        if ui_rows < max_slots and st.button(
+            "Add stat",
+            key=keys.card_stat_add(layout),
+        ):
+            st.session_state[count_key] = ui_rows + 1
+            st.rerun()
+    with col_actions_foot:
+        foot_up, foot_down, foot_rm = st.columns(3, gap="small")
+        with foot_down:
+            if st.button(
+                "Reset",
+                key=keys.card_stat_reset(layout),
+                help="Restore this layout's default stat list",
+                use_container_width=True,
+            ):
+                defaults = list(
+                    default_card_stat_labels(
+                        layout,
+                        status_metrics,
+                        period_kind=period_kind,
+                        geo_scope=geo_scope,
+                        fmt=fmt,
+                    )
+                )
+                _clear_card_stat_selectbox_keys(layout, keys)
+                st.session_state[picks_key] = defaults
+                st.session_state[count_key] = default_card_stat_slot_count(
+                    circle_cluster=circle_cluster,
+                    defaults=defaults,
+                    max_slots=max_slots,
+                    layout=layout,
+                    fmt=fmt,
+                    tiles_presentation=tiles_presentation,
+                )
+                st.rerun()
+
+    slot_count = int(st.session_state[count_key])
+    can_add_more = card_can_accept_stat(
+        layout,
+        fmt,
+        picks[:ui_rows],
+        slot_count,
+        tiles_presentation=tiles_presentation,
+        status_metrics=status_metrics,
+    )
+    stats_not_on_card = [
+        label for label in available_labels if label not in stats_on_card(picks[:ui_rows])
+    ]
+    if stats_not_on_card and not can_add_more:
+        st.info("Card is full.")
+
+    st.session_state[picks_key] = picks[:ui_rows]
+    final = effective_card_stat_labels(
+        picks,
+        layout,
+        fmt,
+        tiles_presentation=tiles_presentation,
+        status_metrics=status_metrics,
+    )
+    if not final:
+        st.caption("Select at least one stat to show on the card.")
+
+    st.divider()
+    _not_on_card_chip_strip(
+        layout=layout,
+        period_kind=period_kind,
+        fmt=fmt,
+        status_metrics=status_metrics,
+        picks=picks[:ui_rows],
+        slot_count=slot_count,
+        metrics_lookup=metrics_lookup,
+        tiles_presentation=tiles_presentation,
+        keys=keys,
+    )
+    return final
+
+
+def spotlight_label_from_session(
+    status_metrics: list[tuple[str, str]],
+    keys: SocialCardsSessionKeys,
+) -> str:
+    available = {label for label, _ in status_metrics}
+    raw = st.session_state.get(keys.spotlight_label)
+    if isinstance(raw, str) and raw.strip() in available:
+        return raw.strip()
+    if SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT in available:
+        return SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT
+    if status_metrics:
+        return status_metrics[0][0]
+    return SHARE_SUMMARY_SPOTLIGHT_LABEL_DEFAULT
+
+
+def _select_spotlight_stat(stat_label: str, keys: SocialCardsSessionKeys) -> None:
+    """Callback — runs before widgets so the selectbox key can be updated."""
+    st.session_state[keys.spotlight_label] = stat_label
+
+
+def _spotlight_alternate_chip_strip(
+    status_metrics: list[tuple[str, str]],
+    *,
+    current: str,
+    metrics_lookup: dict[str, str],
+    keys: SocialCardsSessionKeys,
+) -> None:
+    """Quick-switch chips for stats not currently spotlighted."""
+    others = [
+        (label, metrics_lookup[label])
+        for label, _ in status_metrics
+        if label != current
+    ]
+    if not others:
+        return
+    count = len(others)
+    st.caption(
+        f"{count} other stat{'s' if count != 1 else ''} available — click to spotlight."
+    )
+    cols_per_row = 3
+    for row_start in range(0, len(others), cols_per_row):
+        row_items = others[row_start : row_start + cols_per_row]
+        cols = st.columns(len(row_items))
+        for col_index, (stat_label, value) in enumerate(row_items):
+            with cols[col_index]:
+                chip_index = row_start + col_index
+                st.button(
+                    f"{stat_label} · {value}",
+                    key=keys.spotlight_chip(chip_index),
+                    use_container_width=True,
+                    help=f"Spotlight {stat_label}",
+                    on_click=_select_spotlight_stat,
+                    args=(stat_label, keys),
+                )
+
+
+def render_spotlight_stat_picker(
+    status_metrics: list[tuple[str, str]],
+    keys: SocialCardsSessionKeys,
+) -> None:
+    labels = [label for label, _ in status_metrics]
+    if not labels:
+        st.caption("No statistics available for this period.")
+        return
+    metrics_lookup = status_metrics_lookup(status_metrics)
+    current = spotlight_label_from_session(status_metrics, keys)
+    col_sel, col_val = st.columns([4, 1], vertical_alignment="bottom")
+    with col_sel:
+        st.selectbox(
+            "Spotlight stat",
+            options=labels,
+            index=labels.index(current) if current in labels else 0,
+            key=keys.spotlight_label,
+            help="Single highlighted stat for the Spotlight layout.",
+        )
+    selected = spotlight_label_from_session(status_metrics, keys)
+    with col_val:
+        st.markdown(f"**{metrics_lookup.get(selected, '—')}**")
+
+    st.divider()
+    _spotlight_alternate_chip_strip(
+        status_metrics,
+        current=selected,
+        metrics_lookup=metrics_lookup,
+        keys=keys,
+    )
+
+
+def _insight_fact_options(
+    facts: list[ShareSummaryInsightFact],
+    *,
+    species_options: tuple[str, ...] = (),
+) -> list[tuple[InsightFactId, str]]:
+    auto_ids: tuple[InsightFactId, ...] = (
+        "most_common_checklist_species",
+        "most_individuals_species",
+        "biggest_checklist_count",
+    )
+    options: list[tuple[InsightFactId, str]] = []
+    for fact_id in auto_ids:
+        if any(f.fact_id == fact_id for f in facts):
+            options.append((fact_id, INSIGHT_FACT_PICKER_LABELS[fact_id]))
+    if species_options:
+        options.append(("species_individuals", INSIGHT_FACT_PICKER_LABELS["species_individuals"]))
+    return options
+
+
+def _insight_fact_id_from_session(
+    options: list[tuple[InsightFactId, str]],
+    keys: SocialCardsSessionKeys,
+) -> InsightFactId:
+    valid = {fact_id for fact_id, _ in options}
+    raw = st.session_state.get(keys.insight_fact, SHARE_SUMMARY_INSIGHT_FACT_DEFAULT)
+    if raw in valid:
+        return raw  # type: ignore[return-value]
+    if SHARE_SUMMARY_INSIGHT_FACT_DEFAULT in valid:
+        return SHARE_SUMMARY_INSIGHT_FACT_DEFAULT
+    return options[0][0] if options else SHARE_SUMMARY_INSIGHT_FACT_DEFAULT
+
+
+def _insight_species_from_session(
+    species_options: tuple[str, ...],
+    keys: SocialCardsSessionKeys,
+) -> str:
+    raw = st.session_state.get(keys.insight_species)
+    if isinstance(raw, str) and raw in species_options:
+        return raw
+    return species_options[0] if species_options else ""
+
+
+def render_insight_fact_picker_ui(
+    facts: list[ShareSummaryInsightFact],
+    species_options: tuple[str, ...],
+    *,
+    df: pd.DataFrame,
+    period,
+    keys: SocialCardsSessionKeys,
+) -> ShareSummaryInsightFact | None:
+    """Insights fact picker; returns the resolved fact for preview/export."""
+    options = _insight_fact_options(facts, species_options=species_options)
+    if not options:
+        st.caption("No insights available for this period.")
+        return None
+
+    fact_ids = [fact_id for fact_id, _ in options]
+    current_id = _insight_fact_id_from_session(options, keys)
+    st.selectbox(
+        "Insights",
+        options=fact_ids,
+        format_func=lambda fid: INSIGHT_FACT_PICKER_LABELS[fid],
+        index=fact_ids.index(current_id) if current_id in fact_ids else 0,
+        key=keys.insight_fact,
+        help="Species- and checklist-derived highlights for Interesting Insights cards.",
+    )
+    selected_id = _insight_fact_id_from_session(options, keys)
+
+    species_common = ""
+    if insight_fact_requires_species(selected_id):
+        if not species_options:
+            st.caption("No species in this period for a selected-species fact.")
+            return None
+        species_common = _insight_species_from_session(species_options, keys)
+        st.selectbox(
+            "Species",
+            options=list(species_options),
+            index=list(species_options).index(species_common) if species_common else 0,
+            key=keys.insight_species,
+        )
+        species_common = _insight_species_from_session(species_options, keys)
+        refreshed = compute_insight_facts(
+            df,
+            period,
+            species_common=species_common,
+        )
+        return resolve_insight_fact(refreshed, selected_id)
+
+    return resolve_insight_fact(facts, selected_id)
+
+
+def centered_card_download_button(
+    *,
+    label: str,
+    data: bytes,
+    file_name: str,
+    mime: str,
+    help_text: str,
+) -> None:
+    """Download control centred under the scaled card preview."""
+    _, btn_col, _ = st.columns([1, 1, 1])
+    with btn_col:
+        st.download_button(
+            label,
+            data=data,
+            file_name=file_name,
+            mime=mime,
+            use_container_width=True,
+            help=help_text,
+        )
+
+
+@st.fragment
+def render_current_card_fragment(
+    *,
+    stats: ShareSummaryStats,
+    all_time: ShareSummaryAllTimeStats | None,
+    selected_layout: LayoutId,
+    fmt: FormatId,
+    scale: float,
+    status_metrics: list[tuple[str, str]],
+    color_scheme_index: int,
+    card_stat_data_scope: str,
+    scope_label: str,
+    geo_scope: ShareSummaryGeoScope,
+    keys: SocialCardsSessionKeys,
+    tiles_presentation: TilesPresentationId = "grid",
+    spotlight_presentation: SpotlightPresentationId = "classic",
+    insight_facts: list[ShareSummaryInsightFact],
+    insight_species_options: tuple[str, ...],
+    df_scoped: pd.DataFrame,
+    resolved_period,
+    statistics_label: str = SOCIAL_CARDS_STATISTICS_LABEL,
+    current_card_label: str = SOCIAL_CARDS_CURRENT_CARD_LABEL,
+    export_button_label: str = "Export card",
+) -> None:
+    """Card statistics controls, live preview, and PNG export."""
+    card_stat_labels: tuple[str, ...] = ()
+    resolved_fact: ShareSummaryInsightFact | None = None
+    with st.expander(statistics_label, expanded=False):
+        if selected_layout == "spotlight":
+            render_spotlight_stat_picker(status_metrics, keys)
+        elif selected_layout == "insight":
+            resolved_fact = render_insight_fact_picker_ui(
+                insight_facts,
+                insight_species_options,
+                df=df_scoped,
+                period=resolved_period,
+                keys=keys,
+            )
+        else:
+            card_stat_labels = render_card_stat_picker_ui(
+                selected_layout,
+                status_metrics,
+                fmt,
+                stats.period_kind,
+                data_scope=card_stat_data_scope,
+                geo_scope=geo_scope,
+                tiles_presentation=tiles_presentation,
+                keys=keys,
+            )
+
+    spotlight_label = spotlight_label_from_session(status_metrics, keys)
+
+    st.subheader(current_card_label)
+    st.markdown(
+        render_share_summary_preview_html(
+            stats,
+            layout=selected_layout,
+            fmt=fmt,
+            tiles_presentation=tiles_presentation,
+            spotlight_presentation=spotlight_presentation,
+            scale=scale,
+            spotlight_label=spotlight_label,
+            insight_fact=resolved_fact,
+            card_stat_labels=card_stat_labels,
+            all_time=all_time,
+            color_scheme_index=color_scheme_index,
+            geo_scope=geo_scope,
+            scope_label=scope_label,
+        ),
+        unsafe_allow_html=True,
+    )
+
+    png_filename = share_summary_png_filename(stats, layout=selected_layout, fmt=fmt)
+    try:
+        png_bytes = cached_share_summary_png(
+            stats,
+            selected_layout,
+            fmt,
+            card_stat_labels,
+            spotlight_label,
+            all_time,
+            color_scheme_index,
+            share_summary_color_scheme_fingerprint(color_scheme_index),
+            scope_label,
+            geo_scope,
+            tiles_presentation,
+            spotlight_presentation,
+            resolved_fact,
+        )
+    except RuntimeError as exc:
+        st.warning(str(exc))
+    else:
+        centered_card_download_button(
+            label=export_button_label,
+            data=png_bytes,
+            file_name=png_filename,
+            mime="image/png",
+            help_text="PNG of the current card above.",
+        )

--- a/explorer/app/streamlit/social_cards_streamlit_ui.py
+++ b/explorer/app/streamlit/social_cards_streamlit_ui.py
@@ -39,6 +39,7 @@ from explorer.core.share_summary_insight_facts import (
 )
 from explorer.presentation.share_summary_circles_preview import (
     TILES_CIRCLE_CLUSTER_DEFAULT,
+    tiles_circle_cluster_max,
 )
 from explorer.presentation.share_summary_png_export import (
     share_summary_png_filename,
@@ -131,10 +132,6 @@ def _ensure_card_stat_picks(
     keys: SocialCardsSessionKeys,
 ) -> list[str]:
     """Initialize or sanitize session picks for *layout*; returns UI row values."""
-    from explorer.presentation.share_summary_circles_preview import (
-        tiles_circle_cluster_max,
-    )
-
     circle_cluster = tiles_circle_cluster_picker(layout, tiles_presentation)
     max_slots = card_stat_max_slots(
         layout, fmt, tiles_presentation=tiles_presentation, status_metrics=status_metrics
@@ -171,12 +168,11 @@ def _ensure_card_stat_picks(
             tiles_presentation=tiles_presentation,
         )
 
-    sanitized = sanitize_card_stat_picks(
+    if not sanitize_card_stat_picks(
         list(st.session_state[picks_key]),
         available=available,
         max_slots=storage_max,
-    )
-    if not sanitized and defaults:
+    ) and defaults:
         _clear_card_stat_selectbox_keys(layout, keys)
         st.session_state[picks_key] = defaults
         st.session_state[count_key] = default_card_stat_slot_count(
@@ -187,7 +183,6 @@ def _ensure_card_stat_picks(
             fmt=fmt,
             tiles_presentation=tiles_presentation,
         )
-        sanitized = list(defaults)
 
     sanitized = sanitize_card_stat_picks(
         list(st.session_state[picks_key]),
@@ -492,7 +487,7 @@ def render_card_stat_picker_ui(
             st.session_state[count_key] = ui_rows + 1
             st.rerun()
     with col_actions_foot:
-        foot_up, foot_down, foot_rm = st.columns(3, gap="small")
+        _, foot_down, _ = st.columns(3, gap="small")
         with foot_down:
             if st.button(
                 "Reset",
@@ -601,9 +596,8 @@ def _spotlight_alternate_chip_strip(
     st.caption(
         f"{count} other stat{'s' if count != 1 else ''} available — click to spotlight."
     )
-    cols_per_row = 3
-    for row_start in range(0, len(others), cols_per_row):
-        row_items = others[row_start : row_start + cols_per_row]
+    for row_start in range(0, len(others), _CHIP_STRIP_COLS_PER_ROW):
+        row_items = others[row_start : row_start + _CHIP_STRIP_COLS_PER_ROW]
         cols = st.columns(len(row_items))
         for col_index, (stat_label, value) in enumerate(row_items):
             with cols[col_index]:

--- a/tests/explorer/test_design_share_summary_app.py
+++ b/tests/explorer/test_design_share_summary_app.py
@@ -1,31 +1,35 @@
-"""Tests for design share summary app helpers."""
+"""Tests for Social Cards Streamlit helpers and design-app sample data."""
 
-from explorer.app.streamlit.design_share_summary_app import (
-    _card_stat_data_scope,
-    _card_stat_ui_row_count,
-    _default_card_stat_slot_count,
-    _design_sample_dataset,
-    _period_has_checklist_data,
-    _resolve_card_stat_selectbox_value,
+from datetime import date
+
+from explorer.app.streamlit.design_share_summary_app import _design_sample_dataset
+from explorer.app.streamlit.social_cards_streamlit_helpers import (
+    card_stat_data_scope_from_design_source,
+    card_stat_ui_row_count,
+    default_card_stat_slot_count,
+    period_has_checklist_data,
+    resolve_card_stat_selectbox_value,
 )
 from explorer.core.share_summary_compute import (
     ShareSummaryGeoScope,
     ShareSummaryStats,
+    compute_share_summary_stats,
     geo_country_keys_from_df,
     geo_region_options_for_country,
+    period_for_year,
 )
 
 
 def test_card_stat_ui_row_count_clamps_slot_count_to_layout_limit():
-    assert _card_stat_ui_row_count("tiles", "story", slot_count=4) == 4
-    assert _card_stat_ui_row_count("minimal", "story", slot_count=6) == 6
-    assert _card_stat_ui_row_count("tiles", "story", slot_count=14) == 14
-    assert _card_stat_ui_row_count("tiles", "story", slot_count=16) == 14
-    assert _card_stat_ui_row_count("tiles", "story", slot_count=2) == 4
-    assert _card_stat_ui_row_count("tiles", "portrait_post", slot_count=9) == 8
-    assert _card_stat_ui_row_count("tiles", "portrait_post", slot_count=3) == 4
+    assert card_stat_ui_row_count("tiles", "story", slot_count=4) == 4
+    assert card_stat_ui_row_count("minimal", "story", slot_count=6) == 6
+    assert card_stat_ui_row_count("tiles", "story", slot_count=14) == 14
+    assert card_stat_ui_row_count("tiles", "story", slot_count=16) == 14
+    assert card_stat_ui_row_count("tiles", "story", slot_count=2) == 4
+    assert card_stat_ui_row_count("tiles", "portrait_post", slot_count=9) == 8
+    assert card_stat_ui_row_count("tiles", "portrait_post", slot_count=3) == 4
     assert (
-        _card_stat_ui_row_count(
+        card_stat_ui_row_count(
             "tiles",
             "square",
             slot_count=8,
@@ -34,7 +38,7 @@ def test_card_stat_ui_row_count_clamps_slot_count_to_layout_limit():
         == 6
     )
     assert (
-        _card_stat_ui_row_count(
+        card_stat_ui_row_count(
             "tiles",
             "portrait_post",
             slot_count=12,
@@ -43,7 +47,7 @@ def test_card_stat_ui_row_count_clamps_slot_count_to_layout_limit():
         == 8
     )
     assert (
-        _card_stat_ui_row_count(
+        card_stat_ui_row_count(
             "tiles",
             "story",
             slot_count=12,
@@ -70,14 +74,14 @@ def test_layout_grid_stat_default_count():
 
 
 def test_default_card_stat_slot_count():
-    assert _default_card_stat_slot_count(
+    assert default_card_stat_slot_count(
         circle_cluster=True,
         defaults=["A", "B", "C", "D", "E", "F"],
         max_slots=10,
         layout="tiles",
         fmt="story",
     ) == 6
-    assert _default_card_stat_slot_count(
+    assert default_card_stat_slot_count(
         circle_cluster=False,
         defaults=["A", "B", "C", "D", "E", "F"],
         max_slots=10,
@@ -85,7 +89,7 @@ def test_default_card_stat_slot_count():
         fmt="square",
         tiles_presentation="grid",
     ) == 4
-    assert _default_card_stat_slot_count(
+    assert default_card_stat_slot_count(
         circle_cluster=False,
         defaults=["A", "B", "C", "D", "E", "F"],
         max_slots=10,
@@ -93,7 +97,7 @@ def test_default_card_stat_slot_count():
         fmt="portrait_post",
         tiles_presentation="grid",
     ) == 6
-    assert _default_card_stat_slot_count(
+    assert default_card_stat_slot_count(
         circle_cluster=False,
         defaults=["A", "B", "C", "D", "E", "F"],
         max_slots=10,
@@ -101,14 +105,14 @@ def test_default_card_stat_slot_count():
         fmt="story",
         tiles_presentation="grid",
     ) == 6
-    assert _default_card_stat_slot_count(
+    assert default_card_stat_slot_count(
         circle_cluster=False,
         defaults=["A", "B", "C", "D"],
         max_slots=10,
         layout="minimal",
         fmt="story",
     ) == 4
-    assert _default_card_stat_slot_count(
+    assert default_card_stat_slot_count(
         circle_cluster=False,
         defaults=[],
         max_slots=6,
@@ -118,19 +122,19 @@ def test_default_card_stat_slot_count():
 
 
 def test_card_stat_data_scope_changes_when_source_or_period_changes():
-    sample = _card_stat_data_scope(
+    sample = card_stat_data_scope_from_design_source(
         use_sample=True,
         period_kind="month",
         period_label="June 2025",
         upload_name=None,
     )
-    csv = _card_stat_data_scope(
+    csv = card_stat_data_scope_from_design_source(
         use_sample=False,
         period_kind="month",
         period_label="June 2025",
         upload_name="MyEBirdData.csv",
     )
-    other_month = _card_stat_data_scope(
+    other_month = card_stat_data_scope_from_design_source(
         use_sample=False,
         period_kind="month",
         period_label="May 2025",
@@ -142,7 +146,7 @@ def test_card_stat_data_scope_changes_when_source_or_period_changes():
     assert sample != csv
     assert csv != other_month
     assert (
-        _card_stat_data_scope(
+        card_stat_data_scope_from_design_source(
             use_sample=True,
             period_kind="month",
             period_label="June 2025",
@@ -153,14 +157,14 @@ def test_card_stat_data_scope_changes_when_source_or_period_changes():
 
 
 def test_card_stat_data_scope_changes_when_geo_scope_changes():
-    world = _card_stat_data_scope(
+    world = card_stat_data_scope_from_design_source(
         use_sample=False,
         period_kind="year",
         period_label="2025",
         upload_name="MyEBirdData.csv",
         geo_scope=ShareSummaryGeoScope(),
     )
-    country = _card_stat_data_scope(
+    country = card_stat_data_scope_from_design_source(
         use_sample=False,
         period_kind="year",
         period_label="2025",
@@ -173,21 +177,21 @@ def test_card_stat_data_scope_changes_when_geo_scope_changes():
 
 
 def test_card_stat_data_scope_changes_when_format_or_presentation_changes():
-    square = _card_stat_data_scope(
+    square = card_stat_data_scope_from_design_source(
         use_sample=True,
         period_kind="year",
         period_label="2025",
         upload_name=None,
         fmt="square",
     )
-    story = _card_stat_data_scope(
+    story = card_stat_data_scope_from_design_source(
         use_sample=True,
         period_kind="year",
         period_label="2025",
         upload_name=None,
         fmt="story",
     )
-    circles = _card_stat_data_scope(
+    circles = card_stat_data_scope_from_design_source(
         use_sample=True,
         period_kind="year",
         period_label="2025",
@@ -202,7 +206,7 @@ def test_card_stat_data_scope_changes_when_format_or_presentation_changes():
 def test_resolve_card_stat_selectbox_value_prefers_widget_over_stale_pick():
     options = ["", "Lifers", "Australia Lifers", "Total species"]
     assert (
-        _resolve_card_stat_selectbox_value(
+        resolve_card_stat_selectbox_value(
             session_value="Australia Lifers",
             desired="Lifers",
             options=options,
@@ -210,7 +214,7 @@ def test_resolve_card_stat_selectbox_value_prefers_widget_over_stale_pick():
         == "Australia Lifers"
     )
     assert (
-        _resolve_card_stat_selectbox_value(
+        resolve_card_stat_selectbox_value(
             session_value="Countries",
             desired="Lifers",
             options=options,
@@ -220,8 +224,6 @@ def test_resolve_card_stat_selectbox_value_prefers_widget_over_stale_pick():
 
 
 def test_design_sample_dataset_has_expected_geo_options():
-    from datetime import date
-
     df = _design_sample_dataset(date.today().year)
     countries = geo_country_keys_from_df(df)
     assert countries == ["AU", "IN"]
@@ -232,10 +234,6 @@ def test_design_sample_dataset_has_expected_geo_options():
 
 
 def test_design_sample_dataset_has_checklists_for_current_year():
-    from datetime import date
-
-    from explorer.core.share_summary_compute import compute_share_summary_stats, period_for_year
-
     year = date.today().year
     df = _design_sample_dataset(year)
     stats = compute_share_summary_stats(df, period_for_year(year))
@@ -252,12 +250,12 @@ def test_design_sample_dataset_has_checklists_for_current_year():
 
 
 def test_period_has_checklist_data():
-    assert _period_has_checklist_data(
+    assert period_has_checklist_data(
         ShareSummaryStats(period_label="June 2025", period_kind="month", checklists=3)
     )
-    assert not _period_has_checklist_data(
+    assert not period_has_checklist_data(
         ShareSummaryStats(period_label="June 2026", period_kind="month")
     )
-    assert not _period_has_checklist_data(
+    assert not period_has_checklist_data(
         ShareSummaryStats(period_label="June 2026", period_kind="month", checklists=0)
     )

--- a/tests/explorer/test_share_summary_preview.py
+++ b/tests/explorer/test_share_summary_preview.py
@@ -867,13 +867,13 @@ def test_design_app_png_cache_key_includes_scheme_fingerprint():
         / "explorer"
         / "app"
         / "streamlit"
-        / "design_share_summary_app.py"
+        / "social_cards_streamlit_ui.py"
     )
     tree = ast.parse(app_path.read_text(encoding="utf-8"))
     cached_func = next(
         node
         for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "_cached_share_summary_png"
+        if isinstance(node, ast.FunctionDef) and node.name == "cached_share_summary_png"
     )
     assert "color_scheme_fingerprint" in [arg.arg for arg in cached_func.args.args]
 
@@ -882,7 +882,7 @@ def test_design_app_png_cache_key_includes_scheme_fingerprint():
         for node in ast.walk(tree)
         if isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
-        and node.func.id == "_cached_share_summary_png"
+        and node.func.id == "cached_share_summary_png"
     ]
     assert cache_calls
     assert any(


### PR DESCRIPTION
## Summary

- Extract Social Cards sidebar, stat pickers, card preview fragment, and PNG export from `design_share_summary_app.py` into shared Streamlit modules
- Design studio reduced to a thin shell (sample/CSV data, period orchestration, dev-only hex/circle tabs)
- Introduce `SocialCardsSessionKeys` namespace so design studio and main app can use separate widget keys

## Changes

- `social_cards_session_keys.py` — session key namespace (`DESIGN_SOCIAL_CARDS_KEYS` for design studio)
- `social_cards_streamlit_helpers.py` — pure helpers (slot limits, data-scope tokens, selectbox resolution)
- `social_cards_sidebar_ui.py` — geo scope, layout/format/theme, preview scale
- `social_cards_streamlit_ui.py` — stat pickers, spotlight/insight controls, `@st.fragment` preview, PNG export
- `design_share_summary_app.py` — wires shared modules; no behaviour change intended

## Test plan

- [x] `python3 -m ruff check explorer/`
- [x] `python3 -m pytest tests/ -q` (821 passed)
- [x] Manual: `streamlit run explorer/app/streamlit/design_share_summary_app.py` — parity smoke test (layouts, stat picker, insights, PNG export)
- [x] Main app launch sanity check — no Social Cards tab yet (expected; #326)

## Issues

Refs #324 (batch 1 of #323)

**Out of scope:** main app tab (#326), tab-aware sidebar (#325)