### PR TITLE
Auto-approve low-risk Dependabot PRs after CI

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,169 @@
+# Auto-approve low-risk Dependabot PRs after Python CI succeeds.
+# See docs/development.md § Dependabot auto-approve.
+#
+# Uses pull_request_target so the workflow token can write reviews / enable
+# auto-merge (Dependabot-triggered pull_request runs get a read-only token).
+# This workflow never checks out or executes code from the PR head.
+
+name: Dependabot auto-approve
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: dependabot-auto-approve-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-approve:
+    name: Auto-approve low-risk Dependabot PR
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Evaluate update risk
+        id: risk
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          set -euo pipefail
+          case "${UPDATE_TYPE}" in
+            version-update:semver-patch|version-update:semver-minor)
+              echo "eligible=true" >> "${GITHUB_OUTPUT}"
+              echo "Update type ${UPDATE_TYPE} is eligible for auto-approve."
+              ;;
+            *)
+              echo "eligible=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping auto-approve: update-type=${UPDATE_TYPE:-<empty>} (majors and unknown types stay manual)."
+              ;;
+          esac
+
+      - name: Verify changed files are dependency-related only
+        if: steps.risk.outputs.eligible == 'true'
+        id: files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Conservative allowlist — anything else requires manual review.
+          allowed_regex='^(requirements(-[A-Za-z0-9._-]+)?\.txt|pyproject\.toml|uv\.lock|poetry\.lock|(.*/)?package(-lock)?\.json|\.github/workflows/[^/]+\.ya?ml)$'
+
+          mapfile -t changed_files < <(
+            gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate \
+              --jq '.[].filename'
+          )
+
+          if [[ ${#changed_files[@]} -eq 0 ]]; then
+            echo "eligible=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping auto-approve: PR reports no changed files."
+            exit 0
+          fi
+
+          unexpected=()
+          for path in "${changed_files[@]}"; do
+            if [[ ! "${path}" =~ ${allowed_regex} ]]; then
+              unexpected+=("${path}")
+            fi
+          done
+
+          if [[ ${#unexpected[@]} -gt 0 ]]; then
+            echo "eligible=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping auto-approve: unexpected paths:"
+            printf '  - %s\n' "${unexpected[@]}"
+            exit 0
+          fi
+
+          echo "eligible=true" >> "${GITHUB_OUTPUT}"
+          echo "All changed files are on the dependency allowlist:"
+          printf '  - %s\n' "${changed_files[@]}"
+
+      - name: Wait for Python CI
+        if: steps.risk.outputs.eligible == 'true' && steps.files.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Wait only for the "Python CI" workflow (tests.yml), not this job,
+          # so we do not deadlock on our own check.
+          echo "Waiting for Python CI on ${HEAD_SHA}..."
+          for _ in $(seq 1 90); do
+            run_json="$(
+              gh run list \
+                --workflow "Python CI" \
+                --commit "${HEAD_SHA}" \
+                --limit 1 \
+                --json status,conclusion,databaseId,url \
+                --jq '.[0] // empty'
+            )"
+
+            if [[ -z "${run_json}" ]]; then
+              echo "Python CI has not started yet; retrying..."
+              sleep 20
+              continue
+            fi
+
+            status="$(jq -r '.status' <<<"${run_json}")"
+            conclusion="$(jq -r '.conclusion // empty' <<<"${run_json}")"
+            url="$(jq -r '.url' <<<"${run_json}")"
+            echo "Python CI status=${status} conclusion=${conclusion:-none} (${url})"
+
+            if [[ "${status}" == "completed" ]]; then
+              if [[ "${conclusion}" == "success" ]]; then
+                echo "Python CI succeeded."
+                exit 0
+              fi
+              echo "::error::Python CI did not succeed (conclusion=${conclusion}). Not auto-approving."
+              exit 1
+            fi
+
+            sleep 20
+          done
+
+          echo "::error::Timed out waiting for Python CI (≈30 minutes)."
+          exit 1
+
+      - name: Approve and enable auto-merge
+        if: steps.risk.outputs.eligible == 'true' && steps.files.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          set -euo pipefail
+
+          review_decision="$(
+            gh pr view "${PR_URL}" --json reviewDecision --jq '.reviewDecision // empty'
+          )"
+          if [[ "${review_decision}" == "APPROVED" ]]; then
+            echo "PR already approved; skipping duplicate approval."
+          else
+            body="$(printf '%s\n' \
+              'Auto-approved low-risk Dependabot update after Python CI passed.' \
+              '' \
+              "- update-type: ${UPDATE_TYPE}" \
+              "- dependencies: ${DEPENDENCY_NAMES}" \
+              '' \
+              'Policy: patch/minor only; dependency-related files only; majors and unexpected paths stay manual. See docs/development.md.')"
+            gh pr review "${PR_URL}" --approve --body "${body}"
+            echo "Approved ${PR_URL}"
+          fi
+
+          if gh pr merge --auto --squash "${PR_URL}"; then
+            echo "Enabled auto-merge (squash) for ${PR_URL}"
+          else
+            echo "::warning::Could not enable auto-merge. Approval still stands — enable auto-merge in repo settings if desired."
+          fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,19 +81,19 @@ Patch releases within the same minor line (for example 3.12.3 vs 3.12.7) are fin
 
 ## Dependabot auto-approve
 
-Low-risk Dependabot PRs can be approved (and auto-merged) by GitHub Actions — not by Cursor or other AI tools. Workflow: [`.github/workflows/dependabot-auto-approve.yml`](../.github/workflows/dependabot-auto-approve.yml). Dependabot config: [`.github/dependabot.yml`](../.github/dependabot.yml).
+Low-risk Dependabot PRs are approved (and auto-merged when enabled) by GitHub Actions — not by Cursor or other AI tools. Workflow: [`.github/workflows/dependabot-auto-approve.yml`](../.github/workflows/dependabot-auto-approve.yml). Dependabot config: [`.github/dependabot.yml`](../.github/dependabot.yml).
 
 ### What is auto-approved
 
 All of the following must hold:
 
-1. **Author** is `dependabot[bot]` (non-Dependabot PRs are ignored).
+1. **Author** is `dependabot[bot]`.
 2. **Update type** is patch or minor (`version-update:semver-patch` or `version-update:semver-minor` via `dependabot/fetch-metadata`). Grouped PRs use the highest semver change in the group.
 3. **Changed files** are only dependency-related paths:
    - `requirements.txt` / `requirements-*.txt`
    - `pyproject.toml`, `uv.lock`, `poetry.lock`
    - `package.json` / `package-lock.json` (any directory)
-   - `.github/workflows/*.yml` / `.yaml` (Action version pins)
+   - `.github/workflows/*.yml` / `.yaml` (GitHub Actions version pins)
 4. **Python CI** (`.github/workflows/tests.yml`) has completed **successfully** for the PR head SHA.
 
 When eligible, the workflow approves as `github-actions[bot]` and enables **squash auto-merge** (merge still waits on branch protection / required checks).
@@ -106,7 +106,7 @@ When eligible, the workflow approves as `github-actions[bot]` and enables **squa
 - Non-Dependabot pull requests
 - Anything that needs new secrets or broad new permissions (out of scope for this gate)
 
-AI summarisation of non-auto-approved Dependabot PRs is a possible later enhancement; it is **not** part of the approval decision path.
+**Note:** AI summarisation of non-auto-approved Dependabot PRs is a possible later enhancement; it is **not** part of the approval decision path.
 
 ### Permissions and safety notes
 
@@ -114,7 +114,7 @@ AI summarisation of non-auto-approved Dependabot PRs is a possible later enhance
 - Explicit permissions: `contents: write`, `pull-requests: write`, `actions: read`.
 - It never checks out or executes code from the PR head; it only inspects metadata, the PR file list, and Python CI status.
 - Repository **Settings → General → Pull Requests → Allow auto-merge** must be enabled for the auto-merge step to succeed. Approval still applies if auto-merge cannot be enabled.
-- If branch protection requires reviews from specific users/teams (or “approval of the most recent reviewable push”), a `GITHUB_TOKEN` approval may not satisfy those rules — use a fine-scoped PAT or GitHub App token only if you deliberately change the workflow for that.
+- If branch protection requires reviews from specific users/teams (or "approval of the most recent reviewable push"), a `GITHUB_TOKEN` approval may not satisfy those rules — use a fine-grained PAT or GitHub App token only if you deliberately change the workflow for that.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,6 +79,45 @@ Patch releases within the same minor line (for example 3.12.3 vs 3.12.7) are fin
 
 ---
 
+## Dependabot auto-approve
+
+Low-risk Dependabot PRs can be approved (and auto-merged) by GitHub Actions — not by Cursor or other AI tools. Workflow: [`.github/workflows/dependabot-auto-approve.yml`](../.github/workflows/dependabot-auto-approve.yml). Dependabot config: [`.github/dependabot.yml`](../.github/dependabot.yml).
+
+### What is auto-approved
+
+All of the following must hold:
+
+1. **Author** is `dependabot[bot]` (non-Dependabot PRs are ignored).
+2. **Update type** is patch or minor (`version-update:semver-patch` or `version-update:semver-minor` via `dependabot/fetch-metadata`). Grouped PRs use the highest semver change in the group.
+3. **Changed files** are only dependency-related paths:
+   - `requirements.txt` / `requirements-*.txt`
+   - `pyproject.toml`, `uv.lock`, `poetry.lock`
+   - `package.json` / `package-lock.json` (any directory)
+   - `.github/workflows/*.yml` / `.yaml` (Action version pins)
+4. **Python CI** (`.github/workflows/tests.yml`) has completed **successfully** for the PR head SHA.
+
+When eligible, the workflow approves as `github-actions[bot]` and enables **squash auto-merge** (merge still waits on branch protection / required checks).
+
+### What stays manual
+
+- Major version updates
+- Any PR that touches files outside the allowlist (including application code)
+- Failed or incomplete Python CI
+- Non-Dependabot pull requests
+- Anything that needs new secrets or broad new permissions (out of scope for this gate)
+
+AI summarisation of non-auto-approved Dependabot PRs is a possible later enhancement; it is **not** part of the approval decision path.
+
+### Permissions and safety notes
+
+- The workflow uses `pull_request_target` so it can write reviews / enable auto-merge (Dependabot-triggered `pull_request` workflows get a read-only `GITHUB_TOKEN`).
+- Explicit permissions: `contents: write`, `pull-requests: write`, `actions: read`.
+- It never checks out or executes code from the PR head; it only inspects metadata, the PR file list, and Python CI status.
+- Repository **Settings → General → Pull Requests → Allow auto-merge** must be enabled for the auto-merge step to succeed. Approval still applies if auto-merge cannot be enabled.
+- If branch protection requires reviews from specific users/teams (or “approval of the most recent reviewable push”), a `GITHUB_TOKEN` approval may not satisfy those rules — use a fine-scoped PAT or GitHub App token only if you deliberately change the workflow for that.
+
+---
+
 ## Leaflet map component (npm)
 
 Explorer’s Map tab uses a Streamlit custom component with **committed** compiled assets under `explorer/components/all_locations_map/frontend/build/` (so runtime does not require Node). After editing TypeScript/CSS in `frontend/src/`:


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically approves (and enables squash auto-merge for) low-risk Dependabot PRs after Python CI succeeds, reducing routine dependency-maintenance friction without AI in the approval path.

## Changes
- Add `.github/workflows/dependabot-auto-approve.yml`:
  - Runs on `pull_request_target` for Dependabot only
  - Approves patch/minor updates only (majors stay manual)
  - Requires dependency-related file allowlist only
  - Waits for Python CI success on the PR head before approving
  - Enables squash auto-merge when repo settings allow it
  - Uses minimal explicit permissions; does not check out PR head code
- Document behaviour and limits in `docs/development.md`

## Testing
- YAML parse check for the new workflow
- Lint/tests not run (no application Python changes)

## Notes
- Repository **Allow auto-merge** must be enabled for the auto-merge step; approval still applies without it
- If branch protection requires human reviewers, `github-actions[bot]` approval may not satisfy those rules

## Issues
Fixes #287

Made with [Cursor](https://cursor.com)