### PR TITLE
feat: Add tab-aware Social Cards sidebar and main tab

### DIFF
--- a/explorer/app/streamlit/app.py
+++ b/explorer/app/streamlit/app.py
@@ -18,7 +18,7 @@ and tab fragments. Orchestration phases are documented in
 :mod:`explorer.app.streamlit.app_orchestration`.
 
 **Main tabs:** Map, Checklist Statistics, Ranking & Lists, Bird Families, Yearly Summary,
-Country, Maintenance, Settings. Map prep runs first in a sidebar bottom ``st.spinner`` (see
+Country, Social Cards, Maintenance, Settings. Map prep runs first in a sidebar bottom ``st.spinner`` (see
 :mod:`explorer.app.streamlit.app_prep_map_ui`). Data tabs use ``@st.fragment`` where possible so
 control changes avoid rerunning the full map pipeline.
 

--- a/explorer/app/streamlit/app_constants.py
+++ b/explorer/app/streamlit/app_constants.py
@@ -108,6 +108,9 @@ EXPLORER_MAP_HTML_BYTES_KEY = "_explorer_map_html_bytes"
 EBIRD_LANDING_MAIN_CONTAINER_KEY = "ebird_landing_main"
 EBIRD_LANDING_CSV_UPLOADER_KEY = "ebird_landing_csv_uploader"
 
+# Main tab strip (``st.tabs`` widget key — active label in session state when ``on_change="rerun"``).
+STREAMLIT_MAIN_TAB_KEY = "streamlit_main_tab"
+
 # Map view widget keys.
 STREAMLIT_MAP_VIEW_LABEL_KEY = "streamlit_map_view_label"
 STREAMLIT_MAP_DATE_FILTER_KEY = "streamlit_map_date_filter"

--- a/explorer/app/streamlit/app_dashboard_shell.py
+++ b/explorer/app/streamlit/app_dashboard_shell.py
@@ -8,6 +8,7 @@ import streamlit as st
 
 from explorer.app.streamlit.app_bootstrap import TaxonomyPopupAssets
 from explorer.app.streamlit.app_landing_ui import title_with_logo
+from explorer.app.streamlit.app_main_tab_ui import notebook_main_tabs
 from explorer.app.streamlit.app_prep_map_ui import render_prep_spinner_and_map_tab
 from explorer.app.streamlit.app_settings_ui import render_settings_tab
 from explorer.app.streamlit.bird_families_streamlit_html import (
@@ -26,7 +27,7 @@ from explorer.app.streamlit.rankings_streamlit_html import (
     run_rankings_streamlit_tab_fragment,
 )
 from explorer.app.streamlit.streamlit_theme import inject_main_tab_panel_top_compact_css
-from explorer.app.streamlit.streamlit_ui_constants import NOTEBOOK_MAIN_TAB_LABELS
+from explorer.app.streamlit.streamlit_ui_constants import SOCIAL_CARDS_TAB_LABEL
 from explorer.app.streamlit.yearly_summary_streamlit_html import (
     run_yearly_summary_streamlit_fragment,
 )
@@ -82,9 +83,10 @@ def render_dashboard_shell(
         tab_families,
         tab_yearly,
         tab_country,
+        tab_social_cards,
         tab_maint,
         tab_settings,
-    ) = st.tabs(NOTEBOOK_MAIN_TAB_LABELS)
+    ) = notebook_main_tabs()
 
     inject_main_tab_panel_top_compact_css()
 
@@ -121,6 +123,14 @@ def render_dashboard_shell(
         tab_country,
         tab_maint,
     )
+
+    with tab_social_cards:
+        if tab_social_cards.open:
+            st.subheader(SOCIAL_CARDS_TAB_LABEL)
+            st.caption(
+                "Card preview and export are wired in a follow-up batch. "
+                "Use the sidebar to configure period, layout, and theme."
+            )
 
     with tab_settings:
         render_settings_tab(

--- a/explorer/app/streamlit/app_main_tab_ui.py
+++ b/explorer/app/streamlit/app_main_tab_ui.py
@@ -1,0 +1,36 @@
+"""Main dashboard tab selection helpers (keyed ``st.tabs``)."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from explorer.app.streamlit.app_constants import STREAMLIT_MAIN_TAB_KEY
+from explorer.app.streamlit.streamlit_ui_constants import (
+    NOTEBOOK_MAIN_TAB_LABELS,
+    SOCIAL_CARDS_TAB_LABEL,
+)
+
+
+def active_main_tab_label() -> str:
+    """Return the active main-tab label from the keyed tab widget, with a safe default."""
+    raw = st.session_state.get(STREAMLIT_MAIN_TAB_KEY)
+    if isinstance(raw, str) and raw in NOTEBOOK_MAIN_TAB_LABELS:
+        return raw
+    return NOTEBOOK_MAIN_TAB_LABELS[0]
+
+
+def is_social_cards_main_tab() -> bool:
+    """True when the Social Cards main tab is selected."""
+    return active_main_tab_label() == SOCIAL_CARDS_TAB_LABEL
+
+
+def notebook_main_tabs(
+    *,
+    on_change: str = "rerun",
+) -> tuple:
+    """Keyed main tab row; active label stored in ``STREAMLIT_MAIN_TAB_KEY``."""
+    return st.tabs(
+        list(NOTEBOOK_MAIN_TAB_LABELS),
+        key=STREAMLIT_MAIN_TAB_KEY,
+        on_change=on_change,
+    )

--- a/explorer/app/streamlit/app_main_tab_ui.py
+++ b/explorer/app/streamlit/app_main_tab_ui.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import streamlit as st
 
 from explorer.app.streamlit.app_constants import STREAMLIT_MAIN_TAB_KEY
@@ -27,7 +29,7 @@ def is_social_cards_main_tab() -> bool:
 def notebook_main_tabs(
     *,
     on_change: str = "rerun",
-) -> tuple:
+) -> tuple[Any, ...]:
     """Keyed main tab row; active label stored in ``STREAMLIT_MAIN_TAB_KEY``."""
     return st.tabs(
         list(NOTEBOOK_MAIN_TAB_LABELS),

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -149,6 +149,7 @@ class MapWorkingContext:
 
 
 def _effective_map_style() -> str:
+    """Basemap key from session, falling back to saved/default when invalid."""
     saved_basemap = st.session_state.get(STREAMLIT_MAP_BASEMAP_SAVED_KEY, MAP_BASEMAP_OPTIONS[0])
     if saved_basemap not in MAP_BASEMAP_OPTIONS:
         saved_basemap = MAP_BASEMAP_OPTIONS[0]
@@ -159,6 +160,7 @@ def _effective_map_style() -> str:
 
 
 def _map_view_from_session() -> tuple[str, str, bool, bool]:
+    """Map view label/mode and lifer/family flags from session (legacy label migration)."""
     map_view_label = st.session_state.get(STREAMLIT_MAP_VIEW_LABEL_KEY, MAP_VIEW_LABELS[0])
     if map_view_label == "Selected species":
         map_view_label = "Species locations"
@@ -174,6 +176,7 @@ def _date_filter_from_session(
     is_lifer_view: bool,
     is_family_view: bool,
 ) -> tuple[bool, tuple | None]:
+    """Date-filter toggle and clamped range from session; disabled for lifer/family views."""
     if is_lifer_view or is_family_view:
         return False, None
     if STREAMLIT_MAP_DATE_FILTER_KEY not in st.session_state:
@@ -217,6 +220,7 @@ def render_map_sidebar(df_full: Any, *, work_df: Any) -> None:
                 key=STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY,
             )
         elif is_family_view:
+            # Family map view (v1): ignore date filter controls in the sidebar.
             pass
         else:
             if STREAMLIT_MAP_DATE_FILTER_KEY not in st.session_state:

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -46,6 +46,7 @@ from explorer.app.streamlit.app_constants import (
     STREAMLIT_TAXONOMY_LOCALE_KEY,
 )
 from explorer.app.streamlit.app_go_to_gps_ui import render_go_to_gps_sidebar_expander
+from explorer.app.streamlit.app_main_tab_ui import is_social_cards_main_tab
 from explorer.app.streamlit.app_map_ui import (
     ensure_streamlit_map_basemap_height_keys,
     ensure_streamlit_map_marker_colour_scheme_keys,
@@ -58,10 +59,14 @@ from explorer.app.streamlit.app_settings_state import (
     apply_pending_map_height_override,
     apply_pending_map_marker_colour_scheme,
 )
+from explorer.app.streamlit.app_social_cards_sidebar_ui import (
+    render_social_cards_main_sidebar,
+)
 from explorer.app.streamlit.defaults import (
     MAP_BASEMAP_LABELS,
     MAP_BASEMAP_OPTIONS,
     MAP_DATE_FILTER_DEFAULT,
+    MAP_HEIGHT_PX_DEFAULT,
     MAP_HEIGHT_PX_MAX,
     MAP_HEIGHT_PX_MIN,
     MAP_HEIGHT_PX_STEP,
@@ -143,29 +148,57 @@ class MapWorkingContext:
     family_colour_scheme: int
 
 
-def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
-    """Map sidebar widgets, working set + species search, Leaflet cache invalidation on All↔Species."""
-    ensure_streamlit_map_basemap_height_keys()
-    ensure_streamlit_map_marker_colour_scheme_keys()
+def _effective_map_style() -> str:
+    saved_basemap = st.session_state.get(STREAMLIT_MAP_BASEMAP_SAVED_KEY, MAP_BASEMAP_OPTIONS[0])
+    if saved_basemap not in MAP_BASEMAP_OPTIONS:
+        saved_basemap = MAP_BASEMAP_OPTIONS[0]
+    override = st.session_state.get(STREAMLIT_MAP_BASEMAP_KEY, saved_basemap)
+    if override not in MAP_BASEMAP_OPTIONS:
+        override = saved_basemap
+    return override
 
-    apply_pending_map_cluster_toggle(st.session_state)
-    apply_pending_map_basemap_override(st.session_state)
-    apply_pending_map_height_override(st.session_state)
-    apply_pending_map_marker_colour_scheme(st.session_state)
 
-    inject_spinner_theme_css()
+def _map_view_from_session() -> tuple[str, str, bool, bool]:
+    map_view_label = st.session_state.get(STREAMLIT_MAP_VIEW_LABEL_KEY, MAP_VIEW_LABELS[0])
+    if map_view_label == "Selected species":
+        map_view_label = "Species locations"
+    map_view_mode = MAP_VIEW_LABEL_TO_MODE.get(map_view_label, "all")
+    is_lifer_view = map_view_mode == "lifers"
+    is_family_view = map_view_mode == "families"
+    return map_view_label, map_view_mode, is_lifer_view, is_family_view
 
+
+def _date_filter_from_session(
+    df_full: Any,
+    *,
+    is_lifer_view: bool,
+    is_family_view: bool,
+) -> tuple[bool, tuple | None]:
+    if is_lifer_view or is_family_view:
+        return False, None
+    if STREAMLIT_MAP_DATE_FILTER_KEY not in st.session_state:
+        st.session_state[STREAMLIT_MAP_DATE_FILTER_KEY] = bool(
+            st.session_state.get(PERSIST_MAP_DATE_FILTER_KEY, MAP_DATE_FILTER_DEFAULT)
+        )
+    date_filter_on_effective = bool(st.session_state.get(STREAMLIT_MAP_DATE_FILTER_KEY, False))
+    if not date_filter_on_effective:
+        return False, None
+    d_inception, today = date_inception_to_today_default(df_full)
+    if STREAMLIT_MAP_DATE_RANGE_KEY not in st.session_state:
+        st.session_state[STREAMLIT_MAP_DATE_RANGE_KEY] = (d_inception, today)
+    rng = st.session_state[STREAMLIT_MAP_DATE_RANGE_KEY]
+    if not isinstance(rng, tuple) or len(rng) != 2:
+        return date_filter_on_effective, (d_inception, today)
+    r0 = max(min(rng[0], today), d_inception)
+    r1 = max(min(rng[1], today), d_inception)
+    date_range_sel = (r0, r1) if r0 <= r1 else (r1, r0)
+    return date_filter_on_effective, date_range_sel
+
+
+def render_map_sidebar(df_full: Any, *, work_df: Any) -> None:
+    """Map sidebar widgets only; map session keys persist when another main tab is active."""
     with st.sidebar:
         st.header("Map")
-        saved_basemap = st.session_state.get(STREAMLIT_MAP_BASEMAP_SAVED_KEY, MAP_BASEMAP_OPTIONS[0])
-        if saved_basemap not in MAP_BASEMAP_OPTIONS:
-            saved_basemap = MAP_BASEMAP_OPTIONS[0]
-        override = st.session_state.get(STREAMLIT_MAP_BASEMAP_KEY, saved_basemap)
-        if override not in MAP_BASEMAP_OPTIONS:
-            override = saved_basemap
-        map_style = override
-
-        # Renamed label (was "Selected species"); keep existing sessions valid.
         if st.session_state.get(STREAMLIT_MAP_VIEW_LABEL_KEY) == "Selected species":
             st.session_state[STREAMLIT_MAP_VIEW_LABEL_KEY] = "Species locations"
 
@@ -183,16 +216,11 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 "Show subspecies lifers",
                 key=STREAMLIT_LIFER_SHOW_SUBSPECIES_KEY,
             )
-            date_filter_on_effective = False
-            date_range_sel: tuple | None = None
         elif is_family_view:
-            # Family map view (v1): keep UI minimal; ignore date filter and clustering controls.
-            # We do **not** clear persisted date filter state; switching back restores prior picks.
-            date_filter_on_effective = False
-            date_range_sel = None
+            pass
         else:
             if STREAMLIT_MAP_DATE_FILTER_KEY not in st.session_state:
-                st.session_state.streamlit_map_date_filter = bool(
+                st.session_state[STREAMLIT_MAP_DATE_FILTER_KEY] = bool(
                     st.session_state.get(PERSIST_MAP_DATE_FILTER_KEY, MAP_DATE_FILTER_DEFAULT)
                 )
             if st.session_state.get(STREAMLIT_MAP_DATE_FILTER_KEY, False):
@@ -208,9 +236,7 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 "Date filter",
                 key=STREAMLIT_MAP_DATE_FILTER_KEY,
             )
-            if not date_filter_on_effective:
-                date_range_sel = None
-            else:
+            if date_filter_on_effective:
                 d_inception, today = date_inception_to_today_default(df_full)
                 if STREAMLIT_MAP_DATE_RANGE_KEY not in st.session_state:
                     st.session_state[STREAMLIT_MAP_DATE_RANGE_KEY] = (d_inception, today)
@@ -223,25 +249,26 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                     rng_val = (r0, r1) if r0 <= r1 else (r1, r0)
                     if rng_val != rng:
                         st.session_state[STREAMLIT_MAP_DATE_RANGE_KEY] = rng_val
-                dr = st.date_input(
+                st.date_input(
                     "Date range",
                     min_value=d_inception,
                     max_value=today,
                     key=STREAMLIT_MAP_DATE_RANGE_KEY,
                 )
-                if isinstance(dr, tuple) and len(dr) == 2:
-                    date_range_sel = (dr[0], dr[1])
-                else:
-                    date_range_sel = (d_inception, today)
-
                 if map_view_mode == "species":
                     st.caption(MAP_DATE_FILTER_SPECIES_SIGHTINGS_CAPTION)
                     st.caption(MAP_DATE_FILTER_SPECIES_MARKERS_CAPTION)
                 else:
                     st.caption(MAP_DATE_FILTER_ALL_LOCATIONS_CAPTION)
 
+            date_filter_on_effective = bool(st.session_state.get(STREAMLIT_MAP_DATE_FILTER_KEY, False))
+            date_range_sel = (
+                st.session_state.get(STREAMLIT_MAP_DATE_RANGE_KEY)
+                if date_filter_on_effective
+                else None
+            )
             st.session_state[PERSIST_MAP_DATE_FILTER_KEY] = date_filter_on_effective
-            if date_filter_on_effective and date_range_sel is not None:
+            if date_filter_on_effective and isinstance(date_range_sel, tuple) and len(date_range_sel) == 2:
                 st.session_state[PERSIST_MAP_DATE_RANGE_KEY] = date_range_sel
 
         if map_view_mode == "all":
@@ -251,24 +278,7 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 help="Groups nearby markers when zoomed out to reduce clutter.",
             )
 
-    # Working set is still date-filtered for checklist stats and other tabs.
-    # Family map ignores date filtering (v1), but we preserve the date filter controls and state.
-    _ws_mode = "all" if is_family_view else map_view_mode
-    ws, date_filter_banner = streamlit_working_set_and_status(
-        df_full,
-        map_view_mode=_ws_mode,
-        date_filter_on=date_filter_on_effective,
-        date_range=date_range_sel,
-    )
-    if ws is None:
-        st.error("Invalid date range. Using all-time data for this run.")
-        ws, date_filter_banner = streamlit_working_set_and_status(
-            df_full,
-            map_view_mode=map_view_mode,
-            date_filter_on=False,
-            date_range=None,
-        )
-    work_df = ws.df
+    _, map_view_mode, _, _ = _map_view_from_session()
 
     if map_view_mode == "all":
         with st.sidebar:
@@ -303,12 +313,164 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
                 )
             render_go_to_gps_sidebar_expander()
 
+    if map_view_mode == "species":
+        with st.sidebar:
+            st.markdown("**Species**")
+            species_searchbox_fragment()
+            if STREAMLIT_SPECIES_HIDE_ONLY_KEY not in st.session_state:
+                st.session_state[STREAMLIT_SPECIES_HIDE_ONLY_KEY] = MAP_SPECIES_HIDE_ONLY_DEFAULT
+            st.toggle(
+                "Show only selected species",
+                key=STREAMLIT_SPECIES_HIDE_ONLY_KEY,
+            )
+            with st.expander(SPECIES_SEARCH_HELP_EXPANDER_LABEL, expanded=False):
+                for _para in (p.strip() for p in SPECIES_SEARCH_CAPTION.split("\n\n")):
+                    if _para:
+                        st.caption(_para)
+            render_go_to_gps_sidebar_expander()
+
+    if map_view_mode in ("all", "families"):
+        from explorer.app.streamlit.app_caches import cached_family_map_bundle
+        from explorer.core.family_map_compute import (
+            filter_work_to_family,
+            highlight_species_choices_alphabetical,
+        )
+
+        with st.sidebar:
+            if map_view_mode == "families":
+                tax_loc = (
+                    str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
+                    or DEFAULT_TAXONOMY_LOCALE
+                )
+                bundle = cached_family_map_bundle(df_full, tax_loc)
+                fams = list(bundle.get("families") or ())
+                work = bundle.get("work")
+                base_to_common = bundle.get("base_to_common") or {}
+
+                st.selectbox(
+                    "Family",
+                    options=[""] + fams,
+                    format_func=lambda x: "— Select a family —" if x == "" else x,
+                    key=STREAMLIT_FAMILY_MAP_FAMILY_KEY,
+                )
+
+                family_name = st.session_state.get(STREAMLIT_FAMILY_MAP_FAMILY_KEY, "")
+                if family_name and isinstance(work, pd.DataFrame) and not work.empty:
+                    wf = filter_work_to_family(work, family_name)
+                    pairs = highlight_species_choices_alphabetical(wf, base_to_common)
+                    bases = [b for _lab, b in pairs]
+                    st.selectbox(
+                        "Highlight species (optional)",
+                        options=[""] + bases,
+                        format_func=lambda b: "— None —"
+                        if b == ""
+                        else (base_to_common.get(str(b).strip().lower()) or b),
+                        key=STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY,
+                    )
+                else:
+                    st.selectbox(
+                        "Highlight species (optional)",
+                        options=["— None —"],
+                        disabled=True,
+                        key=f"{STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY}__disabled",
+                    )
+
+    _scheme_preset_labels = {
+        1: MAP_MARKER_COLOUR_SCHEME_1.display_name,
+        2: MAP_MARKER_COLOUR_SCHEME_2.display_name,
+        3: MAP_MARKER_COLOUR_SCHEME_3.display_name,
+    }
+
+    with st.sidebar:
+        st.divider()
+        with st.expander("Basemap", expanded=False):
+            st.selectbox(
+                "Basemap",
+                options=list(MAP_BASEMAP_OPTIONS),
+                format_func=lambda k: MAP_BASEMAP_LABELS.get(k, k),
+                key=STREAMLIT_MAP_BASEMAP_KEY,
+                on_change=_on_basemap_changed,
+            )
+        with st.expander("Colour schemes", expanded=False):
+            st.radio(
+                "Map marker colour scheme",
+                options=[1, 2, 3],
+                format_func=lambda n: _scheme_preset_labels[int(n)],
+                key=STREAMLIT_MAP_MARKER_COLOUR_SCHEME_KEY,
+                on_change=invalidate_map_embed_cache,
+                width="stretch",
+            )
+        _src = str(st.session_state.get(SETTINGS_CONFIG_SOURCE_KEY, "") or "").strip()
+        _map_height_help = (
+            "Changes the map height for this session. Save a default in Settings if needed."
+            if settings_yaml_path_for_source(REPO_ROOT, _src)
+            else "Changes the map height."
+        )
+        st.slider(
+            "Map height (px)",
+            min_value=MAP_HEIGHT_PX_MIN,
+            max_value=MAP_HEIGHT_PX_MAX,
+            step=MAP_HEIGHT_PX_STEP,
+            key=STREAMLIT_MAP_HEIGHT_PX_KEY,
+            help=_map_height_help,
+        )
+
+    with st.sidebar:
+        render_explorer_perf_sidebar_panel()
+
+
+def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
+    """Sidebar (map or Social Cards) plus working-set resolution for all main tabs."""
+    ensure_streamlit_map_basemap_height_keys()
+    ensure_streamlit_map_marker_colour_scheme_keys()
+
+    apply_pending_map_cluster_toggle(st.session_state)
+    apply_pending_map_basemap_override(st.session_state)
+    apply_pending_map_height_override(st.session_state)
+    apply_pending_map_marker_colour_scheme(st.session_state)
+
+    social_cards_tab = is_social_cards_main_tab()
+    if social_cards_tab:
+        render_social_cards_main_sidebar(df_full)
+    else:
+        inject_spinner_theme_css()
+
+    map_style = _effective_map_style()
+    _map_view_label, map_view_mode, is_lifer_view, is_family_view = _map_view_from_session()
+    date_filter_on_effective, date_range_sel = _date_filter_from_session(
+        df_full,
+        is_lifer_view=is_lifer_view,
+        is_family_view=is_family_view,
+    )
+
+    _ws_mode = "all" if is_family_view else map_view_mode
+    ws, date_filter_banner = streamlit_working_set_and_status(
+        df_full,
+        map_view_mode=_ws_mode,
+        date_filter_on=date_filter_on_effective,
+        date_range=date_range_sel,
+    )
+    if ws is None:
+        st.error("Invalid date range. Using all-time data for this run.")
+        ws, date_filter_banner = streamlit_working_set_and_status(
+            df_full,
+            map_view_mode=map_view_mode,
+            date_filter_on=False,
+            date_range=None,
+        )
+    work_df = ws.df
+
+    if not social_cards_tab:
+        render_map_sidebar(df_full, work_df=work_df)
+
     hide_non_matching_locations = False
     species_pick_common: str | None = None
     species_pick_sci = ""
     family_name = ""
     family_highlight_base = ""
-    family_colour_scheme = 1
+    scheme_sel = st.session_state.get(STREAMLIT_MAP_MARKER_COLOUR_SCHEME_KEY, 1)
+    family_colour_scheme = int(scheme_sel if scheme_sel is not None else 1)
+    map_height = int(st.session_state.get(STREAMLIT_MAP_HEIGHT_PX_KEY, MAP_HEIGHT_PX_DEFAULT))
 
     _prev_mv = st.session_state.get(SESSION_PREV_MAP_VIEW_KEY)
     if map_view_mode == "species" and _prev_mv is not None and _prev_mv != "species":
@@ -318,8 +480,6 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         st.session_state.pop(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, None)
 
     if map_view_mode == "species":
-        # PICK is cleared when leaving species for All / Family / Lifers; PERSIST keeps the last
-        # species name for the map. Restore PICK so the map, search box, and persist stay aligned.
         if not st.session_state.get(SESSION_SPECIES_PICK_KEY):
             _pc = st.session_state.get(PERSIST_SPECIES_COMMON_KEY)
             if _pc:
@@ -344,21 +504,9 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             st.session_state[SESSION_SPECIES_IX_SIG_KEY] = _ix_sig
         st.session_state[SESSION_SPECIES_WS_KEY] = ws
 
-        with st.sidebar:
-            st.markdown("**Species**")
-            species_searchbox_fragment()
-            if STREAMLIT_SPECIES_HIDE_ONLY_KEY not in st.session_state:
-                st.session_state[STREAMLIT_SPECIES_HIDE_ONLY_KEY] = MAP_SPECIES_HIDE_ONLY_DEFAULT
-            hide_non_matching_locations = st.toggle(
-                "Show only selected species",
-                key=STREAMLIT_SPECIES_HIDE_ONLY_KEY,
-            )
-            with st.expander(SPECIES_SEARCH_HELP_EXPANDER_LABEL, expanded=False):
-                # Match Yearly Summary helper line (``st.caption`` for “Showing results…”).
-                for _para in (p.strip() for p in SPECIES_SEARCH_CAPTION.split("\n\n")):
-                    if _para:
-                        st.caption(_para)
-            render_go_to_gps_sidebar_expander()
+        hide_non_matching_locations = bool(
+            st.session_state.get(STREAMLIT_SPECIES_HIDE_ONLY_KEY, MAP_SPECIES_HIDE_ONLY_DEFAULT)
+        )
 
         species_pick_common = st.session_state.get(SESSION_SPECIES_PICK_KEY)
         if species_pick_common:
@@ -371,91 +519,10 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
     else:
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
 
-    if map_view_mode in ("all", "families"):
-        from explorer.app.streamlit.app_caches import cached_family_map_bundle
-        from explorer.core.family_map_compute import (
-            filter_work_to_family,
-            highlight_species_choices_alphabetical,
-        )
-
-        with st.sidebar:
-            if map_view_mode == "families":
-                tax_loc = (
-                    str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
-                    or DEFAULT_TAXONOMY_LOCALE
-                )
-                bundle = cached_family_map_bundle(df_full, tax_loc)
-                fams = list(bundle.get("families") or ())
-                work = bundle.get("work")
-                base_to_common = bundle.get("base_to_common") or {}
-
-                family_name = st.selectbox(
-                    "Family",
-                    options=[""] + fams,
-                    format_func=lambda x: "— Select a family —" if x == "" else x,
-                    key=STREAMLIT_FAMILY_MAP_FAMILY_KEY,
-                )
-
-                if family_name and isinstance(work, pd.DataFrame) and not work.empty:
-                    wf = filter_work_to_family(work, family_name)
-                    pairs = highlight_species_choices_alphabetical(wf, base_to_common)
-                    bases = [b for _lab, b in pairs]
-                    family_highlight_base = st.selectbox(
-                        "Highlight species (optional)",
-                        options=[""] + bases,
-                        format_func=lambda b: "— None —"
-                        if b == ""
-                        else (base_to_common.get(str(b).strip().lower()) or b),
-                        key=STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY,
-                    )
-                else:
-                    st.selectbox(
-                        "Highlight species (optional)",
-                        options=["— None —"],
-                        disabled=True,
-                        key=f"{STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY}__disabled",
-                    )
-                    family_highlight_base = ""
-
-    _scheme_preset_labels = {
-        1: MAP_MARKER_COLOUR_SCHEME_1.display_name,
-        2: MAP_MARKER_COLOUR_SCHEME_2.display_name,
-        3: MAP_MARKER_COLOUR_SCHEME_3.display_name,
-    }
-
-    with st.sidebar:
-        st.divider()
-        with st.expander("Basemap", expanded=False):
-            st.selectbox(
-                "Basemap",
-                options=list(MAP_BASEMAP_OPTIONS),
-                format_func=lambda k: MAP_BASEMAP_LABELS.get(k, k),
-                key=STREAMLIT_MAP_BASEMAP_KEY,
-                on_change=_on_basemap_changed,
-            )
-        with st.expander("Colour schemes", expanded=False):
-            _scheme_sel = st.radio(
-                "Map marker colour scheme",
-                options=[1, 2, 3],
-                format_func=lambda n: _scheme_preset_labels[int(n)],
-                key=STREAMLIT_MAP_MARKER_COLOUR_SCHEME_KEY,
-                on_change=invalidate_map_embed_cache,
-                width="stretch",
-            )
-            family_colour_scheme = int(_scheme_sel if _scheme_sel is not None else 1)
-        _src = str(st.session_state.get(SETTINGS_CONFIG_SOURCE_KEY, "") or "").strip()
-        _map_height_help = (
-            "Changes the map height for this session. Save a default in Settings if needed."
-            if settings_yaml_path_for_source(REPO_ROOT, _src)
-            else "Changes the map height."
-        )
-        map_height = st.slider(
-            "Map height (px)",
-            min_value=MAP_HEIGHT_PX_MIN,
-            max_value=MAP_HEIGHT_PX_MAX,
-            step=MAP_HEIGHT_PX_STEP,
-            key=STREAMLIT_MAP_HEIGHT_PX_KEY,
-            help=_map_height_help,
+    if map_view_mode == "families":
+        family_name = str(st.session_state.get(STREAMLIT_FAMILY_MAP_FAMILY_KEY, "") or "")
+        family_highlight_base = str(
+            st.session_state.get(STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY, "") or ""
         )
 
     prev_effective = st.session_state.get(SESSION_PREV_EFFECTIVE_BASEMAP_KEY)
@@ -464,17 +531,12 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         if not _all_locations_leaflet_embed_active(st.session_state):
             invalidate_map_embed_cache()
 
-    # Bump mount nonce when the view mode changes so the Leaflet component remounts with the new map.
-    # Leaflet payload LRU keys already include map_view_mode; do not clear export HTML here.
     if _prev_mv is not None and _prev_mv != map_view_mode:
         st.session_state[LEAFLET_MAP_MOUNT_NONCE_KEY] = int(
             st.session_state.get(LEAFLET_MAP_MOUNT_NONCE_KEY, 0)
         ) + 1
 
     st.session_state[SESSION_PREV_MAP_VIEW_KEY] = map_view_mode
-
-    with st.sidebar:
-        render_explorer_perf_sidebar_panel()
 
     return MapWorkingContext(
         map_style=map_style,
@@ -486,7 +548,7 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         species_pick_common=species_pick_common,
         species_pick_sci=species_pick_sci,
         map_height=map_height,
-        family_name=str(family_name or ""),
-        family_highlight_base=str(family_highlight_base or ""),
-        family_colour_scheme=int(family_colour_scheme),
+        family_name=family_name,
+        family_highlight_base=family_highlight_base,
+        family_colour_scheme=family_colour_scheme,
     )

--- a/explorer/app/streamlit/app_prep_map_ui.py
+++ b/explorer/app/streamlit/app_prep_map_ui.py
@@ -18,10 +18,12 @@ from explorer.app.streamlit.app_constants import (
     LEAFLET_EXPORT_BUILT_CACHE_KEY,
     LEAFLET_EXPORT_RECIPE_KEY,
 )
+from explorer.app.streamlit.app_main_tab_ui import is_social_cards_main_tab
 from explorer.app.streamlit.app_map_ui import (
     place_spinner_emoji_strip,
     sidebar_bottom_slot_end,
     sidebar_bottom_slot_start,
+    sidebar_footer_links,
 )
 from explorer.app.streamlit.app_prep_map_blank_viewport import (
     seed_blank_map_default_viewport_recipe,
@@ -167,5 +169,8 @@ def render_prep_spinner_and_map_tab(
         )
 
         _spinner_emoji_placeholder.empty()
-        render_prep_sidebar_after_map(map_height)
+        if is_social_cards_main_tab():
+            sidebar_footer_links(leading_divider=True)
+        else:
+            render_prep_sidebar_after_map(map_height)
         sidebar_bottom_slot_end()

--- a/explorer/app/streamlit/app_social_cards_sidebar_ui.py
+++ b/explorer/app/streamlit/app_social_cards_sidebar_ui.py
@@ -19,6 +19,7 @@ from explorer.app.streamlit.social_cards_sidebar_ui import (
 from explorer.core.share_summary_compute import (
     PeriodAnchor,
     ShareSummaryGeoScope,
+    ShareSummaryPeriod,
     filter_df_by_geo_scope,
     period_for_custom,
     period_for_lifetime,
@@ -27,6 +28,7 @@ from explorer.core.share_summary_compute import (
     suggest_period_anchor,
 )
 
+SOCIAL_CARDS_DF_SCOPED_SESSION_KEY = "_social_cards_df_scoped"
 SOCIAL_CARDS_GEO_SCOPE_SESSION_KEY = "_social_cards_geo_scope"
 SOCIAL_CARDS_SIDEBAR_SELECTION_KEY = "_social_cards_sidebar_selection"
 
@@ -127,13 +129,13 @@ def render_social_cards_main_sidebar(df_full: Any) -> None:
 
         # Batch 3 will resolve period + stats from session keys and scoped export.
         scoped = filter_df_by_geo_scope(df_full, geo_scope)
-        st.session_state["_social_cards_df_scoped"] = scoped
+        st.session_state[SOCIAL_CARDS_DF_SCOPED_SESSION_KEY] = scoped
 
 
 def resolve_social_cards_period_from_session(
     df_scoped: pd.DataFrame,
     keys: SocialCardsSessionKeys = APP_SOCIAL_CARDS_KEYS,
-) -> Any | None:
+) -> ShareSummaryPeriod | None:
     """Resolve the selected period object from sidebar session keys (for batch 3 wiring)."""
     if df_scoped is None or df_scoped.empty:
         return None
@@ -153,7 +155,7 @@ def resolve_social_cards_period_from_session(
         anchor: PeriodAnchor = st.session_state.get(keys.period_anchor, "current")
         return resolve_period("month", anchor=anchor, reference=reference)
     if period_mode == "week":
-        anchor = st.session_state.get(keys.period_anchor, "current")
+        anchor: PeriodAnchor = st.session_state.get(keys.period_anchor, "current")
         return resolve_period("week", anchor=anchor, reference=reference)
     if period_mode == "lifetime":
         return period_for_lifetime(min_d, max_d)

--- a/explorer/app/streamlit/app_social_cards_sidebar_ui.py
+++ b/explorer/app/streamlit/app_social_cards_sidebar_ui.py
@@ -1,0 +1,168 @@
+"""Social Cards sidebar for the main explorer app (tab-aware)."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pandas as pd
+import streamlit as st
+
+from explorer.app.streamlit.social_cards_session_keys import (
+    APP_SOCIAL_CARDS_KEYS,
+    SocialCardsSessionKeys,
+)
+from explorer.app.streamlit.social_cards_sidebar_ui import (
+    render_sidebar_card_controls,
+    render_sidebar_geo_scope_controls,
+)
+from explorer.core.share_summary_compute import (
+    PeriodAnchor,
+    ShareSummaryGeoScope,
+    filter_df_by_geo_scope,
+    period_for_custom,
+    period_for_lifetime,
+    period_for_year,
+    resolve_period,
+    suggest_period_anchor,
+)
+
+SOCIAL_CARDS_GEO_SCOPE_SESSION_KEY = "_social_cards_geo_scope"
+SOCIAL_CARDS_SIDEBAR_SELECTION_KEY = "_social_cards_sidebar_selection"
+
+
+def _card_heading_or_none(text: str) -> str | None:
+    stripped = (text or "").strip()
+    return stripped or None
+
+
+def _render_period_controls(
+    df: pd.DataFrame,
+    keys: SocialCardsSessionKeys,
+) -> None:
+    """Period pickers for session export (no sample-data toggle)."""
+    dates = pd.to_datetime(df["Date"], errors="coerce").dropna()
+    if dates.empty:
+        st.caption("No dated checklists in this export.")
+        return
+
+    min_d = dates.min().date()
+    max_d = dates.max().date()
+    reference = date.today()
+
+    period_mode = st.selectbox(
+        "Range",
+        options=["year", "month", "week", "custom", "lifetime"],
+        format_func=lambda x: {
+            "year": "Yearly",
+            "month": "Monthly",
+            "week": "Weekly",
+            "custom": "Custom date range",
+            "lifetime": "Lifetime",
+        }[x],
+        key=keys.period_mode,
+    )
+
+    if period_mode == "year":
+        st.number_input(
+            "Year",
+            min_value=2000,
+            max_value=2100,
+            value=date.today().year,
+            step=1,
+            key=keys.period_year,
+        )
+    elif period_mode in ("month", "week"):
+        default_anchor = suggest_period_anchor(period_mode, reference)
+        st.radio(
+            "Period",
+            options=["current", "previous"],
+            index=0 if default_anchor == "current" else 1,
+            format_func=lambda x: {
+                "current": f"Current {period_mode}",
+                "previous": f"Previous {period_mode}",
+            }[x],
+            help="Current vs previous calendar period (e.g. post May results on 2 June → previous month).",
+            key=keys.period_anchor,
+        )
+    elif period_mode == "custom":
+        st.date_input(
+            "Start date",
+            value=min_d,
+            min_value=min_d,
+            max_value=max_d,
+            key=keys.custom_start,
+        )
+        st.date_input(
+            "End date",
+            value=max_d,
+            min_value=min_d,
+            max_value=max_d,
+            key=keys.custom_end,
+        )
+        st.text_input(
+            "Card Heading (optional)",
+            value="",
+            placeholder="e.g. North Coast NSW Exploration",
+            key=keys.custom_card_heading,
+        )
+
+
+def render_social_cards_main_sidebar(df_full: Any) -> None:
+    """Social Cards sidebar block — period, geo scope, layout/format/theme."""
+    with st.sidebar:
+        keys = APP_SOCIAL_CARDS_KEYS
+        st.header("Social Cards")
+
+        st.subheader("Scope")
+        _render_period_controls(df_full, keys)
+
+        geo_scope = ShareSummaryGeoScope()
+        if df_full is not None and not df_full.empty:
+            geo_scope = render_sidebar_geo_scope_controls(df_full, keys)
+        st.session_state[SOCIAL_CARDS_GEO_SCOPE_SESSION_KEY] = geo_scope
+
+        selection = render_sidebar_card_controls(keys)
+        st.session_state[SOCIAL_CARDS_SIDEBAR_SELECTION_KEY] = selection
+
+        # Batch 3 will resolve period + stats from session keys and scoped export.
+        scoped = filter_df_by_geo_scope(df_full, geo_scope)
+        st.session_state["_social_cards_df_scoped"] = scoped
+
+
+def resolve_social_cards_period_from_session(
+    df_scoped: pd.DataFrame,
+    keys: SocialCardsSessionKeys = APP_SOCIAL_CARDS_KEYS,
+) -> Any | None:
+    """Resolve the selected period object from sidebar session keys (for batch 3 wiring)."""
+    if df_scoped is None or df_scoped.empty:
+        return None
+    dates = pd.to_datetime(df_scoped["Date"], errors="coerce").dropna()
+    if dates.empty:
+        return None
+
+    min_d = dates.min().date()
+    max_d = dates.max().date()
+    reference = date.today()
+    period_mode = st.session_state.get(keys.period_mode, "year")
+
+    if period_mode == "year":
+        selected_year = int(st.session_state.get(keys.period_year, date.today().year))
+        return period_for_year(selected_year)
+    if period_mode == "month":
+        anchor: PeriodAnchor = st.session_state.get(keys.period_anchor, "current")
+        return resolve_period("month", anchor=anchor, reference=reference)
+    if period_mode == "week":
+        anchor = st.session_state.get(keys.period_anchor, "current")
+        return resolve_period("week", anchor=anchor, reference=reference)
+    if period_mode == "lifetime":
+        return period_for_lifetime(min_d, max_d)
+    if period_mode == "custom":
+        start = st.session_state.get(keys.custom_start, min_d)
+        end = st.session_state.get(keys.custom_end, max_d)
+        if end < start:
+            start, end = end, start
+        heading = _card_heading_or_none(st.session_state.get(keys.custom_card_heading, ""))
+        return period_for_custom(start, end, trip_title=heading)
+
+    return period_for_year(int(st.session_state.get(keys.period_year, date.today().year)))

--- a/explorer/app/streamlit/social_cards_session_keys.py
+++ b/explorer/app/streamlit/social_cards_session_keys.py
@@ -50,6 +50,30 @@ class SocialCardsSessionKeys:
     def preview_scale(self) -> str:
         return f"{self.prefix}_preview_scale"
 
+    @property
+    def period_mode(self) -> str:
+        return f"{self.prefix}_period_mode"
+
+    @property
+    def period_year(self) -> str:
+        return f"{self.prefix}_period_year"
+
+    @property
+    def period_anchor(self) -> str:
+        return f"{self.prefix}_period_anchor"
+
+    @property
+    def custom_start(self) -> str:
+        return f"{self.prefix}_custom_start"
+
+    @property
+    def custom_end(self) -> str:
+        return f"{self.prefix}_custom_end"
+
+    @property
+    def custom_card_heading(self) -> str:
+        return f"{self.prefix}_custom_card_heading"
+
     def card_stat_picks(self, layout: LayoutId, period_kind: PeriodKind) -> str:
         return f"{self.prefix}_card_stat_picks_{layout}_{period_kind}"
 
@@ -87,3 +111,5 @@ class SocialCardsSessionKeys:
 
 
 DESIGN_SOCIAL_CARDS_KEYS = SocialCardsSessionKeys(prefix="design")
+
+APP_SOCIAL_CARDS_KEYS = SocialCardsSessionKeys(prefix="social_cards")

--- a/explorer/app/streamlit/streamlit_ui_constants.py
+++ b/explorer/app/streamlit/streamlit_ui_constants.py
@@ -55,6 +55,8 @@ MAP_DATE_FILTER_SPECIES_MARKERS_CAPTION = (
 # Main tab strip (``st.tabs`` order)
 # ---------------------------------------------------------------------------
 
+SOCIAL_CARDS_TAB_LABEL = "Social Cards"
+
 NOTEBOOK_MAIN_TAB_LABELS: tuple[str, ...] = (
     "Map",
     "Checklist Statistics",
@@ -62,6 +64,7 @@ NOTEBOOK_MAIN_TAB_LABELS: tuple[str, ...] = (
     "Bird Families",
     "Yearly Summary",
     "Country",
+    SOCIAL_CARDS_TAB_LABEL,
     "Maintenance",
     "Settings",
 )

--- a/tests/explorer/test_app_main_tab_ui.py
+++ b/tests/explorer/test_app_main_tab_ui.py
@@ -1,0 +1,50 @@
+"""Tests for main dashboard tab selection helpers."""
+
+from explorer.app.streamlit.app_constants import STREAMLIT_MAIN_TAB_KEY
+from explorer.app.streamlit.app_main_tab_ui import (
+    active_main_tab_label,
+    is_social_cards_main_tab,
+)
+from explorer.app.streamlit.streamlit_ui_constants import (
+    NOTEBOOK_MAIN_TAB_LABELS,
+    SOCIAL_CARDS_TAB_LABEL,
+)
+
+
+class _SessionState(dict):
+    def __getattr__(self, name: str):
+        return self[name]
+
+    def __setattr__(self, name: str, value) -> None:
+        self[name] = value
+
+
+def test_active_main_tab_label_defaults_to_map():
+    state = _SessionState()
+    import streamlit as st
+
+    original = st.session_state
+    try:
+        st.session_state = state  # type: ignore[misc]
+        assert active_main_tab_label() == "Map"
+    finally:
+        st.session_state = original  # type: ignore[misc]
+
+
+def test_active_main_tab_label_reads_keyed_tab_widget():
+    state = _SessionState({STREAMLIT_MAIN_TAB_KEY: SOCIAL_CARDS_TAB_LABEL})
+    import streamlit as st
+
+    original = st.session_state
+    try:
+        st.session_state = state  # type: ignore[misc]
+        assert active_main_tab_label() == SOCIAL_CARDS_TAB_LABEL
+        assert is_social_cards_main_tab() is True
+    finally:
+        st.session_state = original  # type: ignore[misc]
+
+
+def test_social_cards_tab_is_before_maintenance_and_settings():
+    labels = list(NOTEBOOK_MAIN_TAB_LABELS)
+    assert labels.index(SOCIAL_CARDS_TAB_LABEL) < labels.index("Maintenance")
+    assert labels[-1] == "Settings"

--- a/tests/explorer/test_app_main_tab_ui.py
+++ b/tests/explorer/test_app_main_tab_ui.py
@@ -1,9 +1,27 @@
 """Tests for main dashboard tab selection helpers."""
 
-from explorer.app.streamlit.app_constants import STREAMLIT_MAIN_TAB_KEY
+from datetime import date
+from types import SimpleNamespace
+
+import pandas as pd
+
+from explorer.app.streamlit import app_map_working_ui
+from explorer.app.streamlit.app_constants import (
+    STREAMLIT_MAIN_TAB_KEY,
+    STREAMLIT_MAP_HEIGHT_PX_KEY,
+    STREAMLIT_MAP_MARKER_COLOUR_SCHEME_KEY,
+    STREAMLIT_MAP_VIEW_LABEL_KEY,
+)
 from explorer.app.streamlit.app_main_tab_ui import (
     active_main_tab_label,
     is_social_cards_main_tab,
+)
+from explorer.app.streamlit.app_social_cards_sidebar_ui import (
+    resolve_social_cards_period_from_session,
+)
+from explorer.app.streamlit.social_cards_session_keys import (
+    APP_SOCIAL_CARDS_KEYS,
+    DESIGN_SOCIAL_CARDS_KEYS,
 )
 from explorer.app.streamlit.streamlit_ui_constants import (
     NOTEBOOK_MAIN_TAB_LABELS,
@@ -17,6 +35,12 @@ class _SessionState(dict):
 
     def __setattr__(self, name: str, value) -> None:
         self[name] = value
+
+
+def _install_session_state(monkeypatch, state: _SessionState) -> None:
+    import streamlit as st
+
+    monkeypatch.setattr(st, "session_state", state)
 
 
 def test_active_main_tab_label_defaults_to_map():
@@ -48,3 +72,160 @@ def test_social_cards_tab_is_before_maintenance_and_settings():
     labels = list(NOTEBOOK_MAIN_TAB_LABELS)
     assert labels.index(SOCIAL_CARDS_TAB_LABEL) < labels.index("Maintenance")
     assert labels[-1] == "Settings"
+
+
+def test_social_cards_tab_renders_social_sidebar_without_losing_map_working_set(monkeypatch):
+    state = _SessionState(
+        {
+            STREAMLIT_MAIN_TAB_KEY: SOCIAL_CARDS_TAB_LABEL,
+            STREAMLIT_MAP_VIEW_LABEL_KEY: "All locations",
+            STREAMLIT_MAP_HEIGHT_PX_KEY: 777,
+            STREAMLIT_MAP_MARKER_COLOUR_SCHEME_KEY: 2,
+        }
+    )
+    _install_session_state(monkeypatch, state)
+    calls: list[str] = []
+    work_df = pd.DataFrame({"Date": ["2025-01-01"], "Common Name": ["Apostlebird"]})
+
+    monkeypatch.setattr(
+        app_map_working_ui, "ensure_streamlit_map_basemap_height_keys", lambda: None
+    )
+    monkeypatch.setattr(
+        app_map_working_ui, "ensure_streamlit_map_marker_colour_scheme_keys", lambda: None
+    )
+    monkeypatch.setattr(app_map_working_ui, "apply_pending_map_cluster_toggle", lambda _state: None)
+    monkeypatch.setattr(app_map_working_ui, "apply_pending_map_basemap_override", lambda _state: None)
+    monkeypatch.setattr(app_map_working_ui, "apply_pending_map_height_override", lambda _state: None)
+    monkeypatch.setattr(app_map_working_ui, "apply_pending_map_marker_colour_scheme", lambda _state: None)
+    monkeypatch.setattr(
+        app_map_working_ui,
+        "render_social_cards_main_sidebar",
+        lambda _df: calls.append("social_sidebar"),
+    )
+    monkeypatch.setattr(
+        app_map_working_ui,
+        "render_map_sidebar",
+        lambda _df, *, work_df: calls.append("map_sidebar"),
+    )
+    monkeypatch.setattr(
+        app_map_working_ui,
+        "streamlit_working_set_and_status",
+        lambda _df, **_kwargs: (
+            SimpleNamespace(df=work_df, species_list=[], name_map={}),
+            "all-time",
+        ),
+    )
+
+    context = app_map_working_ui.render_map_sidebar_and_working_set(work_df)
+
+    assert calls == ["social_sidebar"]
+    assert context.work_df is work_df
+    assert context.map_view_mode == "all"
+    assert context.map_height == 777
+    assert state[STREAMLIT_MAP_VIEW_LABEL_KEY] == "All locations"
+
+
+def test_map_tab_renders_map_sidebar(monkeypatch):
+    state = _SessionState(
+        {
+            STREAMLIT_MAIN_TAB_KEY: "Map",
+            STREAMLIT_MAP_VIEW_LABEL_KEY: "All locations",
+            STREAMLIT_MAP_HEIGHT_PX_KEY: 640,
+            STREAMLIT_MAP_MARKER_COLOUR_SCHEME_KEY: 1,
+        }
+    )
+    _install_session_state(monkeypatch, state)
+    calls: list[str] = []
+    work_df = pd.DataFrame({"Date": ["2025-01-01"], "Common Name": ["Apostlebird"]})
+
+    monkeypatch.setattr(
+        app_map_working_ui, "ensure_streamlit_map_basemap_height_keys", lambda: None
+    )
+    monkeypatch.setattr(
+        app_map_working_ui, "ensure_streamlit_map_marker_colour_scheme_keys", lambda: None
+    )
+    monkeypatch.setattr(app_map_working_ui, "apply_pending_map_cluster_toggle", lambda _state: None)
+    monkeypatch.setattr(app_map_working_ui, "apply_pending_map_basemap_override", lambda _state: None)
+    monkeypatch.setattr(app_map_working_ui, "apply_pending_map_height_override", lambda _state: None)
+    monkeypatch.setattr(app_map_working_ui, "apply_pending_map_marker_colour_scheme", lambda _state: None)
+    monkeypatch.setattr(
+        app_map_working_ui, "inject_spinner_theme_css", lambda: calls.append("spinner_css")
+    )
+    monkeypatch.setattr(
+        app_map_working_ui,
+        "render_social_cards_main_sidebar",
+        lambda _df: calls.append("social_sidebar"),
+    )
+    monkeypatch.setattr(
+        app_map_working_ui,
+        "render_map_sidebar",
+        lambda _df, *, work_df: calls.append("map_sidebar"),
+    )
+    monkeypatch.setattr(
+        app_map_working_ui,
+        "streamlit_working_set_and_status",
+        lambda _df, **_kwargs: (
+            SimpleNamespace(df=work_df, species_list=[], name_map={}),
+            "all-time",
+        ),
+    )
+
+    app_map_working_ui.render_map_sidebar_and_working_set(work_df)
+
+    assert calls == ["spinner_css", "map_sidebar"]
+
+
+def test_app_social_cards_period_keys_do_not_collide_with_design_keys():
+    app_period_keys = {
+        APP_SOCIAL_CARDS_KEYS.period_mode,
+        APP_SOCIAL_CARDS_KEYS.period_year,
+        APP_SOCIAL_CARDS_KEYS.period_anchor,
+        APP_SOCIAL_CARDS_KEYS.custom_start,
+        APP_SOCIAL_CARDS_KEYS.custom_end,
+        APP_SOCIAL_CARDS_KEYS.custom_card_heading,
+    }
+    design_period_keys = {
+        DESIGN_SOCIAL_CARDS_KEYS.period_mode,
+        DESIGN_SOCIAL_CARDS_KEYS.period_year,
+        DESIGN_SOCIAL_CARDS_KEYS.period_anchor,
+        DESIGN_SOCIAL_CARDS_KEYS.custom_start,
+        DESIGN_SOCIAL_CARDS_KEYS.custom_end,
+        DESIGN_SOCIAL_CARDS_KEYS.custom_card_heading,
+    }
+
+    assert app_period_keys.isdisjoint(design_period_keys)
+    assert all(key.startswith("social_cards_") for key in app_period_keys)
+
+
+def test_resolve_social_cards_period_from_app_session_custom_range(monkeypatch):
+    state = _SessionState(
+        {
+            APP_SOCIAL_CARDS_KEYS.period_mode: "custom",
+            APP_SOCIAL_CARDS_KEYS.custom_start: date(2025, 6, 7),
+            APP_SOCIAL_CARDS_KEYS.custom_end: date(2025, 6, 1),
+            APP_SOCIAL_CARDS_KEYS.custom_card_heading: "  North Coast trip  ",
+        }
+    )
+    _install_session_state(monkeypatch, state)
+    df = pd.DataFrame({"Date": ["2025-06-01", "2025-06-07"]})
+
+    period = resolve_social_cards_period_from_session(df)
+
+    assert period is not None
+    assert period.kind == "custom"
+    assert period.start == date(2025, 6, 1)
+    assert period.end == date(2025, 6, 7)
+    assert period.trip_title == "North Coast trip"
+
+
+def test_resolve_social_cards_period_from_app_session_lifetime(monkeypatch):
+    state = _SessionState({APP_SOCIAL_CARDS_KEYS.period_mode: "lifetime"})
+    _install_session_state(monkeypatch, state)
+    df = pd.DataFrame({"Date": ["2023-03-15", "not a date", "2025-07-20"]})
+
+    period = resolve_social_cards_period_from_session(df)
+
+    assert period is not None
+    assert period.kind == "lifetime"
+    assert period.start == date(2023, 3, 15)
+    assert period.end == date(2025, 7, 20)


### PR DESCRIPTION
## Summary

- Adds a **Social Cards** main tab (before Maintenance) with a placeholder panel; card preview/export lands in batch 3–4.
- Sidebar switches between **map controls** and **Social Cards controls** based on the active main tab, using keyed `st.tabs` (`STREAMLIT_MAIN_TAB_KEY`).
- Map session state (basemap, view mode, species pick, date filter, etc.) is preserved when switching tabs.

## Changes

- `app_main_tab_ui.py` — keyed main tabs + `active_main_tab_label()` / `is_social_cards_main_tab()`
- `app_social_cards_sidebar_ui.py` — period, geo scope, layout/format/theme in `st.sidebar`
- `app_map_working_ui.py` — `render_map_sidebar()` extracted; gated by active tab
- `app_prep_map_ui.py` — hide map export chrome on Social Cards tab; keep footer links
- `APP_SOCIAL_CARDS_KEYS` session keys for app-scoped widgets
- Tests: `test_app_main_tab_ui.py`

## Testing

- [x] `python3 -m ruff check explorer/`
- [x] `python3 -m pytest tests/ -q` (824 passed)
- [x] Manual: Social Cards sidebar controls in left sidebar on Social Cards tab
- [x] Manual: Tab order … Country → Social Cards → Maintenance → Settings
- [x] Manual: Light pass on other tabs — no obvious regressions

## Issues

Refs #325

Parent: #323 (Social Cards port epic)

Made with [Cursor](https://cursor.com)