### PR TITLE
Clarify Streamlit defaults.py ownership

### DIFF
--- a/.cursor/rules/streamlit-ui-thin.mdc
+++ b/.cursor/rules/streamlit-ui-thin.mdc
@@ -18,7 +18,7 @@ Streamlit under `explorer/app/` is **UI only**. Business logic belongs in `explo
 
 **Before adding a literal number, colour, size, bound, or layout knob** in Streamlit or map UI code, ask: would a developer or technical end user want to tune this without reading implementation? If yes → put it in **`explorer/app/streamlit/defaults.py`** (named `UPPER_SNAKE_CASE` constant), then import it.
 
-There is no rigid taxonomy — use judgement. Typical `defaults.py` contents: map pin geometry, colours, opacities, cluster options, legend sizes, zoom/slider bounds, layout widths, debug toggles, active colour-scheme index. Feature-specific card/layout tunables may live in a `explorer/core/*_defaults.py` module (re-exported from `defaults.py` when Streamlit needs them).
+There is no rigid taxonomy — use judgement. Typical `defaults.py` contents: map pin geometry, colours, opacities, cluster options, legend sizes, zoom/slider bounds, layout widths, debug toggles, active colour-scheme index. Feature-specific card/layout tunables may live in an `explorer/core/*_defaults.py` module (re-exported from `defaults.py` when Streamlit needs them).
 
 | Kind | Location |
 |------|----------|

--- a/.cursor/rules/streamlit-ui-thin.mdc
+++ b/.cursor/rules/streamlit-ui-thin.mdc
@@ -22,12 +22,13 @@ There is no rigid taxonomy — use judgement. Typical `defaults.py` contents: ma
 
 | Kind | Location |
 |------|----------|
-| **Developer / technical-user tweakables** | `explorer/app/streamlit/defaults.py` |
-| Fixed product copy, tab labels, URLs | `explorer/app/streamlit/streamlit_ui_constants.py` |
+| **Developer / technical-user tweakables** (incl. map marker scheme presets) | `explorer/app/streamlit/defaults.py` |
+| Fixed product copy, tab labels, URLs, spinner *text* | `explorer/app/streamlit/streamlit_ui_constants.py` |
 | Persisted settings schema (YAML-backed) | `explorer/core/settings_schema_defaults.py` |
-| Feature tunables (e.g. share summary) | `explorer/core/*_defaults.py` → often re-exported via `defaults.py` |
+| Feature tunables (e.g. share summary) | `explorer/core/*_defaults.py` → re-exported via `defaults.py` as **façade only** |
+| Map marker scheme *dataclass shapes* | `explorer/core/map_marker_scheme_model.py` |
 
-Do not scatter magic numbers in `explorer/app/` — centralise tunables in `defaults.py` (or the matching `*_defaults.py`). See [`docs/AI_CONTEXT.md`](docs/AI_CONTEXT.md) § Configuration and [`docs/python-style-guide.md`](docs/python-style-guide.md) § Constants.
+Do not scatter magic numbers in `explorer/app/` — centralise tunables in `defaults.py` (or the matching `*_defaults.py`). Do not “own” re-exported schema/share-summary literals inside `defaults.py`. See [`docs/AI_CONTEXT.md`](docs/AI_CONTEXT.md) § Defaults and [`docs/python-style-guide.md`](docs/python-style-guide.md) § Constants.
 
 ## Design / playground apps
 

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -215,17 +215,17 @@ Do not duplicate HTML in UI code — use shared formatters.
 ### Defaults
 
 - **`explorer/data/basemaps.yaml`** — **Map basemaps** (keys, labels, tile URLs); loaded by `explorer/core/basemap_manifest.py`. Regenerate React assets with `python3 scripts/generate_basemap_assets.py`.
-- **`explorer/app/streamlit/defaults.py`** — **Developer tweakables**: map cluster options, pin **size / stroke / opacity**, legend dot sizes, theme hex, map height slider bounds, layout widths, temporary map debug (live zoom). Edit here to change look/behaviour without hunting core modules.
+- **`explorer/app/streamlit/defaults.py`** — **Developer tweakables** you edit for look/behaviour without hunting core modules: map cluster options, pin **size / stroke / opacity**, viewport/framing guards, **map marker colour scheme presets** (`MAP_MARKER_COLOUR_SCHEME_*`), theme hex, layout widths, cache sizes, temporary map debug (live zoom), spinner **theme CSS** cache-key suffix. Also a **re-export façade** for basemap labels/schema map-height bounds and share-summary defaults — those literals are **not** owned here (edit the defining module; section headers in the file label façade imports).
 
-- **Map marker design utility** — separate Streamlit app (not user-facing): `streamlit run explorer/app/streamlit/design_map_app.py`. Previews roles and exports scheme dicts; see [development.md](development.md#map-marker-colour-design-utility-developers).
+- **Map marker design utility** — separate Streamlit app (not user-facing): `streamlit run explorer/app/streamlit/design_map_app.py`. Previews roles and exports scheme dicts into `defaults.py`; dataclass shapes live in `explorer/core/map_marker_scheme_model.py`. See [development.md](development.md#map-marker-colour-design-utility-developers).
 
-- **`explorer/app/streamlit/streamlit_ui_constants.py`** — **Fixed UI content**: tab labels, species-search widget strings, spinner text and emoji list, export filename, sidebar footer URLs. Not “tweak colour/size” defaults.
+- **`explorer/app/streamlit/streamlit_ui_constants.py`** — **Fixed UI content**: tab labels, species-search widget strings, spinner **text** and emoji list, export filename, sidebar footer URLs. Not “tweak colour/size” defaults.
 - **Map HTML export UX** — Shipped one-click sidebar export; alternative two-button design and browser-risk notes: [docs/explorer/map-html-export-ux-alternative.md](explorer/map-html-export-ux-alternative.md) (use if users report export/download failures).
 
-- **`explorer/core/settings_schema_defaults.py`** — **Persisted YAML settings schema** defaults (tables, rankings bounds, taxonomy locale, maintenance distance, pin **colour** names allowed in settings).
-- **`explorer/core/share_summary_defaults.py`** — **Share-summary card** colour schemes and layout stat defaults (#157); re-exported from `defaults.py` for Streamlit tuning.
+- **`explorer/core/settings_schema_defaults.py`** — **Persisted YAML settings schema** defaults (tables, rankings bounds, taxonomy locale, maintenance distance, pin **colour** names allowed in settings). Owns `MAP_HEIGHT_PX_{MIN,MAX,DEFAULT}` and basemap default/options used by settings — re-exported from `defaults.py` as façade only.
+- **`explorer/core/share_summary_defaults.py`** — **Share-summary card** colour schemes and layout stat defaults (#157); re-exported from `defaults.py` for a single Streamlit import surface (no duplicate literals in `defaults.py`).
 
-Do not hardcode tunable numbers in UI files; use `defaults.py` (or the matching `explorer/core/*_defaults.py` module) for those.
+Do not hardcode tunable numbers in UI files; use `defaults.py` (or the matching `explorer/core/*_defaults.py` module) for those. Prefer clarifying comments/section headers over large file splits unless an issue explicitly moves a block.
 
 ---
 

--- a/docs/python-style-guide.md
+++ b/docs/python-style-guide.md
@@ -365,10 +365,14 @@ if zoom_level < 8:
 
 ### Where constants live
 
-- **Developer tweakables** (map/UI defaults): `explorer/app/streamlit/defaults.py`
+- **Developer tweakables** (map/UI defaults, marker colour scheme *literals*): `explorer/app/streamlit/defaults.py`
 - **Fixed UI strings**: `explorer/app/streamlit/streamlit_ui_constants.py`
 - **Persisted settings schema defaults**: `explorer/core/settings_schema_defaults.py`
+- **Feature-domain defaults** (e.g. share summary): `explorer/core/*_defaults.py` (often re-exported from `defaults.py` as façade only)
+- **Map marker scheme dataclasses** (shapes, not preset hex): `explorer/core/map_marker_scheme_model.py`
 - **Basemaps**: `explorer/data/basemaps.yaml`
+
+See `docs/AI_CONTEXT.md` § Defaults for ownership vs re-export rules.
 
 ---
 

--- a/explorer/app/streamlit/defaults.py
+++ b/explorer/app/streamlit/defaults.py
@@ -2,26 +2,44 @@
 Developer tweakables for the Streamlit explorer: **sizes, colours, layout bounds, and map behaviour**
 you may edit in one place without hunting through core modules.
 
-**What belongs here**
+**Owned here (edit literals in this file)**
 
 - Marker cluster options, pin **radius / stroke / opacities**, legend dot sizes, popup width
-- Map UI: basemap list/labels (from ``explorer/data/basemaps.yaml``), height slider bounds, view labels, date-filter default; **debug-only map toggles** registered in :func:`debug_defaults_enabled` for CI
-- Theme hex values aligned with ``.streamlit/config.toml``, settings panel width cap
-- Rankings HTML layout width / scroll hint default; spinner CSS cache key suffix when theme CSS changes
+- Map viewport / framing guards (``fit_bounds``, single-point zoom, focused quantiles, species blank view)
+- Map marker colour schemes (``MAP_MARKER_COLOUR_SCHEME_*``) — design-utility target; types live in
+  :mod:`explorer.core.map_marker_scheme_model`
+- Map UI knobs owned locally: height **step** / iframe floor, view labels, date-filter default,
+  session LRU sizes, bird-families dataframe height; **debug-only map toggles** registered in
+  :func:`debug_defaults_enabled` for CI
+- Theme hex values aligned with ``.streamlit/config.toml``, settings panel width cap, and
+  ``SPINNER_THEME_CSS_CACHE_KEY_SUFFIX`` (bump when spinner theme CSS in ``app_constants`` changes)
+- Rankings HTML layout width / scroll hint default; taxonomy coverage extinct-species flag
 
-**What does *not* belong here** (see other modules)
+**Façade only (re-exported; do not treat as owned here — no duplicate literals)**
 
-- **Fixed copy, URLs, emoji lists, tab names** → :mod:`explorer.app.streamlit.streamlit_ui_constants`
-- **Persisted YAML settings schema defaults** (tables, taxonomy locale ranges) →
+- Basemap labels → :mod:`explorer.core.basemap_manifest` / ``explorer/data/basemaps.yaml``
+- Basemap default / options and map height min/max/default → :mod:`explorer.core.settings_schema_defaults`
+- Share-summary schemes, layout stats, subtitles → :mod:`explorer.core.share_summary_defaults`
+
+**What does *not* belong here**
+
+- **Fixed copy, URLs, emoji lists, tab names, spinner *text*** →
+  :mod:`explorer.app.streamlit.streamlit_ui_constants`
+- **Persisted YAML settings schema defaults** (tables, taxonomy locale ranges, pin colour *names*) →
   :mod:`explorer.core.settings_schema_defaults`
+- **Scheme dataclass shapes** (field layout only) → :mod:`explorer.core.map_marker_scheme_model`
 
-Map code under ``explorer/`` imports cluster/pin/theme values from this module where noted in code.
+See ``docs/AI_CONTEXT.md`` § Defaults. Prefer sectioning and comments over large file splits.
 """
 
 from __future__ import annotations
 
+# ---------------------------------------------------------------------------
+# Re-export façade — owned elsewhere; imported here for a single Streamlit surface.
+# Do not add new literals in this block; edit the defining module instead.
+# ---------------------------------------------------------------------------
 from explorer.core.basemap_manifest import (
-    MAP_BASEMAP_LABELS,  # noqa: F401 — re-export for Streamlit UI
+    MAP_BASEMAP_LABELS,  # noqa: F401 — re-export; owned by basemap_manifest / basemaps.yaml
 )
 from explorer.core.map_marker_scheme_model import (
     MapMarkerAllLocationsStyle,
@@ -33,14 +51,14 @@ from explorer.core.map_marker_scheme_model import (
     MapMarkerSpeciesLocationsStyle,
     MapMarkerSpeciesMapBackgroundStyle,
 )
-from explorer.core.settings_schema_defaults import (  # noqa: F401 — re-export for Streamlit UI
+from explorer.core.settings_schema_defaults import (  # noqa: F401 — re-export; owned by settings schema
     MAP_BASEMAP_DEFAULT,
     MAP_BASEMAP_OPTIONS,
     MAP_HEIGHT_PX_DEFAULT,
     MAP_HEIGHT_PX_MAX,
     MAP_HEIGHT_PX_MIN,
 )
-from explorer.core.share_summary_defaults import (  # noqa: F401 — re-export for Streamlit UI
+from explorer.core.share_summary_defaults import (  # noqa: F401 — re-export; owned by share_summary_defaults
     SHARE_SUMMARY_COLOR_SCHEME_INDEX_DEFAULT,
     SHARE_SUMMARY_COLOR_SCHEMES,
     SHARE_SUMMARY_FOUR_STAT_DEFAULT_STATS,
@@ -161,8 +179,9 @@ MAP_SPECIES_HIDE_ONLY_DEFAULT = True
 MAP_VIEW_LABELS: tuple[str, ...] = ("All locations", "Species locations", "Lifer locations", "Family locations")
 
 # ---------------------------------------------------------------------------
-# Map marker colour schemes (Leaflet circle markers)
-#
+# Map marker colour schemes — owned here (design utility exports into this block).
+# Dataclass shapes: ``map_marker_scheme_model``. Do not duplicate in core.
+# ---------------------------------------------------------------------------
 # Fallback when a scheme has no ``global_defaults.radius_px`` (design utility / migration).
 MAP_MARKER_CIRCLE_RADIUS_PX_FALLBACK = 2
 # Design-utility sliders and pasted preset values clamp to this max; you can set higher radii by
@@ -202,10 +221,8 @@ MAP_MARKER_CLUSTER_HALO_OPACITY_DEFAULT = 0.6
 MAP_MARKER_CLUSTER_BORDER_OPACITY_DEFAULT = 1.0
 MAP_MARKER_CLUSTER_HALO_SPREAD_PX_DEFAULT = 6
 MAP_MARKER_CLUSTER_BORDER_WIDTH_PX_DEFAULT = 2
-#
-# Three presets. Family-map sidebar radio selects the active scheme;
+# Three production presets. Family-map sidebar radio selects the active scheme;
 # ``MAP_MARKER_ACTIVE_COLOUR_SCHEME`` is the default when no UI index is passed (tests).
-# ---------------------------------------------------------------------------
 
 MAP_MARKER_COLOUR_SCHEME_1 = MapMarkerColourScheme(
     display_name='Eucalypt',
@@ -422,7 +439,7 @@ def active_map_marker_colour_scheme(scheme_index: int | None = None) -> MapMarke
 
 
 # ---------------------------------------------------------------------------
-# Layout / theme (Streamlit-only)
+# Layout / theme (Streamlit-only; owned here)
 # ---------------------------------------------------------------------------
 
 SETTINGS_PANEL_MAX_WIDTH_REM = 40
@@ -434,6 +451,8 @@ THEME_MAIN_TAB_HOVER_HEX = "#156248"
 THEME_APP_HEADER_TITLE_HEX = "#1f3d2b"
 THEME_SECONDARY_BG_HEX = "#EEF4F0"
 
+# Cache-bust key for spinner theme CSS (``SPINNER_THEME_CSS`` in ``app_constants``).
+# Stays with theme tweakables — not spinner copy (that lives in ``streamlit_ui_constants``).
 SPINNER_THEME_CSS_CACHE_KEY_SUFFIX = "v19"
 
 # ---------------------------------------------------------------------------
@@ -447,8 +466,6 @@ RANKINGS_BUNDLE_SCROLL_HINT_DEFAULT = "shading"
 # and family/world coverage tables.
 TAXONOMY_INCLUDE_EXTINCT_SPECIES_IN_COVERAGE = False
 
-# Share summary cards (#157): colour schemes and layout stat defaults — see
-# :mod:`explorer.core.share_summary_defaults` (re-exported above; no UI picker yet).
 
 def debug_defaults_enabled() -> list[str]:
     """Return names of debug toggles in this module that are currently ``True``.


### PR DESCRIPTION
## Summary

Sharpens the ownership contract for `explorer/app/streamlit/defaults.py` so agents and humans can tell what is editable here versus re-export façade versus other constants modules. No product behaviour change.

## Changes

- Expand `defaults.py` module docstring (owned / façade / not here) and label the re-export block clearly
- Clarify section comments for map marker schemes and spinner theme CSS cache-key suffix
- Align `docs/AI_CONTEXT.md` § Defaults, `docs/python-style-guide.md` constants placement, and `.cursor/rules/streamlit-ui-thin.mdc`
- Inventory of current contents posted on #341 (no large module moves — prefer sectioning over splits)

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (874 passed, 11 skipped)

## Notes

Optional relocation of marker-scheme literals was deferred; presets remain in `defaults.py` with shapes in `map_marker_scheme_model`.

## Issues

Fixes #341

Made with [Cursor](https://cursor.com)