### PR TITLE
Wire Social Cards tab shell and period stats from session export

### DIFF
--- a/explorer/app/streamlit/app_dashboard_shell.py
+++ b/explorer/app/streamlit/app_dashboard_shell.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import streamlit as st
-
 from explorer.app.streamlit.app_bootstrap import TaxonomyPopupAssets
 from explorer.app.streamlit.app_landing_ui import title_with_logo
 from explorer.app.streamlit.app_main_tab_ui import notebook_main_tabs
@@ -26,8 +24,10 @@ from explorer.app.streamlit.maintenance_streamlit_html import (
 from explorer.app.streamlit.rankings_streamlit_html import (
     run_rankings_streamlit_tab_fragment,
 )
+from explorer.app.streamlit.social_cards_streamlit_html import (
+    run_social_cards_streamlit_tab_fragment,
+)
 from explorer.app.streamlit.streamlit_theme import inject_main_tab_panel_top_compact_css
-from explorer.app.streamlit.streamlit_ui_constants import SOCIAL_CARDS_TAB_LABEL
 from explorer.app.streamlit.yearly_summary_streamlit_html import (
     run_yearly_summary_streamlit_fragment,
 )
@@ -126,11 +126,7 @@ def render_dashboard_shell(
 
     with tab_social_cards:
         if tab_social_cards.open:
-            st.subheader(SOCIAL_CARDS_TAB_LABEL)
-            st.caption(
-                "Card preview and export are wired in a follow-up batch. "
-                "Use the sidebar to configure period, layout, and theme."
-            )
+            run_social_cards_streamlit_tab_fragment(df_full)
 
     with tab_settings:
         render_settings_tab(

--- a/explorer/app/streamlit/app_dashboard_shell.py
+++ b/explorer/app/streamlit/app_dashboard_shell.py
@@ -125,6 +125,8 @@ def render_dashboard_shell(
     )
 
     with tab_social_cards:
+        # Lazy-mount: period stats run only when this tab is selected (other data tabs
+        # always enter their ``@st.fragment`` blocks on every full rerun).
         if tab_social_cards.open:
             run_social_cards_streamlit_tab_fragment(df_full)
 

--- a/explorer/app/streamlit/app_social_cards_sidebar_ui.py
+++ b/explorer/app/streamlit/app_social_cards_sidebar_ui.py
@@ -127,7 +127,6 @@ def render_social_cards_main_sidebar(df_full: Any) -> None:
         selection = render_sidebar_card_controls(keys)
         st.session_state[SOCIAL_CARDS_SIDEBAR_SELECTION_KEY] = selection
 
-        # Batch 3 will resolve period + stats from session keys and scoped export.
         scoped = filter_df_by_geo_scope(df_full, geo_scope)
         st.session_state[SOCIAL_CARDS_DF_SCOPED_SESSION_KEY] = scoped
 

--- a/explorer/app/streamlit/app_social_cards_sidebar_ui.py
+++ b/explorer/app/streamlit/app_social_cards_sidebar_ui.py
@@ -132,10 +132,10 @@ def render_social_cards_main_sidebar(df_full: Any) -> None:
 
 
 def resolve_social_cards_period_from_session(
-    df_scoped: pd.DataFrame,
+    df_scoped: pd.DataFrame | None,
     keys: SocialCardsSessionKeys = APP_SOCIAL_CARDS_KEYS,
 ) -> ShareSummaryPeriod | None:
-    """Resolve the selected period object from sidebar session keys (for batch 3 wiring)."""
+    """Resolve the selected period object from sidebar session keys."""
     if df_scoped is None or df_scoped.empty:
         return None
     dates = pd.to_datetime(df_scoped["Date"], errors="coerce").dropna()
@@ -150,12 +150,9 @@ def resolve_social_cards_period_from_session(
     if period_mode == "year":
         selected_year = int(st.session_state.get(keys.period_year, date.today().year))
         return period_for_year(selected_year)
-    if period_mode == "month":
+    if period_mode in ("month", "week"):
         anchor: PeriodAnchor = st.session_state.get(keys.period_anchor, "current")
-        return resolve_period("month", anchor=anchor, reference=reference)
-    if period_mode == "week":
-        anchor: PeriodAnchor = st.session_state.get(keys.period_anchor, "current")
-        return resolve_period("week", anchor=anchor, reference=reference)
+        return resolve_period(period_mode, anchor=anchor, reference=reference)
     if period_mode == "lifetime":
         return period_for_lifetime(min_d, max_d)
     if period_mode == "custom":
@@ -163,7 +160,11 @@ def resolve_social_cards_period_from_session(
         end = st.session_state.get(keys.custom_end, max_d)
         if end < start:
             start, end = end, start
-        heading = _card_heading_or_none(st.session_state.get(keys.custom_card_heading, ""))
+        heading = _card_heading_or_none(
+            st.session_state.get(keys.custom_card_heading, "")
+        )
         return period_for_custom(start, end, trip_title=heading)
 
-    return period_for_year(int(st.session_state.get(keys.period_year, date.today().year)))
+    return period_for_year(
+        int(st.session_state.get(keys.period_year, date.today().year))
+    )

--- a/explorer/app/streamlit/bird_families_streamlit_html.py
+++ b/explorer/app/streamlit/bird_families_streamlit_html.py
@@ -26,6 +26,10 @@ from explorer.app.streamlit.defaults import (
 )
 from explorer.app.streamlit.perf_instrumentation import perf_fragment
 from explorer.app.streamlit.streamlit_theme import inject_streamlit_checklist_css
+from explorer.core.share_summary_compute import (
+    GROUP_COVERAGE_SUMMARY_KEY,
+    WORLD_SPECIES_COVERAGE_METRICS_KEY,
+)
 from explorer.core.species_family import (
     assign_group_for_taxon_order,
     load_taxonomy_groups,
@@ -42,10 +46,8 @@ logger = logging.getLogger(__name__)
 _STREAMLIT_TABLE_SCOPE = "streamlit-checklist-html-ab"
 _RANKINGS_SCOPE_EXTRA = "streamlit-rankings-html"
 
-GROUP_COVERAGE_SUMMARY_KEY = "group_coverage_summary"
 GROUP_COVERAGE_DETAIL_KEY = "group_coverage_detail"
 GROUP_COVERAGE_ERROR_KEY = "group_coverage_error"
-WORLD_SPECIES_COVERAGE_METRICS_KEY = "world_species_coverage_metrics"
 WORLD_SPECIES_COVERAGE_SECTION_KEY = "world_species_coverage_section"
 _STREAMLIT_GROUP_COVERAGE_SELECTED_KEY = "streamlit_group_coverage_selected_group"
 _STREAMLIT_GROUP_COVERAGE_TABLE_KEY = "streamlit_group_coverage_summary_table"

--- a/explorer/app/streamlit/social_cards_streamlit_helpers.py
+++ b/explorer/app/streamlit/social_cards_streamlit_helpers.py
@@ -2,21 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-import pandas as pd
-
-from explorer.app.streamlit.bird_families_streamlit_html import (
-    GROUP_COVERAGE_SUMMARY_KEY,
-    WORLD_SPECIES_COVERAGE_METRICS_KEY,
-)
 from explorer.core.share_summary_compute import (
     PeriodKind,
-    ShareSummaryAllTimeStats,
     ShareSummaryGeoScope,
-    ShareSummaryPeriod,
     ShareSummaryStats,
-    compute_share_summary_stats,
 )
 from explorer.presentation.share_summary_circles_preview import (
     TILES_CIRCLE_CLUSTER_DEFAULT,
@@ -71,74 +60,6 @@ def card_stat_data_scope_from_design_source(
 def period_has_checklist_data(stats: ShareSummaryStats) -> bool:
     """False when the selected period has no checklists in the loaded export."""
     return stats.checklists is not None and stats.checklists > 0
-
-
-def all_time_stats_from_rankings_bundle(
-    bundle: dict[str, Any] | None,
-) -> ShareSummaryAllTimeStats | None:
-    """Build taxonomy denominators from the rankings/families prep bundle (no re-merge)."""
-    if not bundle:
-        return None
-
-    observed: int | None = None
-    total_sp: int | None = None
-    pct: float | None = None
-    world = bundle.get(WORLD_SPECIES_COVERAGE_METRICS_KEY)
-    if isinstance(world, tuple) and len(world) == 3:
-        observed, total_sp, pct = world
-
-    total_families: int | None = None
-    observed_families: int | None = None
-    summary = bundle.get(GROUP_COVERAGE_SUMMARY_KEY)
-    if isinstance(summary, pd.DataFrame) and not summary.empty:
-        total_families = int(summary["group_name"].nunique())
-        if "seen_species" in summary.columns:
-            seen = pd.to_numeric(summary["seen_species"], errors="coerce").fillna(0)
-            observed_families = int((seen > 0).sum())
-
-    if all(
-        value is None
-        for value in (
-            observed,
-            total_sp,
-            pct,
-            total_families,
-            observed_families,
-        )
-    ):
-        return None
-
-    return ShareSummaryAllTimeStats(
-        total_species_taxa=total_sp,
-        total_families_taxa=total_families,
-        observed_species_taxa=observed,
-        observed_families=observed_families,
-        world_bird_coverage_pct=pct,
-    )
-
-
-def resolve_social_cards_stats(
-    *,
-    df_full: pd.DataFrame,
-    df_scoped: pd.DataFrame,
-    period: ShareSummaryPeriod,
-    geo_scope: ShareSummaryGeoScope,
-    rankings_bundle: dict[str, Any] | None,
-) -> tuple[ShareSummaryStats | None, ShareSummaryAllTimeStats | None]:
-    """Period stats from scoped export; all-time taxonomy rows from the shared prep bundle."""
-    lifer_ref = df_full if not geo_scope.is_world else None
-    stats = compute_share_summary_stats(
-        df_scoped,
-        period,
-        lifer_reference_df=lifer_ref,
-        geo_scope=geo_scope,
-    )
-    all_time = (
-        all_time_stats_from_rankings_bundle(rankings_bundle)
-        if geo_scope.is_world
-        else None
-    )
-    return stats, all_time
 
 
 def tiles_circle_cluster_picker(
@@ -269,6 +190,7 @@ def resolve_card_stat_selectbox_value(
 
 
 def status_metrics_lookup(status_metrics: list[tuple[str, str]]) -> dict[str, str]:
+    """Map stat label to display value from status_metrics rows."""
     return dict(status_metrics)
 
 

--- a/explorer/app/streamlit/social_cards_streamlit_helpers.py
+++ b/explorer/app/streamlit/social_cards_streamlit_helpers.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import pandas as pd
+
+from explorer.app.streamlit.bird_families_streamlit_html import (
+    GROUP_COVERAGE_SUMMARY_KEY,
+    WORLD_SPECIES_COVERAGE_METRICS_KEY,
+)
 from explorer.core.share_summary_compute import (
     PeriodKind,
+    ShareSummaryAllTimeStats,
     ShareSummaryGeoScope,
+    ShareSummaryPeriod,
     ShareSummaryStats,
+    compute_share_summary_stats,
 )
 from explorer.presentation.share_summary_circles_preview import (
     TILES_CIRCLE_CLUSTER_DEFAULT,
@@ -60,6 +71,74 @@ def card_stat_data_scope_from_design_source(
 def period_has_checklist_data(stats: ShareSummaryStats) -> bool:
     """False when the selected period has no checklists in the loaded export."""
     return stats.checklists is not None and stats.checklists > 0
+
+
+def all_time_stats_from_rankings_bundle(
+    bundle: dict[str, Any] | None,
+) -> ShareSummaryAllTimeStats | None:
+    """Build taxonomy denominators from the rankings/families prep bundle (no re-merge)."""
+    if not bundle:
+        return None
+
+    observed: int | None = None
+    total_sp: int | None = None
+    pct: float | None = None
+    world = bundle.get(WORLD_SPECIES_COVERAGE_METRICS_KEY)
+    if isinstance(world, tuple) and len(world) == 3:
+        observed, total_sp, pct = world
+
+    total_families: int | None = None
+    observed_families: int | None = None
+    summary = bundle.get(GROUP_COVERAGE_SUMMARY_KEY)
+    if isinstance(summary, pd.DataFrame) and not summary.empty:
+        total_families = int(summary["group_name"].nunique())
+        if "seen_species" in summary.columns:
+            seen = pd.to_numeric(summary["seen_species"], errors="coerce").fillna(0)
+            observed_families = int((seen > 0).sum())
+
+    if all(
+        value is None
+        for value in (
+            observed,
+            total_sp,
+            pct,
+            total_families,
+            observed_families,
+        )
+    ):
+        return None
+
+    return ShareSummaryAllTimeStats(
+        total_species_taxa=total_sp,
+        total_families_taxa=total_families,
+        observed_species_taxa=observed,
+        observed_families=observed_families,
+        world_bird_coverage_pct=pct,
+    )
+
+
+def resolve_social_cards_stats(
+    *,
+    df_full: pd.DataFrame,
+    df_scoped: pd.DataFrame,
+    period: ShareSummaryPeriod,
+    geo_scope: ShareSummaryGeoScope,
+    rankings_bundle: dict[str, Any] | None,
+) -> tuple[ShareSummaryStats | None, ShareSummaryAllTimeStats | None]:
+    """Period stats from scoped export; all-time taxonomy rows from the shared prep bundle."""
+    lifer_ref = df_full if not geo_scope.is_world else None
+    stats = compute_share_summary_stats(
+        df_scoped,
+        period,
+        lifer_reference_df=lifer_ref,
+        geo_scope=geo_scope,
+    )
+    all_time = (
+        all_time_stats_from_rankings_bundle(rankings_bundle)
+        if geo_scope.is_world
+        else None
+    )
+    return stats, all_time
 
 
 def tiles_circle_cluster_picker(

--- a/explorer/app/streamlit/social_cards_streamlit_html.py
+++ b/explorer/app/streamlit/social_cards_streamlit_html.py
@@ -100,7 +100,7 @@ def render_social_cards_tab_content(
         render_social_cards_status_metrics(status_metrics)
 
     st.caption(
-        "Card preview and export are wired in the next batch. "
+        "Card preview and export are wired in batch 4. "
         "Use the sidebar to configure period, layout, and theme."
     )
 
@@ -113,18 +113,24 @@ def run_social_cards_streamlit_tab_fragment(df_full: Any) -> None:
             st.info("Load checklist data to use Social Cards.")
             return
 
-        df_scoped = st.session_state.get(SOCIAL_CARDS_DF_SCOPED_SESSION_KEY)
-        if (
-            df_scoped is None
-            or not isinstance(df_scoped, pd.DataFrame)
-            or df_scoped.empty
-        ):
-            st.info("Load checklist data to use Social Cards.")
-            return
-
         geo_scope = st.session_state.get(SOCIAL_CARDS_GEO_SCOPE_SESSION_KEY)
         if not isinstance(geo_scope, ShareSummaryGeoScope):
             geo_scope = ShareSummaryGeoScope()
+
+        df_scoped = st.session_state.get(SOCIAL_CARDS_DF_SCOPED_SESSION_KEY)
+        if df_scoped is None or not isinstance(df_scoped, pd.DataFrame):
+            st.info("Load checklist data to use Social Cards.")
+            return
+        if df_scoped.empty:
+            if not geo_scope.is_world:
+                scope_label = geo_scope_display_label(geo_scope)
+                st.info(
+                    f"No checklists in this export match **{scope_label}**. "
+                    "Try **World** or a different country/region in the sidebar."
+                )
+                return
+            st.info("Load checklist data to use Social Cards.")
+            return
 
         bundle = st.session_state.get(RANKING_LISTS_FAMILIES_BUNDLE_KEY)
         rankings_bundle = bundle if isinstance(bundle, dict) else None

--- a/explorer/app/streamlit/social_cards_streamlit_html.py
+++ b/explorer/app/streamlit/social_cards_streamlit_html.py
@@ -22,12 +22,13 @@ from explorer.app.streamlit.app_social_cards_sidebar_ui import (
 from explorer.app.streamlit.perf_instrumentation import perf_fragment
 from explorer.app.streamlit.social_cards_streamlit_helpers import (
     period_has_checklist_data,
-    resolve_social_cards_stats,
 )
 from explorer.app.streamlit.streamlit_ui_constants import SOCIAL_CARDS_TAB_LABEL
 from explorer.core.share_summary_compute import (
     ShareSummaryGeoScope,
     geo_scope_display_label,
+    resolve_social_cards_stats,
+    world_taxonomy_bundle_status,
 )
 from explorer.presentation.share_summary_preview import summary_status_metrics
 
@@ -80,7 +81,21 @@ def render_social_cards_tab_content(
             "Try **Previous month** (or another range) in the sidebar, or pick a period that includes your data."
         )
 
-    status_metrics = summary_status_metrics(stats, all_time=all_time, geo_scope=geo_scope)
+    if geo_scope.is_world:
+        tax_status = world_taxonomy_bundle_status(rankings_bundle)
+        if tax_status == "pending":
+            st.caption(
+                "Taxonomy reference stats are still loading — wait for checklist and "
+                "rankings prep to finish, then try again."
+            )
+        elif tax_status == "unavailable":
+            st.caption(
+                "Taxonomy reference stats unavailable (taxonomy data may not be loaded)."
+            )
+
+    status_metrics = summary_status_metrics(
+        stats, all_time=all_time, geo_scope=geo_scope
+    )
     with st.expander("Computed statistics", expanded=True):
         render_social_cards_status_metrics(status_metrics)
 
@@ -99,7 +114,11 @@ def run_social_cards_streamlit_tab_fragment(df_full: Any) -> None:
             return
 
         df_scoped = st.session_state.get(SOCIAL_CARDS_DF_SCOPED_SESSION_KEY)
-        if df_scoped is None or not isinstance(df_scoped, pd.DataFrame) or df_scoped.empty:
+        if (
+            df_scoped is None
+            or not isinstance(df_scoped, pd.DataFrame)
+            or df_scoped.empty
+        ):
             st.info("Load checklist data to use Social Cards.")
             return
 

--- a/explorer/app/streamlit/social_cards_streamlit_html.py
+++ b/explorer/app/streamlit/social_cards_streamlit_html.py
@@ -1,0 +1,118 @@
+"""
+**Social Cards** (Streamlit main tab): period-scoped stats wired from the session export.
+
+Card preview, stat picker, and PNG export are batch 4 (:mod:`explorer.app.streamlit.social_cards_streamlit_ui`).
+All-time taxonomy denominators reuse the rankings/families prep bundle — not
+:func:`~explorer.core.share_summary_compute.compute_share_summary_all_time_stats`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import streamlit as st
+
+from explorer.app.streamlit.app_constants import RANKING_LISTS_FAMILIES_BUNDLE_KEY
+from explorer.app.streamlit.app_social_cards_sidebar_ui import (
+    SOCIAL_CARDS_DF_SCOPED_SESSION_KEY,
+    SOCIAL_CARDS_GEO_SCOPE_SESSION_KEY,
+    resolve_social_cards_period_from_session,
+)
+from explorer.app.streamlit.perf_instrumentation import perf_fragment
+from explorer.app.streamlit.social_cards_streamlit_helpers import (
+    period_has_checklist_data,
+    resolve_social_cards_stats,
+)
+from explorer.app.streamlit.streamlit_ui_constants import SOCIAL_CARDS_TAB_LABEL
+from explorer.core.share_summary_compute import (
+    ShareSummaryGeoScope,
+    geo_scope_display_label,
+)
+from explorer.presentation.share_summary_preview import summary_status_metrics
+
+
+def render_social_cards_status_metrics(
+    status_metrics: list[tuple[str, str]],
+) -> None:
+    """Compact read-only metrics grid (batch 3 wiring; replaced by card preview in batch 4)."""
+    if not status_metrics:
+        st.caption("No statistics available for this period.")
+        return
+    cols = st.columns(min(4, len(status_metrics)))
+    for index, (label, value) in enumerate(status_metrics):
+        with cols[index % len(cols)]:
+            st.metric(label, value)
+
+
+def render_social_cards_tab_content(
+    *,
+    df_full: pd.DataFrame,
+    df_scoped: pd.DataFrame,
+    geo_scope: ShareSummaryGeoScope,
+    rankings_bundle: dict[str, Any] | None,
+) -> None:
+    """Social Cards main column — period stats and empty-period handling."""
+    st.subheader(SOCIAL_CARDS_TAB_LABEL)
+
+    period = resolve_social_cards_period_from_session(df_scoped)
+    if period is None:
+        st.caption("No dated checklists in this export.")
+        return
+
+    stats, all_time = resolve_social_cards_stats(
+        df_full=df_full,
+        df_scoped=df_scoped,
+        period=period,
+        geo_scope=geo_scope,
+        rankings_bundle=rankings_bundle,
+    )
+    if stats is None:
+        st.warning("Could not compute stats for this period.")
+        return
+
+    scope_label = geo_scope_display_label(geo_scope)
+    st.caption(f"**{stats.period_label}** · {scope_label}")
+
+    if not period_has_checklist_data(stats):
+        st.warning(
+            f"No checklists in **{stats.period_label}** in this export. "
+            "Try **Previous month** (or another range) in the sidebar, or pick a period that includes your data."
+        )
+
+    status_metrics = summary_status_metrics(stats, all_time=all_time, geo_scope=geo_scope)
+    with st.expander("Computed statistics", expanded=True):
+        render_social_cards_status_metrics(status_metrics)
+
+    st.caption(
+        "Card preview and export are wired in the next batch. "
+        "Use the sidebar to configure period, layout, and theme."
+    )
+
+
+@st.fragment
+def run_social_cards_streamlit_tab_fragment(df_full: Any) -> None:
+    """Partial reruns when Social Cards sidebar controls change."""
+    with perf_fragment("social_cards"):
+        if df_full is None or not isinstance(df_full, pd.DataFrame) or df_full.empty:
+            st.info("Load checklist data to use Social Cards.")
+            return
+
+        df_scoped = st.session_state.get(SOCIAL_CARDS_DF_SCOPED_SESSION_KEY)
+        if df_scoped is None or not isinstance(df_scoped, pd.DataFrame) or df_scoped.empty:
+            st.info("Load checklist data to use Social Cards.")
+            return
+
+        geo_scope = st.session_state.get(SOCIAL_CARDS_GEO_SCOPE_SESSION_KEY)
+        if not isinstance(geo_scope, ShareSummaryGeoScope):
+            geo_scope = ShareSummaryGeoScope()
+
+        bundle = st.session_state.get(RANKING_LISTS_FAMILIES_BUNDLE_KEY)
+        rankings_bundle = bundle if isinstance(bundle, dict) else None
+
+        render_social_cards_tab_content(
+            df_full=df_full,
+            df_scoped=df_scoped,
+            geo_scope=geo_scope,
+            rankings_bundle=rankings_bundle,
+        )

--- a/explorer/core/share_summary_compute.py
+++ b/explorer/core/share_summary_compute.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, timedelta
-from typing import Literal
+from typing import Any, Literal
 
 import pandas as pd
 
@@ -628,3 +628,89 @@ def compute_share_summary_all_time_stats(
         observed_families=observed_families,
         world_bird_coverage_pct=pct,
     )
+
+
+# Rankings + Bird Families prep bundle keys (``attach_group_coverage_to_bundle``).
+GROUP_COVERAGE_SUMMARY_KEY = "group_coverage_summary"
+WORLD_SPECIES_COVERAGE_METRICS_KEY = "world_species_coverage_metrics"
+
+WorldTaxonomyBundleStatus = Literal["ready", "pending", "unavailable"]
+
+
+def all_time_stats_from_rankings_bundle(
+    bundle: dict[str, Any] | None,
+) -> ShareSummaryAllTimeStats | None:
+    """Build taxonomy denominators from the rankings/families prep bundle (no re-merge)."""
+    if not bundle:
+        return None
+
+    observed: int | None = None
+    total_sp: int | None = None
+    pct: float | None = None
+    world = bundle.get(WORLD_SPECIES_COVERAGE_METRICS_KEY)
+    if isinstance(world, tuple) and len(world) == 3:
+        observed, total_sp, pct = world
+
+    total_families: int | None = None
+    observed_families: int | None = None
+    summary = bundle.get(GROUP_COVERAGE_SUMMARY_KEY)
+    if isinstance(summary, pd.DataFrame) and not summary.empty:
+        total_families = int(summary["group_name"].nunique())
+        if "seen_species" in summary.columns:
+            seen = pd.to_numeric(summary["seen_species"], errors="coerce").fillna(0)
+            observed_families = int((seen > 0).sum())
+
+    if all(
+        value is None
+        for value in (
+            observed,
+            total_sp,
+            pct,
+            total_families,
+            observed_families,
+        )
+    ):
+        return None
+
+    return ShareSummaryAllTimeStats(
+        total_species_taxa=total_sp,
+        total_families_taxa=total_families,
+        observed_species_taxa=observed,
+        observed_families=observed_families,
+        world_bird_coverage_pct=pct,
+    )
+
+
+def world_taxonomy_bundle_status(
+    bundle: dict[str, Any] | None,
+) -> WorldTaxonomyBundleStatus:
+    """Whether world-scope taxonomy reference rows can be read from the prep bundle."""
+    if bundle is None:
+        return "pending"
+    if all_time_stats_from_rankings_bundle(bundle) is not None:
+        return "ready"
+    return "unavailable"
+
+
+def resolve_social_cards_stats(
+    *,
+    df_full: pd.DataFrame,
+    df_scoped: pd.DataFrame,
+    period: ShareSummaryPeriod,
+    geo_scope: ShareSummaryGeoScope,
+    rankings_bundle: dict[str, Any] | None,
+) -> tuple[ShareSummaryStats | None, ShareSummaryAllTimeStats | None]:
+    """Period stats from scoped export; all-time taxonomy rows from the shared prep bundle."""
+    lifer_ref = df_full if not geo_scope.is_world else None
+    stats = compute_share_summary_stats(
+        df_scoped,
+        period,
+        lifer_reference_df=lifer_ref,
+        geo_scope=geo_scope,
+    )
+    all_time = (
+        all_time_stats_from_rankings_bundle(rankings_bundle)
+        if geo_scope.is_world
+        else None
+    )
+    return stats, all_time

--- a/tests/explorer/test_social_cards_data_wiring.py
+++ b/tests/explorer/test_social_cards_data_wiring.py
@@ -1,0 +1,108 @@
+"""Tests for Social Cards tab shell data wiring (#326)."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from explorer.app.streamlit import bird_families_streamlit_html as bf
+from explorer.app.streamlit.social_cards_streamlit_helpers import (
+    all_time_stats_from_rankings_bundle,
+    resolve_social_cards_stats,
+)
+from explorer.core.share_summary_compute import (
+    ShareSummaryGeoScope,
+    period_for_year,
+)
+
+
+def test_all_time_stats_from_rankings_bundle_reads_world_and_family_keys():
+    summary = pd.DataFrame(
+        {
+            "group_name": ["Waterfowl", "Parrots"],
+            "seen_species": [3, 0],
+            "total_species": [10, 8],
+            "percent_seen": [30.0, 0.0],
+        }
+    )
+    bundle = {
+        bf.WORLD_SPECIES_COVERAGE_METRICS_KEY: (42, 10_800, 0.39),
+        bf.GROUP_COVERAGE_SUMMARY_KEY: summary,
+    }
+
+    all_time = all_time_stats_from_rankings_bundle(bundle)
+
+    assert all_time is not None
+    assert all_time.observed_species_taxa == 42
+    assert all_time.total_species_taxa == 10_800
+    assert all_time.world_bird_coverage_pct == 0.39
+    assert all_time.total_families_taxa == 2
+    assert all_time.observed_families == 1
+
+
+def test_all_time_stats_from_rankings_bundle_empty_returns_none():
+    assert all_time_stats_from_rankings_bundle(None) is None
+    assert all_time_stats_from_rankings_bundle({}) is None
+
+
+def test_resolve_social_cards_stats_uses_bundle_not_recompute(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "Date": ["2025-06-01", "2025-06-02"],
+            "Submission ID": ["s1", "s2"],
+            "Count": [1, 2],
+            "Common Name": ["Grey Teal", "Sulphur-crested Cockatoo"],
+            "Scientific Name": ["Anas gracilis", "Cacatua galerita"],
+        }
+    )
+    calls: list[str] = []
+
+    def _forbidden(*_args, **_kwargs):
+        calls.append("recompute")
+        raise AssertionError("must not re-run taxonomy merge")
+
+    monkeypatch.setattr(
+        "explorer.core.share_summary_compute.compute_share_summary_all_time_stats",
+        _forbidden,
+    )
+
+    bundle = {bf.WORLD_SPECIES_COVERAGE_METRICS_KEY: (1, 100, 1.0)}
+    stats, all_time = resolve_social_cards_stats(
+        df_full=df,
+        df_scoped=df,
+        period=period_for_year(2025),
+        geo_scope=ShareSummaryGeoScope(),
+        rankings_bundle=bundle,
+    )
+
+    assert calls == []
+    assert stats is not None
+    assert stats.checklists == 2
+    assert all_time is not None
+    assert all_time.total_species_taxa == 100
+
+
+def test_resolve_social_cards_stats_skips_all_time_when_geo_scoped():
+    df = pd.DataFrame(
+        {
+            "Date": ["2025-06-01"],
+            "Submission ID": ["s1"],
+            "Count": [1],
+            "Country": ["Australia"],
+            "State/Province": ["New South Wales"],
+            "Common Name": ["Grey Teal"],
+            "Scientific Name": ["Anas gracilis"],
+        }
+    )
+    bundle = {bf.WORLD_SPECIES_COVERAGE_METRICS_KEY: (1, 100, 1.0)}
+    scope = ShareSummaryGeoScope(country_key="AU", region_code="NSW")
+
+    stats, all_time = resolve_social_cards_stats(
+        df_full=df,
+        df_scoped=df,
+        period=period_for_year(2025),
+        geo_scope=scope,
+        rankings_bundle=bundle,
+    )
+
+    assert stats is not None
+    assert all_time is None

--- a/tests/explorer/test_social_cards_data_wiring.py
+++ b/tests/explorer/test_social_cards_data_wiring.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import pandas as pd
 
 from explorer.app.streamlit import bird_families_streamlit_html as bf
-from explorer.app.streamlit.social_cards_streamlit_helpers import (
-    all_time_stats_from_rankings_bundle,
-    resolve_social_cards_stats,
-)
 from explorer.core.share_summary_compute import (
+    GROUP_COVERAGE_SUMMARY_KEY,
+    WORLD_SPECIES_COVERAGE_METRICS_KEY,
     ShareSummaryGeoScope,
+    all_time_stats_from_rankings_bundle,
     period_for_year,
+    resolve_social_cards_stats,
+    world_taxonomy_bundle_status,
 )
 
 
@@ -25,8 +26,8 @@ def test_all_time_stats_from_rankings_bundle_reads_world_and_family_keys():
         }
     )
     bundle = {
-        bf.WORLD_SPECIES_COVERAGE_METRICS_KEY: (42, 10_800, 0.39),
-        bf.GROUP_COVERAGE_SUMMARY_KEY: summary,
+        WORLD_SPECIES_COVERAGE_METRICS_KEY: (42, 10_800, 0.39),
+        GROUP_COVERAGE_SUMMARY_KEY: summary,
     }
 
     all_time = all_time_stats_from_rankings_bundle(bundle)
@@ -44,8 +45,10 @@ def test_all_time_stats_from_rankings_bundle_empty_returns_none():
     assert all_time_stats_from_rankings_bundle({}) is None
 
 
-def test_resolve_social_cards_stats_uses_bundle_not_recompute(monkeypatch):
-    df = pd.DataFrame(
+def test_resolve_social_cards_stats_uses_scoped_export_and_bundle_not_recompute(
+    monkeypatch,
+):
+    df_full = pd.DataFrame(
         {
             "Date": ["2025-06-01", "2025-06-02"],
             "Submission ID": ["s1", "s2"],
@@ -54,21 +57,27 @@ def test_resolve_social_cards_stats_uses_bundle_not_recompute(monkeypatch):
             "Scientific Name": ["Anas gracilis", "Cacatua galerita"],
         }
     )
+    df_scoped = df_full.iloc[[0]].copy()
     calls: list[str] = []
 
-    def _forbidden(*_args, **_kwargs):
-        calls.append("recompute")
+    def _forbidden(label: str):
+        calls.append(label)
         raise AssertionError("must not re-run taxonomy merge")
 
     monkeypatch.setattr(
         "explorer.core.share_summary_compute.compute_share_summary_all_time_stats",
-        _forbidden,
+        lambda *_args, **_kwargs: _forbidden("compute_share_summary_all_time_stats"),
+    )
+    monkeypatch.setattr(
+        bf,
+        "build_group_coverage_tables",
+        lambda *_args, **_kwargs: _forbidden("build_group_coverage_tables"),
     )
 
-    bundle = {bf.WORLD_SPECIES_COVERAGE_METRICS_KEY: (1, 100, 1.0)}
+    bundle = {WORLD_SPECIES_COVERAGE_METRICS_KEY: (1, 100, 1.0)}
     stats, all_time = resolve_social_cards_stats(
-        df_full=df,
-        df_scoped=df,
+        df_full=df_full,
+        df_scoped=df_scoped,
         period=period_for_year(2025),
         geo_scope=ShareSummaryGeoScope(),
         rankings_bundle=bundle,
@@ -76,7 +85,8 @@ def test_resolve_social_cards_stats_uses_bundle_not_recompute(monkeypatch):
 
     assert calls == []
     assert stats is not None
-    assert stats.checklists == 2
+    assert stats.checklists == 1
+    assert stats.species == 1
     assert all_time is not None
     assert all_time.total_species_taxa == 100
 
@@ -93,7 +103,7 @@ def test_resolve_social_cards_stats_skips_all_time_when_geo_scoped():
             "Scientific Name": ["Anas gracilis"],
         }
     )
-    bundle = {bf.WORLD_SPECIES_COVERAGE_METRICS_KEY: (1, 100, 1.0)}
+    bundle = {WORLD_SPECIES_COVERAGE_METRICS_KEY: (1, 100, 1.0)}
     scope = ShareSummaryGeoScope(country_key="AU", region_code="NSW")
 
     stats, all_time = resolve_social_cards_stats(
@@ -106,3 +116,16 @@ def test_resolve_social_cards_stats_skips_all_time_when_geo_scoped():
 
     assert stats is not None
     assert all_time is None
+
+
+def test_world_taxonomy_bundle_status_pending_when_bundle_missing():
+    assert world_taxonomy_bundle_status(None) == "pending"
+
+
+def test_world_taxonomy_bundle_status_ready_when_metrics_present():
+    bundle = {WORLD_SPECIES_COVERAGE_METRICS_KEY: (1, 100, 1.0)}
+    assert world_taxonomy_bundle_status(bundle) == "ready"
+
+
+def test_world_taxonomy_bundle_status_unavailable_when_bundle_empty():
+    assert world_taxonomy_bundle_status({}) == "unavailable"


### PR DESCRIPTION
## Summary

Batch 3 of epic #323 — adds the Social Cards main-tab fragment with period-scoped stats from the session export. All-time taxonomy rows reuse the rankings/families prep bundle instead of re-running `compute_share_summary_all_time_stats()`.

## Changes

- Add `social_cards_streamlit_html.py` — `@st.fragment` tab with period label, empty-period warning, and computed statistics expander (card preview deferred to batch 4)
- Add `all_time_stats_from_rankings_bundle()` and `resolve_social_cards_stats()` helpers for bundle reuse
- Wire fragment into `app_dashboard_shell.py` (replaces placeholder caption)

## Testing

- `python3 -m ruff check explorer/` — pass
- `python3 -m pytest tests/ -q` — 833 passed, 11 skipped
- `tests/explorer/test_social_cards_data_wiring.py` — bundle reuse guard (no second taxonomy merge)
- Manual: real export (~47k rows) with `EXPLORER_PERF=1` — `fragment.social_cards` ~133 ms vs cold `prep.cache_rankings_bundle` ~1,010 ms; no double merge

## Notes

- Card UI, stat picker, and PNG export remain out of scope (batch 4, #327)

Refs #326
Part of #323

Made with [Cursor](https://cursor.com)