### PR TITLE
Audit legacy tests for integrity

### DIFF
--- a/explorer/components/all_locations_map/frontend/src/AllLocationsMapLeaflet.test.ts
+++ b/explorer/components/all_locations_map/frontend/src/AllLocationsMapLeaflet.test.ts
@@ -5,16 +5,13 @@ describe("normalizeBasemapId", () => {
   it("accepts all production basemap keys", () => {
     for (const key of BASEMAP_IDS) {
       expect(normalizeBasemapId(key)).toBe(key);
+      expect(normalizeBasemapId(`  ${key.toUpperCase()}  `)).toBe(key);
     }
   });
 
   it("falls back to default for unknown keys", () => {
-    expect(normalizeBasemapId("voyager_nolabels")).toBe("default");
-    expect(normalizeBasemapId("")).toBe("default");
-    expect(normalizeBasemapId(undefined)).toBe("default");
-  });
-
-  it("normalizes case and whitespace", () => {
-    expect(normalizeBasemapId("  ESRI_TOPO  ")).toBe("esri_topo");
+    for (const value of ["voyager_nolabels", "", "   ", undefined]) {
+      expect(normalizeBasemapId(value)).toBe("default");
+    }
   });
 });

--- a/explorer/components/all_locations_map/frontend/src/mapComponentParsers.test.ts
+++ b/explorer/components/all_locations_map/frontend/src/mapComponentParsers.test.ts
@@ -4,10 +4,13 @@ describe("parseViewportV1", () => {
   it("returns null for non-objects", () => {
     expect(parseViewportV1(null)).toBeNull();
     expect(parseViewportV1("x")).toBeNull();
+    expect(parseViewportV1([])).toBeNull();
   });
 
-  it("requires v === 1", () => {
+  it("requires the supported version and mode", () => {
     expect(parseViewportV1({ v: 2, mode: "center_zoom", center: [0, 0], zoom: 5 })).toBeNull();
+    expect(parseViewportV1({ v: "1", mode: "center_zoom", center: [0, 0], zoom: 5 })).toBeNull();
+    expect(parseViewportV1({ v: 1, mode: "unknown" })).toBeNull();
   });
 
   it("parses go_to_gps", () => {
@@ -46,11 +49,15 @@ describe("parseViewportV1", () => {
       padding_px: 20,
       max_zoom: 12,
     });
-    expect(vp?.mode).toBe("fit_bounds");
-    if (vp?.mode === "fit_bounds" && vp.single_point) {
-      expect(vp.lat).toBe(1);
-      expect(vp.max_zoom).toBe(12);
-    }
+    expect(vp).toEqual({
+      mode: "fit_bounds",
+      single_point: true,
+      lat: 1,
+      lon: 2,
+      epsilon_delta: 0.05,
+      padding_px: 20,
+      max_zoom: 12,
+    });
   });
 
   it("parses fit_bounds multi pair", () => {
@@ -88,5 +95,47 @@ describe("parseViewportV1", () => {
         max_zoom: 11,
       }),
     ).toBeNull();
+  });
+
+  it.each([
+    {
+      v: 1,
+      mode: "go_to_gps",
+      lat: "not-a-number",
+      lon: 149,
+      padding_px: 20,
+      epsilon_delta: 0.01,
+      max_zoom: 14,
+    },
+    { v: 1, mode: "center_zoom", center: [1], zoom: 8 },
+    { v: 1, mode: "center_zoom", center: [1, 2], zoom: Infinity },
+    {
+      v: 1,
+      mode: "fit_bounds",
+      single_point: true,
+      lat: 1,
+      lon: 2,
+      epsilon_delta: Number.NaN,
+      padding_px: 20,
+      max_zoom: 12,
+    },
+    {
+      v: 1,
+      mode: "fit_bounds",
+      single_point: false,
+      pairs: [[1, 2, 3]],
+      padding_px: 20,
+      max_zoom: 12,
+    },
+    {
+      v: 1,
+      mode: "fit_bounds",
+      single_point: false,
+      pairs: [[1, "bad"]],
+      padding_px: 20,
+      max_zoom: 12,
+    },
+  ])("rejects malformed viewport payload %#", (payload) => {
+    expect(parseViewportV1(payload)).toBeNull();
   });
 });

--- a/tests/explorer/test_aggregate_perf_jsonl.py
+++ b/tests/explorer/test_aggregate_perf_jsonl.py
@@ -9,6 +9,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from tests.explorer.e2e_support import (
+    max_elapsed_ms_by_stage,
+    parse_perf_json_objects_from_log_lines,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT_PATH = REPO_ROOT / "scripts" / "aggregate_perf_jsonl.py"
 
@@ -185,3 +190,30 @@ def test_main_returns_nonzero_for_missing_dir(tmp_path: Path) -> None:
     mod = _load_module()
     rc = mod.main([str(tmp_path / "does_not_exist")])
     assert rc == 2
+
+
+def test_e2e_log_parser_extracts_only_complete_perf_records() -> None:
+    lines = [
+        'INFO prefix {"stage":"prep.one","elapsed_ms":1.5} trailing '
+        '{"stage":"prep.two","elapsed_ms":2}\n',
+        '{"stage":"missing-duration"}\n',
+        'noise {"elapsed_ms":3}\n',
+        '{"stage":"broken","elapsed_ms":\n',
+    ]
+
+    assert parse_perf_json_objects_from_log_lines(lines) == [
+        {"stage": "prep.one", "elapsed_ms": 1.5},
+        {"stage": "prep.two", "elapsed_ms": 2},
+    ]
+
+
+def test_e2e_stage_max_ignores_zero_point_events_and_invalid_durations() -> None:
+    events = [
+        {"stage": "prep.one", "elapsed_ms": 0, "run_kind": "point"},
+        {"stage": "prep.one", "elapsed_ms": "12.5"},
+        {"stage": "prep.one", "elapsed_ms": 9},
+        {"stage": "prep.two", "elapsed_ms": "invalid"},
+        {"elapsed_ms": 100},
+    ]
+
+    assert max_elapsed_ms_by_stage(events) == {"prep.one": 12.5}

--- a/tests/explorer/test_all_locations_map_component.py
+++ b/tests/explorer/test_all_locations_map_component.py
@@ -32,7 +32,7 @@ def test_render_all_locations_map_component_passes_zoom_debug_flag(monkeypatch):
     assert captured.get("show_zoom_debug") is True
 
 
-def test_render_all_locations_map_component_passes_popup_scroll_settings(monkeypatch):
+def test_render_all_locations_map_component_passes_render_contract(monkeypatch):
     captured: dict = {}
 
     def fake_component(**kwargs):
@@ -43,14 +43,40 @@ def test_render_all_locations_map_component_passes_popup_scroll_settings(monkeyp
         lambda: fake_component,
     )
 
+    geojson = {"type": "FeatureCollection", "features": [{"type": "Feature"}]}
     render_all_locations_map_component(
-        revision="rev",
-        geojson={"type": "FeatureCollection", "features": []},
-        height=400,
-        key="k",
+        revision="rev-123",
+        geojson=geojson,
+        height=401.9,
+        key="map-key",
+        map_style="voyager",
+        cluster_options={"enabled": True},
+        circle_marker_style={"radius_px": 7},
+        cluster_icon_style={"small": {"fill": "#123456"}},
+        viewport={"mode": "center_zoom", "center": [-35.0, 149.0], "zoom": 8},
+        map_theme_css="<style>.map{}</style>",
+        map_popup_width_script="<script>width()</script>",
         popup_scroll_hint="both",
         popup_scroll_to_bottom=True,
+        banner_html="<div>Banner</div>",
+        legend_html="<div>Legend</div>",
     )
 
-    assert captured.get("popup_scroll_hint") == "both"
-    assert captured.get("popup_scroll_to_bottom") is True
+    assert captured == {
+        "revision": "rev-123",
+        "geojson": geojson,
+        "height": 401,
+        "map_style": "voyager",
+        "cluster_options": {"enabled": True},
+        "circle_marker_style": {"radius_px": 7},
+        "cluster_icon_style": {"small": {"fill": "#123456"}},
+        "viewport": {"mode": "center_zoom", "center": [-35.0, 149.0], "zoom": 8},
+        "map_theme_css": "<style>.map{}</style>",
+        "map_popup_width_script": "<script>width()</script>",
+        "popup_scroll_hint": "both",
+        "popup_scroll_to_bottom": True,
+        "banner_html": "<div>Banner</div>",
+        "legend_html": "<div>Legend</div>",
+        "show_zoom_debug": False,
+        "key": "map-key",
+    }

--- a/tests/explorer/test_all_locations_viewport.py
+++ b/tests/explorer/test_all_locations_viewport.py
@@ -71,7 +71,7 @@ def test_filter_focus_empty_means_all_rows():
     out = filter_location_rows_by_focus_country(
         loc, location_id_to_country=m, focus_country=ALL_LOCATIONS_FOCUS_ALL
     )
-    assert len(out) == 2
+    pd.testing.assert_frame_equal(out, loc)
 
 
 def test_coordinate_pairs_for_viewport_focus():
@@ -129,8 +129,7 @@ def test_coordinate_pairs_focused_viewport_includes_high_observation_country():
         quantile_high=0.99,
         min_observations_full_country=20,
     )
-    assert len(out) == 100
-    assert any(abs(float(lat) - 89.0) < 0.01 for lat, _ in out)
+    assert out == [[i * 0.001, i * 0.001] for i in range(1, 100)] + [[89.0, 179.0]]
 
 
 def test_all_locations_scope_option_values_order():
@@ -174,7 +173,7 @@ def test_leaflet_viewport_recipe_centre_of_gravity_mode():
     assert vp["v"] == 1
     assert vp["mode"] == "center_zoom"
     assert vp["zoom"] == MAP_ALL_LOCATIONS_CENTRE_OF_GRAVITY_ZOOM
-    assert len(vp["center"]) == 2
+    assert vp["center"] == [-35.5, 149.5]
 
 
 def test_leaflet_viewport_recipe_go_to_gps_overrides_scope():

--- a/tests/explorer/test_app_caches_checklist_stats.py
+++ b/tests/explorer/test_app_caches_checklist_stats.py
@@ -39,7 +39,7 @@ def _clear_checklist_stats_cache() -> None:
 
 def test_working_and_full_export_share_one_compute_when_args_match(monkeypatch: pytest.MonkeyPatch) -> None:
     """Default settings: full export uses same top_n/high-count defaults as the Checklist tab."""
-    compute_calls = 0
+    compute_calls: list[tuple[pd.DataFrame, int, str, str, str | None]] = []
 
     def counting_compute(
         df: pd.DataFrame,
@@ -49,8 +49,9 @@ def test_working_and_full_export_share_one_compute_when_args_match(monkeypatch: 
         high_count_tie_break: str = "last",
         taxonomy_locale: str | None = None,
     ) -> ChecklistStatsPayload | None:
-        nonlocal compute_calls
-        compute_calls += 1
+        compute_calls.append(
+            (df, top_n_limit, high_count_sort, high_count_tie_break, taxonomy_locale)
+        )
         return ChecklistStatsPayload(
             n_checklists=1,
             n_species=1,
@@ -101,15 +102,22 @@ def test_working_and_full_export_share_one_compute_when_args_match(monkeypatch: 
         locale,
     )
 
-    assert compute_calls == 1
+    assert compute_calls == [
+        (
+            df,
+            CHECKLIST_STATS_TOP_N_TABLE_LIMIT,
+            "total_count",
+            "last",
+            locale,
+        )
+    ]
 
 
 def test_full_export_recomputes_when_top_n_differs(monkeypatch: pytest.MonkeyPatch) -> None:
-    compute_calls = 0
+    compute_calls: list[tuple[tuple, dict]] = []
 
-    def counting_compute(*_a, **_k) -> ChecklistStatsPayload | None:
-        nonlocal compute_calls
-        compute_calls += 1
+    def counting_compute(*args, **kwargs) -> ChecklistStatsPayload | None:
+        compute_calls.append((args, kwargs))
         return None
 
     monkeypatch.setattr(app_caches, "compute_checklist_stats_payload", counting_compute)
@@ -119,4 +127,19 @@ def test_full_export_recomputes_when_top_n_differs(monkeypatch: pytest.MonkeyPat
     app_caches.cached_checklist_stats_payload(df, locale)
     app_caches.cached_full_export_checklist_stats_payload(df, 50, "total_count", "last", locale)
 
-    assert compute_calls == 2
+    assert [call_args[1] for call_args, _ in compute_calls] == [
+        CHECKLIST_STATS_TOP_N_TABLE_LIMIT,
+        50,
+    ]
+    assert [kwargs for _, kwargs in compute_calls] == [
+        {
+            "high_count_sort": "total_count",
+            "high_count_tie_break": "last",
+            "taxonomy_locale": locale,
+        },
+        {
+            "high_count_sort": "total_count",
+            "high_count_tie_break": "last",
+            "taxonomy_locale": locale,
+        },
+    ]

--- a/tests/explorer/test_app_prep_map_ui_integration.py
+++ b/tests/explorer/test_app_prep_map_ui_integration.py
@@ -71,6 +71,7 @@ def test_apply_dataset_signature_change_clears_leaflet_caches(
     from explorer.app.streamlit.app_constants import (
         ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY,
         EBIRD_DATA_SIG_KEY,
+        FAMILY_LEAFLET_PAYLOAD_CACHE_KEY,
         LEAFLET_EXPORT_HTML_CACHE_KEY,
         LIFER_LEAFLET_PAYLOAD_CACHE_KEY,
         SPECIES_LEAFLET_PAYLOAD_CACHE_KEY,
@@ -92,6 +93,9 @@ def test_apply_dataset_signature_change_clears_leaflet_caches(
     )
     st.session_state[LIFER_LEAFLET_PAYLOAD_CACHE_KEY] = OrderedDict()
     st.session_state[SPECIES_LEAFLET_PAYLOAD_CACHE_KEY] = OrderedDict()
+    st.session_state[FAMILY_LEAFLET_PAYLOAD_CACHE_KEY] = OrderedDict(
+        [(("family",), {"revision": "family-old"})]
+    )
     st.session_state[LEAFLET_EXPORT_HTML_CACHE_KEY] = OrderedDict()
 
     assert apply_dataset_signature_for_map_caches(df_b, "disk") is True
@@ -99,6 +103,7 @@ def test_apply_dataset_signature_change_clears_leaflet_caches(
     assert ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY not in st.session_state
     assert LIFER_LEAFLET_PAYLOAD_CACHE_KEY not in st.session_state
     assert SPECIES_LEAFLET_PAYLOAD_CACHE_KEY not in st.session_state
+    assert FAMILY_LEAFLET_PAYLOAD_CACHE_KEY not in st.session_state
     assert LEAFLET_EXPORT_HTML_CACHE_KEY not in st.session_state
 
 
@@ -158,7 +163,9 @@ def test_leaflet_payload_cache_miss_when_revision_extra_changes(streamlit_stub) 
         {"revision": "off", "geojson": {"type": "FeatureCollection", "features": []}},
         max_entries=ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_MAX_ENTRIES,
     )
-    assert leaflet_payload_cache_lookup(ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY, key_off) is not None
+    assert leaflet_payload_cache_lookup(
+        ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY, key_off
+    )["revision"] == "off"
     assert leaflet_payload_cache_lookup(ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY, key_on) is None
 
 

--- a/tests/explorer/test_basemap_manifest.py
+++ b/tests/explorer/test_basemap_manifest.py
@@ -20,10 +20,23 @@ def test_basemap_manifest_options_labels_and_tiles():
     )
 
     entries = get_basemap_entries()
-    assert len(entries) >= 5
+    assert tuple(entry.key for entry in entries) == (
+        "default",
+        "voyager",
+        "carto",
+        "esri_topo",
+        "google",
+    )
+    assert tuple(entry.label for entry in entries) == (
+        "Default (OpenStreetMap)",
+        "CARTO Voyager",
+        "CartoDB Positron",
+        "Esri World Topo",
+        "Google Hybrid",
+    )
     assert MAP_BASEMAP_OPTIONS == tuple(e.key for e in entries)
-    assert MAP_BASEMAP_DEFAULT in MAP_BASEMAP_OPTIONS
-    assert list(MAP_BASEMAP_LABELS) == list(MAP_BASEMAP_OPTIONS)
+    assert MAP_BASEMAP_DEFAULT == "default"
+    assert MAP_BASEMAP_LABELS == {entry.key: entry.label for entry in entries}
 
     component = basemap_tile_layers_for_component()
     export = basemap_tile_layers_for_export()
@@ -32,6 +45,8 @@ def test_basemap_manifest_options_labels_and_tiles():
         assert key in export
         assert component[key]["url"] == export[key]["url"]
         assert component[key]["opts"]["maxZoom"] == export[key]["opts"]["maxZoom"]
+        assert component[key]["opts"]["attribution"]
+        assert export[key]["opts"]["attribution"]
 
 
 def test_generated_map_assets_are_fresh():

--- a/tests/explorer/test_cached_map_maintenance.py
+++ b/tests/explorer/test_cached_map_maintenance.py
@@ -33,3 +33,54 @@ def test_cached_map_maintenance_matches_direct_call() -> None:
 
     assert first == expected
     assert second == first
+
+
+def test_cached_map_maintenance_reuses_result_for_same_dataframe_and_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loc_df = pd.DataFrame(
+        {
+            "Location ID": ["L1", "L2", "L3"],
+            "Location": ["A", "B", "C"],
+            "Latitude": [-35.0, -35.0000001, -36.0],
+            "Longitude": [149.0, 149.0000001, 150.0],
+        }
+    )
+    threshold_m = 10
+    calls: list[int] = []
+
+    def fake_scan(_loc_df: pd.DataFrame, threshold: int):
+        calls.append(threshold)
+        return [("duplicate", threshold)], [("near", threshold)]
+
+    monkeypatch.setattr("explorer.core.duplicate_checks.get_map_maintenance_data", fake_scan)
+    first = app_caches.cached_map_maintenance_data(loc_df, threshold_m)
+    second = app_caches.cached_map_maintenance_data(loc_df, threshold_m)
+
+    assert first == ([("duplicate", 10)], [("near", 10)])
+    assert second == first
+    assert calls == [10]
+
+
+def test_cached_map_maintenance_threshold_is_part_of_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loc_df = pd.DataFrame(
+        {
+            "Location ID": ["L1", "L2"],
+            "Location": ["A", "B"],
+            "Latitude": [-35.0, -35.0001],
+            "Longitude": [149.0, 149.0001],
+        }
+    )
+    calls: list[int] = []
+
+    def fake_scan(_loc_df: pd.DataFrame, threshold: int):
+        calls.append(threshold)
+        return [], [(threshold,)]
+
+    monkeypatch.setattr("explorer.core.duplicate_checks.get_map_maintenance_data", fake_scan)
+
+    assert app_caches.cached_map_maintenance_data(loc_df, 10) == ([], [(10,)])
+    assert app_caches.cached_map_maintenance_data(loc_df, 20) == ([], [(20,)])
+    assert calls == [10, 20]

--- a/tests/explorer/test_checklist_stats_compute.py
+++ b/tests/explorer/test_checklist_stats_compute.py
@@ -74,7 +74,7 @@ def test_incomplete_checklists_excludes_incidental_and_historical():
     assert keys.index("Incomplete checklists") < keys.index("Completed checklists")
 
 
-def test_compute_and_format_smoke():
+def test_compute_and_format_returns_expected_summary_and_sections():
     df = pd.DataFrame(
         {
             "Submission ID": ["s1", "s1", "s2"],
@@ -94,17 +94,42 @@ def test_compute_and_format_smoke():
     )
     payload = compute_checklist_stats_payload(df, top_n_limit=5)
     assert payload is not None
-    assert payload.n_checklists == 2
-    assert payload.streak >= 1
+    assert (
+        payload.n_checklists,
+        payload.n_species,
+        payload.n_individuals,
+        payload.total_minutes,
+        payload.total_km,
+        payload.streak,
+    ) == (2, 2, 4, 50.0, 1.0, 1)
+    assert payload.rankings["species_individuals"] == [
+        ("Duck", "—", "3"),
+        ("Robin", "—", "1"),
+    ]
     bundle = format_checklist_stats_bundle(
         payload,
         link_urls_fn=lambda _: (None, None),
         scroll_hint=400,
         visible_rows=8,
     )
-    assert "<table" in bundle["stats_html"]
-    assert len(bundle["rankings_sections_top_n"]) == 7
-    assert len(bundle["rankings_sections_other"]) == 6
+    assert "<tr><td>Total checklists</td><td>2</td></tr>" in bundle["stats_html"]
+    assert [title for title, _ in bundle["rankings_sections_top_n"]] == [
+        "Checklist: Longest by time",
+        "Checklist: Longest by distance",
+        "Checklist: Most species",
+        "Checklist: Most individuals",
+        "Location: Most species",
+        "Location: Most individuals",
+        "Location: Most visited",
+    ]
+    assert [title for title, _ in bundle["rankings_sections_other"]] == [
+        "Species: Most individuals",
+        "Species: Most checklists",
+        "Species: Subspecies occurrence",
+        "Species: High counts",
+        "Species: Seen only once",
+        "Species: Not seen in the past year",
+    ]
 
 
 def test_slice_yearly_table_rows():
@@ -209,7 +234,7 @@ def test_strip_yearly_stats_info_icons_removes_span():
     assert out == "Traveling checklists"
 
 
-def test_build_yearly_summary_streamlit_tab_html_dict_smoke():
+def test_build_yearly_summary_streamlit_tabs_have_expected_content():
     """Streamlit yearly tabs: three bodies, no inline info icons, yearly table class."""
     df = pd.DataFrame(
         {

--- a/tests/explorer/test_compute_rankings_vectorized.py
+++ b/tests/explorer/test_compute_rankings_vectorized.py
@@ -23,22 +23,40 @@ def _fixture_tables():
     return df, cl, dur_col, dist_col
 
 
-def test_compute_rankings_returns_nonempty_core_sections(_fixture_tables) -> None:
+def test_compute_rankings_returns_expected_fixture_leaders(_fixture_tables) -> None:
     df, cl, dur_col, dist_col = _fixture_tables
     result = compute_rankings(df, cl, limit=200, dur_col=dur_col, dist_col=dist_col)
-    assert len(result["species"]) > 0
-    assert len(result["species_loc"]) > 0
-    assert len(result["visited"]) > 0
+    assert len(result["species"]) == 15
+    assert result["species"][0][0].endswith(">West Belconnen Pond</a>")
+    assert result["species"][0][4] == "21"
+    assert len(result["species_loc"]) == 15
+    assert result["species_loc"][0] == (
+        '<a href="https://ebird.org/lifelist/L2507517" target="_blank">'
+        "West Belconnen Pond</a>",
+        "ACT",
+        "AU",
+        "1",
+        "21",
+    )
+    assert len(result["visited"]) == 15
+    assert result["visited"][0][0].endswith(">Australian National Botanic Gardens</a>")
 
 
 def test_rankings_by_location_species_respects_limit(_fixture_tables) -> None:
     df, cl, _dur, _dist = _fixture_tables
     rows = rankings_by_location(df, cl, "species", lambda x: f"{int(x):,}", limit=5)
-    assert 1 <= len(rows) <= 5
+    assert len(rows) == 5
+    assert [(row[0].partition(">")[2].removesuffix("</a>"), row[4]) for row in rows] == [
+        ("West Belconnen Pond", "21"),
+        ("Lake Richmond", "20"),
+        ("Benoa dekat Jl Telga Waja", "18"),
+        ("Holloways Beach ( -16.851004, 145.73002 )", "17"),
+        ("Keliki ( -8.428716, 115.258034 )", "14"),
+    ]
 
 
 def test_compute_rankings_all_sections_bounded(_fixture_tables) -> None:
     df, cl, dur_col, dist_col = _fixture_tables
     result = compute_rankings(df, cl, limit=10, dur_col=dur_col, dist_col=dist_col)
     for key in ("species", "individuals", "species_loc", "individuals_loc", "visited"):
-        assert len(result[key]) <= 10
+        assert len(result[key]) == 10

--- a/tests/explorer/test_debug_defaults_ci.py
+++ b/tests/explorer/test_debug_defaults_ci.py
@@ -6,6 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+import scripts.warn_streamlit_debug_defaults as warning_script
+
 
 def test_debug_defaults_enabled_matches_map_debug_constant():
     from explorer.app.streamlit import defaults as d
@@ -19,6 +23,27 @@ def test_debug_defaults_enabled_matches_map_debug_constant():
         assert "MAP_DEBUG_SHOW_ZOOM_LEVEL" not in got
 
 
+def test_warning_script_emits_one_github_annotation_per_enabled_toggle(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        warning_script,
+        "debug_defaults_enabled",
+        lambda: ["MAP_DEBUG_SHOW_ZOOM_LEVEL", "SECOND_DEBUG_TOGGLE"],
+    )
+
+    assert warning_script.main() is None
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.splitlines() == [
+        "::warning::explorer/app/streamlit/defaults.py — MAP_DEBUG_SHOW_ZOOM_LEVEL=True "
+        "(debug; set False for production)",
+        "::warning::explorer/app/streamlit/defaults.py — SECOND_DEBUG_TOGGLE=True "
+        "(debug; set False for production)",
+    ]
+
+
 def test_warn_streamlit_debug_defaults_script_exits_zero():
     repo = Path(__file__).resolve().parents[2]
     script = repo / "scripts" / "warn_streamlit_debug_defaults.py"
@@ -30,3 +55,5 @@ def test_warn_streamlit_debug_defaults_script_exits_zero():
         check=False,
     )
     assert proc.returncode == 0
+    assert proc.stdout == ""
+    assert proc.stderr == ""

--- a/tests/explorer/test_design_map_preview.py
+++ b/tests/explorer/test_design_map_preview.py
@@ -158,15 +158,23 @@ def test_build_design_preview_geojson_all_locations_includes_seq_cluster_demo() 
     clustered = [f for f in gj["features"] if not f["properties"].get("skip_cluster")]
     standalone = [f for f in gj["features"] if f["properties"].get("skip_cluster")]
     assert len(clustered) == 7 + 45 + 120
-    assert len(standalone) > 0
+    role_rows = sum(1 for row in PREVIEW_MARKER_ROWS if MAP_SCOPE_ALL_LOCATIONS in row.map_scopes)
+    assert len(standalone) == role_rows * DESIGN_PREVIEW_MARKER_COPY_COUNT
+    assert {feature["type"] for feature in gj["features"]} == {"Feature"}
+    assert {feature["geometry"]["type"] for feature in gj["features"]} == {"Point"}
+    location_ids = [feature["properties"]["location_id"] for feature in gj["features"]]
+    assert len(location_ids) == len(set(location_ids))
+    assert all(feature["properties"]["name"].startswith("SEQ cluster demo") for feature in clustered)
 
 
 def test_build_design_preview_leaflet_bundle_revision_changes_with_nonce() -> None:
     cfg = scheme_seed_config(2, preview_scope=MAP_SCOPE_FAMILY_LOCATIONS)
     a = build_design_preview_leaflet_bundle(cfg, position_seed=1, render_nonce=1)
+    same = build_design_preview_leaflet_bundle(cfg, position_seed=1, render_nonce=1)
     b = build_design_preview_leaflet_bundle(cfg, position_seed=1, render_nonce=2)
+    assert a["revision"] == same["revision"]
+    assert a["geojson"] == same["geojson"]
     assert a["revision"] != b["revision"]
-    assert len(a["legend_html"]) > 20
     assert "pebird-map-legend" in a["legend_html"]
     assert a["viewport"]["mode"] == "center_zoom"
     assert a["cluster_options"]["enabled"] is False

--- a/tests/explorer/test_e2e_config_isolation.py
+++ b/tests/explorer/test_e2e_config_isolation.py
@@ -68,5 +68,8 @@ def test_build_explorer_candidate_dirs_honours_explorer_config_dir(tmp_path, mon
     monkeypatch.setenv(EXPLORER_CONFIG_DIR_ENV, str(isolated_config))
     folders, sources = build_explorer_candidate_dirs(repo_root=str(repo), cwd=str(tmp_path / "cwd"))
     path, folder, src = resolve_ebird_data_file("MyEBirdData.csv", folders, sources)
+    assert folders == [os.path.normpath(str(data_dir)), os.path.normpath(str(tmp_path / "cwd"))]
+    assert sources == ["config", "cwd"]
+    assert os.path.normpath(path) == os.path.normpath(str(data_dir / "MyEBirdData.csv"))
     assert os.path.normpath(folder) == os.path.normpath(str(data_dir))
     assert src == "config"

--- a/tests/explorer/test_explorer_paths.py
+++ b/tests/explorer/test_explorer_paths.py
@@ -35,6 +35,7 @@ def test_resolve_ebird_data_file_finds_in_cwd_when_no_config(tmp_path):
     folders, sources = build_explorer_candidate_dirs(repo_root=str(repo), cwd=str(cwd_dir))
     path, folder, src = resolve_ebird_data_file("MyEBirdData.csv", folders, sources)
     assert os.path.normpath(path) == os.path.normpath(str(csv_path))
+    assert os.path.normpath(folder) == os.path.normpath(str(cwd_dir))
     assert src == "cwd"
 
 
@@ -61,16 +62,21 @@ def test_resolve_prefers_config_secret_over_cwd(tmp_path):
 
     folders, sources = build_explorer_candidate_dirs(repo_root=str(repo), cwd=str(cwd_dir))
     path, folder, src = resolve_ebird_data_file("MyEBirdData.csv", folders, sources)
+    assert os.path.normpath(path) == os.path.normpath(str(data_secret / "MyEBirdData.csv"))
     assert os.path.normpath(folder) == os.path.normpath(str(data_secret))
     assert src == "config_secret"
 
 
-def test_resolve_raises_file_not_found():
+def test_resolve_raises_file_not_found_with_attempted_locations():
     from explorer.core.explorer_paths import resolve_ebird_data_file
 
+    attempted = ["/missing/one", "/missing/two"]
     with pytest.raises(FileNotFoundError) as exc:
-        resolve_ebird_data_file("nope.csv", ["/nonexistent"], ["x"])
-    assert "nope.csv" in str(exc.value)
+        resolve_ebird_data_file("nope.csv", attempted, ["first", "second"])
+    message = str(exc.value)
+    assert "Data file not found: nope.csv" in message
+    assert all(folder in message for folder in attempted)
+    assert "Expected filename: nope.csv" in message
 
 
 def test_settings_yaml_path_for_source(tmp_path):
@@ -83,8 +89,8 @@ def test_settings_yaml_path_for_source(tmp_path):
     p2 = settings_yaml_path_for_source(str(repo), "config")
     p3 = settings_yaml_path_for_source(str(repo), "cwd")
 
-    assert p1 and p1.endswith("config/config_secret.yaml")
-    assert p2 and p2.endswith("config/config.yaml")
+    assert p1 == os.path.join(str(repo), "config", "config_secret.yaml")
+    assert p2 == os.path.join(str(repo), "config", "config.yaml")
     assert p3 is None
 
 
@@ -125,5 +131,6 @@ def test_config_yaml_wins_over_cwd_when_both_have_csv(tmp_path):
     folders, sources = build_explorer_candidate_dirs(repo_root=str(repo), cwd=str(cwd_dir))
     assert sources == ["config", "cwd"]
     path, folder, src = resolve_ebird_data_file("MyEBirdData.csv", folders, sources)
+    assert os.path.normpath(path) == os.path.normpath(str(data_from_config / "MyEBirdData.csv"))
     assert os.path.normpath(folder) == os.path.normpath(str(data_from_config))
     assert src == "config"

--- a/tests/explorer/test_family_locations_geojson.py
+++ b/tests/explorer/test_family_locations_geojson.py
@@ -79,17 +79,23 @@ def test_build_family_geojson_pins_and_highlight_framing():
         fit_bounds_highlight_only=True,
         revision_extra="{}",
     )
-    assert rev is not None
-    assert gj is not None
+    assert isinstance(rev, str) and len(rev) == 24
+    assert gj["type"] == "FeatureCollection"
     assert len(gj["features"]) == 2
     assert hl_framed is True
-    assert len(framing) == 1
+    assert framing == [[-34.0, 150.0]]
     hl_feat = next(f for f in gj["features"] if f["properties"]["location_id"] == "L2")
-    assert "family_popup_v1" in hl_feat["properties"]
-    assert hl_feat["properties"]["family_popup_v1"]["v"] == 1
-    assert len(hl_feat["properties"]["family_popup_v1"]["species_lines"]) == 1
+    assert hl_feat["geometry"] == {"type": "Point", "coordinates": [150.0, -34.0]}
+    assert hl_feat["properties"]["lifelist_url"] == "https://ebird.org/lifelist/L2"
+    assert hl_feat["properties"]["family_popup_v1"] == {
+        "v": 1,
+        "species_lines": [{"name": "C", "species_href": ""}],
+    }
     fill, stroke, _sw = family_map_marker_style(pins[1], style=sch)
     assert hl_feat["properties"]["circle_pin"]["fill_hex"] == fill
     assert hl_feat["properties"]["circle_pin"]["stroke_hex"] == stroke
+    assert metrics["marker_count"] == 2
+    assert metrics["popup_build_count"] == 2
+    assert metrics["popup_build_total_ms"] >= 0.0
     # Highlight pin drawn after normal (later feature = on top in Leaflet order).
     assert gj["features"][-1]["properties"]["location_id"] == "L2"

--- a/tests/explorer/test_family_map_compute.py
+++ b/tests/explorer/test_family_map_compute.py
@@ -231,9 +231,10 @@ def test_merge_taxonomy_detail_for_family_map_smoke():
         }
     ]
     merged = merge_taxonomy_detail_for_family_map(tax, groups)
-    assert len(merged) == len(tax)
-    assert "group_name" in merged.columns
-    assert merged["group_name"].iloc[0] == "G"
+    assert merged["scientific_name"].tolist() == ["Aa bb", "Cc dd"]
+    assert merged["species_code"].tolist() == ["aabb", "ccdd"]
+    assert merged["group_name"].tolist() == ["G", "G"]
+    assert merged["group_order"].tolist() == [1, 1]
 
 
 def test_base_species_to_common_from_taxonomy():

--- a/tests/explorer/test_go_to_gps_parse.py
+++ b/tests/explorer/test_go_to_gps_parse.py
@@ -14,10 +14,7 @@ from explorer.app.streamlit.app_go_to_gps_ui import (
 def test_parse_google_style_pair_from_issue_comment() -> None:
     raw = "-35.268965820020014, 149.08053613146686"
     pair = parse_lat_lon_pair(raw)
-    assert pair is not None
-    la, lo = pair
-    assert la == pytest.approx(-35.268965820020014)
-    assert lo == pytest.approx(149.08053613146686)
+    assert pair == pytest.approx((-35.268965820020014, 149.08053613146686))
 
 
 def test_parse_lat_lon_pair_rejects_invalid_ranges() -> None:
@@ -27,6 +24,8 @@ def test_parse_lat_lon_pair_rejects_invalid_ranges() -> None:
 
 def test_parse_lat_lon_pair_requires_comma() -> None:
     assert parse_lat_lon_pair("-35.27 149.08") is None
+    assert parse_lat_lon_pair("-35.27, 149.08, 1") is None
+    assert parse_lat_lon_pair("not-a-number, 149.08") is None
 
 
 def test_parse_single_coord_strips_commas() -> None:

--- a/tests/explorer/test_integration_fixture.py
+++ b/tests/explorer/test_integration_fixture.py
@@ -266,19 +266,35 @@ def test_integration_near_duplicate_detection(fixture_checklists):
 
 def test_integration_filter_species_returns_expected_rows(fixture_df):
     """Filter for a known species returns expected row count and locations."""
-    # Grey Teal appears in baseline_act_2023_hybrid (West Belconnen Pond)
     filtered = filter_species(fixture_df, "Anas gracilis")
-    assert len(filtered) >= 1
-    assert "Anas gracilis" in filtered["Scientific Name"].values
-    assert filtered["Location ID"].nunique() >= 1
+    assert filtered[
+        ["Scientific Name", "Location ID", "Submission ID"]
+    ].to_dict("records") == [
+        {
+            "Scientific Name": "Anas gracilis",
+            "Location ID": "L2507517",
+            "Submission ID": "S127638172",
+        },
+        {
+            "Scientific Name": "Anas gracilis",
+            "Location ID": "L2453113",
+            "Submission ID": "S292896870",
+        },
+    ]
 
 
 def test_integration_filter_species_slash_exact_match(fixture_df):
     """Filter with slash (species-level) matches only that taxon."""
-    # Fixture has "Egretta/Ardea sp." in incomplete_bali_2024
     filtered = filter_species(fixture_df, "egretta/ardea sp.")
-    assert len(filtered) >= 1
-    assert filtered["Scientific Name"].str.lower().str.contains("egretta/ardea", na=False).all()
+    assert filtered[
+        ["Scientific Name", "Location ID", "Submission ID"]
+    ].to_dict("records") == [
+        {
+            "Scientific Name": "Egretta/Ardea sp.",
+            "Location ID": "L5527554",
+            "Submission ID": "S188648387",
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -299,7 +315,7 @@ def test_integration_full_pipeline_headline_numbers(fixture_df, fixture_checklis
     years_list, yearly_rows, _ = yearly_summary_stats(
         fixture_df, fixture_checklists, dur_col, dist_col
     )
-    assert len(rankings["time"]) > 0
+    assert rankings["time"][0][4] == "131 min"
     idx_lifers = next(i for i, (label, _) in enumerate(yearly_rows) if label == "Lifers")
     lifer_vals = yearly_rows[idx_lifers][1]
     for i, yr in enumerate(years_list):
@@ -325,14 +341,13 @@ def test_integration_compute_rankings_returns_expected_structure(fixture_df, fix
         "seen_once",
         "species_individuals",
         "species_checklists",
+        "species_high_counts",
         "subspecies",
         "not_seen_recently",
     }
-    for k in expected_keys:
-        assert k in rankings, f"missing key {k}"
-    assert len(rankings["time"]) > 0
-    assert len(rankings["species_loc"]) > 0
-    assert len(rankings["not_seen_recently"]) > 0
+    assert set(rankings) == expected_keys
+    assert rankings["time"][0][4] == "131 min"
+    assert rankings["species_loc"][0][4] == "21"
     assert "ebird.org/checklist/" in rankings["not_seen_recently"][0][1]
 
 
@@ -343,7 +358,7 @@ def test_integration_yearly_summary_stats_structure(fixture_df, fixture_checklis
     years_list, yearly_rows, incomplete_by_year = yearly_summary_stats(
         fixture_df, fixture_checklists, dur_col, dist_col
     )
-    assert len(years_list) >= 1
+    assert years_list == sorted(EXPECTED_COUNTABLE_BY_YEAR)
     labels = [r[0] for r in yearly_rows]
     assert "Total species" in labels
     assert "Lifers" in labels
@@ -417,7 +432,7 @@ def test_integration_malformed_time_in_temp_copy():
             df.to_csv(f.name, index=False, encoding="utf-8")
             loaded = load_dataset(f.name)
             # With unparseable time, that row gets NaT in datetime (date+time parse fails)
-            assert loaded["datetime"].isna().sum() >= 1
+            assert loaded["datetime"].isna().sum() == 1
         finally:
             os.unlink(f.name)
 
@@ -452,7 +467,7 @@ def test_integration_blank_date_in_temp_copy():
             df.to_csv(f.name, index=False, encoding="utf-8")
             loaded = load_dataset(f.name)
             # That row should have NaT in datetime
-            assert loaded["datetime"].isna().sum() >= 1
+            assert loaded["datetime"].isna().sum() == 1
         finally:
             os.unlink(f.name)
 

--- a/tests/explorer/test_leaflet_geojson_build_metrics.py
+++ b/tests/explorer/test_leaflet_geojson_build_metrics.py
@@ -17,11 +17,21 @@ def test_build_all_locations_geojson_payload_emits_build_metrics() -> None:
             "Longitude": [145.0, 146.0],
         }
     )
-    _rev, gj, metrics = build_all_locations_geojson_payload(
+    revision, gj, metrics = build_all_locations_geojson_payload(
         loc_df,
         checklist_counts_by_location={"loc1": 1, "loc2": 0},
     )
-    assert len(gj["features"]) == 2
+    assert revision is not None and len(revision) == 24
+    assert gj["type"] == "FeatureCollection"
+    assert {
+        feature["properties"]["location_id"]: feature["geometry"]["coordinates"]
+        for feature in gj["features"]
+    } == {"loc1": [145.0, -37.0], "loc2": [146.0, -38.0]}
+    assert set(metrics) == {
+        "marker_count",
+        "popup_build_count",
+        "popup_build_total_ms",
+    }
     assert metrics["marker_count"] == 2
     assert metrics["popup_build_count"] == 0
     assert metrics["popup_build_total_ms"] >= 0.0
@@ -36,3 +46,4 @@ def test_merge_leaflet_build_metrics_into_perf_extra() -> None:
     assert extra["marker_count"] == 3
     assert extra["popup_build_count"] == 2
     assert extra["popup_build_total_ms"] == 1.235
+    assert extra["payload_cache_hit"] is False

--- a/tests/explorer/test_leaflet_map_export_cache.py
+++ b/tests/explorer/test_leaflet_map_export_cache.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from explorer.presentation.leaflet_map_export_cache import leaflet_export_html_cache_key
 
 
@@ -26,9 +28,30 @@ def test_cache_key_stable_for_same_inputs():
     assert _base_key() == _base_key()
 
 
-def test_cache_key_changes_when_revision_changes():
-    assert _base_key(leaflet_revision="rev1") != _base_key(leaflet_revision="rev2")
+@pytest.mark.parametrize(
+    ("override", "first", "second"),
+    [
+        ("leaflet_revision", "rev1", "rev2"),
+        ("map_height", 500, 501),
+        ("map_style", "default", "voyager"),
+        ("cluster_options", {"enabled": True}, {"enabled": False}),
+        ("circle_marker_style", {"fill_hex": "#3388ff"}, {"fill_hex": "#ff0000"}),
+        ("cluster_icon_style", {}, {"small": {"fill": "#123456"}}),
+        (
+            "viewport",
+            {"v": 1, "mode": "center_zoom", "center": [0, 0], "zoom": 5},
+            {"v": 1, "mode": "center_zoom", "center": [1, 0], "zoom": 5},
+        ),
+        ("map_theme_css", "<style>.x{}</style>", "<style>.y{}</style>"),
+        ("banner_html", "a", "b"),
+        ("legend_html", "a", "b"),
+    ],
+)
+def test_cache_key_changes_for_every_export_input(override, first, second):
+    assert _base_key(**{override: first}) != _base_key(**{override: second})
 
 
-def test_cache_key_changes_when_banner_changes():
-    assert _base_key(banner_html="a") != _base_key(banner_html="b")
+def test_cache_key_is_stable_for_equivalent_dict_ordering():
+    first = {"enabled": True, "radius": 5}
+    second = {"radius": 5, "enabled": True}
+    assert _base_key(cluster_options=first) == _base_key(cluster_options=second)

--- a/tests/explorer/test_leaflet_map_html_export.py
+++ b/tests/explorer/test_leaflet_map_html_export.py
@@ -34,7 +34,8 @@ def test_popup_export_html_blocks_javascript_href():
         }
     )
     assert "javascript:" not in html
-    assert "pebird-map-popup__visit-link-text" in html
+    assert '<span class="pebird-map-popup__visit-link-text">bad</span>' in html
+    assert "<a href=" not in html
 
 
 def test_popup_export_html_all_locations_visited():

--- a/tests/explorer/test_leaflet_payload_cache.py
+++ b/tests/explorer/test_leaflet_payload_cache.py
@@ -149,8 +149,14 @@ def test_leaflet_payload_cache_lru_evicts_oldest_when_over_max(
         max_entries=max_entries,
     )
     assert leaflet_payload_cache_lookup(session_key, ("a", mode_id)) is None
-    assert leaflet_payload_cache_lookup(session_key, ("b", mode_id)) is not None
-    assert leaflet_payload_cache_lookup(session_key, ("c", mode_id)) is not None
+    assert leaflet_payload_cache_lookup(session_key, ("b", mode_id)) == {
+        "revision": "2",
+        "geojson": {},
+    }
+    assert leaflet_payload_cache_lookup(session_key, ("c", mode_id)) == {
+        "revision": "3",
+        "geojson": {},
+    }
 
 
 @pytest.mark.parametrize(
@@ -176,12 +182,38 @@ def test_leaflet_payload_cache_hit_moves_entry_to_mru_end(
         {"revision": "2", "geojson": {}},
         max_entries=max_entries,
     )
-    assert leaflet_payload_cache_lookup(session_key, ("a", mode_id)) is not None
+    assert leaflet_payload_cache_lookup(session_key, ("a", mode_id))["revision"] == "1"
     leaflet_payload_cache_store(
         session_key,
         ("c", mode_id),
         {"revision": "3", "geojson": {}},
         max_entries=max_entries,
     )
-    assert leaflet_payload_cache_lookup(session_key, ("a", mode_id)) is not None
+    assert leaflet_payload_cache_lookup(session_key, ("a", mode_id))["revision"] == "1"
     assert leaflet_payload_cache_lookup(session_key, ("b", mode_id)) is None
+
+
+def test_leaflet_payload_cache_store_migrates_legacy_single_entry(
+    streamlit_stub,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import explorer.app.streamlit.app_prep_map_leaflet_caches as cache_module
+
+    monkeypatch.setattr(cache_module, "st", streamlit_stub)
+    session_key = ALL_LOCATIONS_LEAFLET_PAYLOAD_CACHE_KEY
+    legacy_key = ("legacy",)
+    streamlit_stub.session_state[session_key] = {
+        "payload_cache_key": legacy_key,
+        "revision": "old",
+        "geojson": {"features": []},
+    }
+
+    leaflet_payload_cache_store(
+        session_key,
+        ("new",),
+        {"revision": "new", "geojson": {"features": [{"id": 1}]}},
+        max_entries=2,
+    )
+
+    assert leaflet_payload_cache_lookup(session_key, legacy_key)["revision"] == "old"
+    assert leaflet_payload_cache_lookup(session_key, ("new",))["revision"] == "new"

--- a/tests/explorer/test_leaflet_payload_cache.py
+++ b/tests/explorer/test_leaflet_payload_cache.py
@@ -197,6 +197,8 @@ def test_leaflet_payload_cache_store_migrates_legacy_single_entry(
     streamlit_stub,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Other Streamlit tests may drop/reimport this module; bind and call the
+    # live module object so ``st`` patching matches store/lookup globals.
     import explorer.app.streamlit.app_prep_map_leaflet_caches as cache_module
 
     monkeypatch.setattr(cache_module, "st", streamlit_stub)
@@ -208,12 +210,16 @@ def test_leaflet_payload_cache_store_migrates_legacy_single_entry(
         "geojson": {"features": []},
     }
 
-    leaflet_payload_cache_store(
+    cache_module.leaflet_payload_cache_store(
         session_key,
         ("new",),
         {"revision": "new", "geojson": {"features": [{"id": 1}]}},
         max_entries=2,
     )
 
-    assert leaflet_payload_cache_lookup(session_key, legacy_key)["revision"] == "old"
-    assert leaflet_payload_cache_lookup(session_key, ("new",))["revision"] == "new"
+    assert cache_module.leaflet_payload_cache_lookup(session_key, legacy_key)[
+        "revision"
+    ] == "old"
+    assert cache_module.leaflet_payload_cache_lookup(session_key, ("new",))[
+        "revision"
+    ] == "new"

--- a/tests/explorer/test_lifer_date_filter_helpers.py
+++ b/tests/explorer/test_lifer_date_filter_helpers.py
@@ -1,6 +1,7 @@
 """Tests for lifer / last-seen date-filter helpers."""
 
 import pandas as pd
+import pytest
 
 from explorer.core.lifer_last_seen_prep import (
     observation_date_within_filter,
@@ -10,31 +11,49 @@ from explorer.core.lifer_last_seen_prep import (
 from explorer.core.species_logic import base_species_for_lifer
 
 
-def test_observation_date_within_filter_inclusive_bounds():
+@pytest.mark.parametrize(
+    ("observation_date", "expected"),
+    [
+        (pd.Timestamp("2021-01-01"), True),
+        (pd.Timestamp("2021-12-31"), True),
+        (pd.Timestamp("2020-12-31"), False),
+        (pd.Timestamp("2022-01-01"), False),
+        (pd.NaT, False),
+        ("not-a-date", False),
+    ],
+)
+def test_observation_date_within_filter_inclusive_bounds(
+    observation_date,
+    expected,
+):
     assert observation_date_within_filter(
-        pd.Timestamp("2021-06-15"),
+        observation_date,
         filter_start_date="2021-01-01",
         filter_end_date="2021-12-31",
-    )
-    assert not observation_date_within_filter(
-        pd.Timestamp("2020-12-31"),
-        filter_start_date="2021-01-01",
-        filter_end_date="2021-12-31",
-    )
+    ) is expected
 
 
 def test_subset_lifer_lookup_for_species_uses_taxon_for_subspecies():
     df = pd.DataFrame(
         {
-            "Submission ID": ["S1", "S2"],
-            "Date": [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-06-01")],
+            "Submission ID": ["S0", "S1", "S2"],
+            "Date": [
+                pd.Timestamp("2023-01-01"),
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-06-01"),
+            ],
             "datetime": [
+                pd.Timestamp("2023-01-01 08:00"),
                 pd.Timestamp("2024-01-01 08:00"),
                 pd.Timestamp("2024-06-01 08:00"),
             ],
-            "Location ID": ["L1", "L2"],
-            "Scientific Name": ["Anas gracilis rogersi", "Anas gracilis rogersi"],
-            "Common Name": ["Grey Teal", "Grey Teal"],
+            "Location ID": ["L0", "L1", "L2"],
+            "Scientific Name": [
+                "Anas gracilis",
+                "Anas gracilis rogersi",
+                "Anas gracilis rogersi",
+            ],
+            "Common Name": ["Grey Teal", "Grey Teal (rogersi)", "Grey Teal (rogersi)"],
         }
     )
     prep = prepare_lifer_last_seen(df, base_species_fn=base_species_for_lifer)
@@ -44,4 +63,5 @@ def test_subset_lifer_lookup_for_species_uses_taxon_for_subspecies():
         base_species_for_lifer,
     )
     assert len(subset) == 2
-    assert subset.iloc[0]["Location ID"] == "L1"
+    assert subset["Location ID"].tolist() == ["L1", "L2"]
+    assert subset["Scientific Name"].unique().tolist() == ["Anas gracilis rogersi"]

--- a/tests/explorer/test_lifer_last_seen_prep.py
+++ b/tests/explorer/test_lifer_last_seen_prep.py
@@ -38,8 +38,55 @@ def test_aggregate_lifer_sites_two_locations():
     )
     assert n == 2
     assert set(by_loc.keys()) == {"A", "C"}
-    assert len(by_loc["A"]) == 1
-    assert len(by_loc["C"]) == 1
+    assert by_loc["A"] == [
+        {
+            "scientific_name": "Turdus migratorius",
+            "common_name": "",
+            "is_base_lifer": True,
+            "is_taxon_lifer": False,
+        }
+    ]
+    assert by_loc["C"] == [
+        {
+            "scientific_name": "Anas superciliosa",
+            "common_name": "",
+            "is_base_lifer": True,
+            "is_taxon_lifer": False,
+        }
+    ]
+
+
+def test_prepare_lifer_last_seen_keeps_only_countable_species():
+    scientific_names = [
+        "Anas gracilis",
+        "Anas gracilis rogersi",
+        "Anas sp.",
+        "Anas gracilis x Anas castanea",
+        "Anas gracilis/castanea",
+        "Columba livia",
+    ]
+    df = pd.DataFrame(
+        {
+            "datetime": pd.date_range("2020-01-01", periods=6),
+            "Date": pd.date_range("2020-01-01", periods=6),
+            "Scientific Name": scientific_names,
+            "Common Name": [
+                "Grey Teal",
+                "Grey Teal (rogersi)",
+                "Duck sp.",
+                "Hybrid duck",
+                "Grey Teal / Chestnut Teal",
+                "Rock Pigeon (Domestic type)",
+            ],
+            "Location ID": [f"L{i}" for i in range(6)],
+        }
+    )
+
+    prep = prepare_lifer_last_seen(df, base_species_fn=base_species_for_lifer)
+
+    assert prep.lifer_lookup_df["Scientific Name"].tolist() == scientific_names[:2]
+    assert prep.true_lifer_locations == {"anas gracilis": "L0"}
+    assert prep.true_last_seen_locations == {"anas gracilis": "L1"}
 
 
 def test_prepare_lifer_last_seen_invariants_first_last_consistent():

--- a/tests/explorer/test_lifer_locations_geojson.py
+++ b/tests/explorer/test_lifer_locations_geojson.py
@@ -43,7 +43,7 @@ def test_build_lifer_geojson_minimal():
     )
     ctx = prepare_all_locations_map_context(df, full_df=df)
     sch = active_map_marker_colour_scheme(MAP_MARKER_COLOUR_SCHEME_DEFAULT)
-    rev, gj, warn, framing, _metrics = build_lifer_locations_geojson_payload(
+    rev, gj, warn, framing, metrics = build_lifer_locations_geojson_payload(
         full_location_data=ctx["full_location_data"],
         lifer_lookup_df=ctx["lifer_lookup_df"],
         true_lifer_locations=ctx["true_lifer_locations"],
@@ -54,14 +54,37 @@ def test_build_lifer_geojson_minimal():
         revision_extra="{}",
     )
     assert warn is None
-    assert rev is not None
-    assert gj is not None
+    assert isinstance(rev, str) and len(rev) == 24
+    assert gj == {
+        "type": "FeatureCollection",
+        "features": gj["features"],
+    }
     assert len(gj["features"]) == 1
-    props = gj["features"][0]["properties"]
+    feature = gj["features"][0]
+    assert feature["geometry"] == {"type": "Point", "coordinates": [151.0, -33.0]}
+    props = feature["properties"]
     assert props["location_id"] == "L1"
     assert props["name"] == "Patch A"
-    assert "lifer_popup_v1" in props
-    assert props["lifer_popup_v1"]["v"] == 1
-    assert len(props["lifer_popup_v1"]["lines"]) >= 1
-    assert "circle_pin" in props
-    assert len(framing) == 1
+    assert props["lifelist_url"] == "https://ebird.org/lifelist/L1"
+    assert props["pin_kind"] == "lifer"
+    assert props["lifer_popup_v1"] == {
+        "v": 1,
+        "lines": [
+            {
+                "label": "Grey Teal",
+                "date": "2024-06-01",
+                "checklist_href": "https://ebird.org/checklist/S1",
+            }
+        ],
+    }
+    assert set(props["circle_pin"]) == {
+        "stroke_hex",
+        "fill_hex",
+        "radius_px",
+        "stroke_weight",
+        "fill_opacity",
+    }
+    assert framing == [[-33.0, 151.0]]
+    assert metrics["marker_count"] == 1
+    assert metrics["popup_build_count"] == 1
+    assert metrics["popup_build_total_ms"] >= 0.0

--- a/tests/explorer/test_map_banner_species_url_integration.py
+++ b/tests/explorer/test_map_banner_species_url_integration.py
@@ -128,9 +128,12 @@ def test_species_map_prep_banner_includes_ebird_species_link(
 
     assert hint is None
     assert bundle.use_species_leaflet is True
-    assert 'href="https://ebird.org/species/grtea"' in (
-        bundle.all_locations_leaflet_banner_html or ""
-    )
+    banner = bundle.all_locations_leaflet_banner_html or ""
+    assert (
+        '<span class="pebird-map-banner__title"><a '
+        'href="https://ebird.org/species/grtea"'
+    ) in banner
+    assert 'target="_blank" rel="noopener noreferrer">Grey Teal</a>' in banner
 
 
 def test_family_map_prep_highlight_banner_includes_ebird_species_link(
@@ -167,3 +170,4 @@ def test_family_map_prep_highlight_banner_includes_ebird_species_link(
     assert bundle.use_family_leaflet is True
     banner = bundle.all_locations_leaflet_banner_html or ""
     assert 'href="https://ebird.org/species/rufwhi1"' in banner
+    assert 'target="_blank" rel="noopener noreferrer">Rufous Whistler</a>' in banner

--- a/tests/explorer/test_map_maintenance.py
+++ b/tests/explorer/test_map_maintenance.py
@@ -18,13 +18,11 @@ def test_exact_duplicates_detected():
         "Longitude": [149.0, 149.0],
     })
     exact_rows, near_pairs = get_map_maintenance_data(data, threshold_m=10)
-    assert len(exact_rows) == 2
-    names = {row[0] for row in exact_rows}
-    assert names == {"Alpha", "Alpha duplicate"}
-    for _, _, count, lat, lon in exact_rows:
-        assert count == 2
-        assert lat == -35.0
-        assert lon == 149.0
+    assert set(exact_rows) == {
+        ("Alpha", "L1", 2, -35.0, 149.0),
+        ("Alpha duplicate", "L2", 2, -35.0, 149.0),
+    }
+    assert near_pairs == []
 
 
 def test_exact_duplicates_same_name_listed_once():
@@ -69,8 +67,13 @@ def test_near_duplicates_within_threshold():
     })
     exact_rows, near_pairs = get_map_maintenance_data(data, threshold_m=10)
     assert exact_rows == []
-    assert len(near_pairs) == 1
-    assert {near_pairs[0][0][0], near_pairs[0][1][0]} == {"L1", "L2"}
+    assert {
+        (location_id, name, latitude, longitude)
+        for location_id, name, latitude, longitude in near_pairs[0]
+    } == {
+        ("L1", "Bravo", -35.001, 149.001),
+        ("L2", "Bravo-near", -35.00105, 149.00105),
+    }
 
 
 def test_near_duplicates_beyond_threshold():

--- a/tests/explorer/test_map_marker_colour_resolve.py
+++ b/tests/explorer/test_map_marker_colour_resolve.py
@@ -2,31 +2,34 @@
 
 from dataclasses import replace
 
-from explorer.app.streamlit.defaults import MAP_MARKER_COLOUR_SCHEME_1, active_map_marker_colour_scheme
+from explorer.app.streamlit.defaults import (
+    MAP_MARKER_COLOUR_SCHEME_1,
+    active_map_marker_colour_scheme,
+)
 from explorer.core.map_marker_colour_resolve import (
     MAP_MARKER_CATCHALL_FILL_HEX,
     MAP_MARKER_CATCHALL_STROKE_HEX,
     MAP_MARKER_SCHEME_DEFAULT_FILL_HEX,
     MAP_MARKER_SCHEME_DEFAULT_STROKE_HEX,
+    family_map_has_highlight_halo,
     family_map_resolved_circle_radius_px,
     family_map_resolved_fill_opacity,
     family_map_resolved_highlight_halo_fill_opacity,
     family_map_resolved_highlight_halo_radius_px,
     family_map_resolved_highlight_halo_stroke_opacity,
     family_map_resolved_highlight_halo_stroke_weight,
-    family_map_has_highlight_halo,
+    family_map_resolved_highlight_pin_stroke_hex,
     is_valid_hex_colour,
     normalize_marker_hex,
     resolve_family_band_colours,
     resolve_family_highlight_halo_fill_hex,
     resolve_family_highlight_halo_stroke_hex,
-    family_map_resolved_highlight_pin_stroke_hex,
     resolve_family_highlight_stroke_hex,
     resolve_location_visit_colours,
     resolve_marker_global_colours,
     resolve_species_map_background_colours,
 )
-
+from explorer.core.map_marker_scheme_model import SchemeColourOverrides
 from tests.colour_scheme_test_utils import BUNDLED_COLOUR_SCHEME_INDICES
 
 
@@ -57,6 +60,40 @@ def test_resolve_species_map_background_colours_valid_for_all_bundled_schemes() 
         f, s = resolve_species_map_background_colours(sch)
         assert is_valid_hex_colour(f)
         assert is_valid_hex_colour(s)
+
+
+def test_location_colour_resolution_prefers_override_then_specific_then_global() -> None:
+    specific = replace(
+        MAP_MARKER_COLOUR_SCHEME_1,
+        all_locations=replace(
+            MAP_MARKER_COLOUR_SCHEME_1.all_locations,
+            fill_hex="#112233",
+            stroke_hex="#445566",
+        ),
+    )
+    assert resolve_location_visit_colours(specific) == ("#112233", "#445566")
+
+    overridden = replace(
+        specific,
+        colour_overrides=SchemeColourOverrides(
+            location_fill_hex="#AABBCC",
+            location_stroke_hex="#DDEEFF",
+        ),
+    )
+    assert resolve_location_visit_colours(overridden) == ("#AABBCC", "#DDEEFF")
+
+    invalid_specific = replace(
+        MAP_MARKER_COLOUR_SCHEME_1,
+        all_locations=replace(
+            MAP_MARKER_COLOUR_SCHEME_1.all_locations,
+            fill_hex="invalid",
+            stroke_hex="invalid",
+        ),
+    )
+    assert resolve_location_visit_colours(invalid_specific) == (
+        MAP_MARKER_COLOUR_SCHEME_1.global_defaults.fill_hex,
+        MAP_MARKER_COLOUR_SCHEME_1.global_defaults.stroke_hex,
+    )
 
 
 def test_is_valid_hex_colour() -> None:

--- a/tests/explorer/test_map_perf_e2e.py
+++ b/tests/explorer/test_map_perf_e2e.py
@@ -140,16 +140,11 @@ def _run_headline_four_map_mode_journey(page: Any) -> None:
     )
     choose_species_by_common_name(page, E2E_FIXTURE_SPECIES_COMMON)
 
-    try:
-        family_label = choose_first_recorded_family(page)
-        wait_for_pebird_map_markup(
-            page,
-            must_contain=map_banner_must_contain(family_label),
-        )
-    except Exception:
-        choose_map_view_mode(page, "Family locations")
-        wait_for_pebird_map_markup(page, must_contain=["pebird-map-banner"])
-        return
+    family_label = choose_first_recorded_family(page)
+    wait_for_pebird_map_markup(
+        page,
+        must_contain=map_banner_must_contain(family_label),
+    )
 
     choose_map_view_mode(page, "Lifer locations")
     wait_for_pebird_map_markup(

--- a/tests/explorer/test_map_popup_heading_text.py
+++ b/tests/explorer/test_map_popup_heading_text.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from explorer.presentation.map_popup_heading_text import prevent_orphan_closing_punctuation
+import pytest
+
+from explorer.presentation.map_popup_heading_text import (
+    prevent_orphan_closing_punctuation,
+)
 
 
 def test_orphan_closing_paren_at_end_of_title():
@@ -22,3 +26,13 @@ def test_orphan_fix_does_not_touch_open_paren_space():
 def test_orphan_fix_skips_titles_without_trailing_close_punct():
     raw = "Lake Gilles Conservation Park--Track at -33.0"
     assert prevent_orphan_closing_punctuation(raw) == raw
+
+
+@pytest.mark.parametrize("closing_punctuation", [")", "]", "}", '"', "'", "»"])
+def test_orphan_fix_supports_every_documented_closing_character(
+    closing_punctuation: str,
+) -> None:
+    assert (
+        prevent_orphan_closing_punctuation(f"Location label {closing_punctuation}  ")
+        == f"Location label\u00a0{closing_punctuation}"
+    )

--- a/tests/explorer/test_perf_instrumentation.py
+++ b/tests/explorer/test_perf_instrumentation.py
@@ -37,6 +37,21 @@ def test_explorer_perf_enabled_true_from_env(mock_st: MagicMock, monkeypatch: py
     assert p.explorer_perf_enabled() is True
 
 
+def test_perf_span_disabled_does_not_create_session_events(
+    mock_st: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.delenv("EXPLORER_PERF", raising=False)
+    log_path = tmp_path / "disabled.jsonl"
+    monkeypatch.setenv("EXPLORER_PERF_LOG_FILE", str(log_path))
+    from explorer.app.streamlit import perf_instrumentation as p
+
+    with p.perf_span("unit.disabled"):
+        pass
+
+    assert EXPLORER_PERF_EVENTS_KEY not in mock_st.session_state
+    assert not log_path.exists()
+
+
 def test_perf_span_records_when_enabled(mock_st: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EXPLORER_PERF", "1")
     from explorer.app.streamlit import perf_instrumentation as p
@@ -74,11 +89,12 @@ def test_perf_log_file_appends_jsonl(
     with p.perf_span("unit.file_probe"):
         pass
 
-    text = log_path.read_text(encoding="utf-8").strip()
-    assert text
-    record = json.loads(text.splitlines()[0])
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
     assert record["stage"] == "unit.file_probe"
     assert record["dataset_sig"] == "sig-file"
+    assert record["run_kind"] == "full_run"
 
 
 def test_perf_fragment_records(mock_st: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/explorer/test_social_cards_streamlit_helpers.py
+++ b/tests/explorer/test_social_cards_streamlit_helpers.py
@@ -121,6 +121,17 @@ def test_social_cards_dataframe_signature_prefers_session_sig():
     assert social_cards_dataframe_signature(None) == ("empty", 0)
 
 
+def test_social_cards_dataframe_signature_fallback_tracks_identity_and_row_count():
+    import pandas as pd
+
+    first = pd.DataFrame({"Submission ID": ["s1", "s2"]})
+    second = first.copy()
+
+    assert social_cards_dataframe_signature(first) == ("id", id(first), 2)
+    assert social_cards_dataframe_signature(second) == ("id", id(second), 2)
+    assert social_cards_dataframe_signature(first) != social_cards_dataframe_signature(second)
+
+
 def _base_png_fingerprint_kwargs() -> dict:
     return {
         "stats": ShareSummaryStats(
@@ -156,8 +167,7 @@ def test_card_stat_data_scope_from_session_export_uses_export_source():
         fmt="portrait",
         tiles_presentation="circles",
     )
-    assert scope.startswith("export|")
-    assert "AU" in scope or "au" in scope.lower() or "|" in scope
+    assert scope == "export|year|2025|AU|portrait|circles"
 
 
 def test_png_export_fingerprint_changes_when_stat_picks_change():

--- a/tests/explorer/test_species_locations_geojson.py
+++ b/tests/explorer/test_species_locations_geojson.py
@@ -71,9 +71,12 @@ def test_build_species_geojson_with_match_and_background_pin():
         revision_extra="{}",
     )
     assert warn is None
-    assert rev is not None
-    assert gj is not None
-    assert len(gj["features"]) == 2
+    assert rev is not None and len(rev) == 24
+    assert gj["type"] == "FeatureCollection"
+    assert {
+        feature["properties"]["location_id"]: feature["geometry"]["coordinates"]
+        for feature in gj["features"]
+    } == {"L1": [151.0, -33.0], "L2": [152.0, -34.0]}
     props_match = next(
         f["properties"]
         for f in gj["features"]
@@ -89,9 +92,56 @@ def test_build_species_geojson_with_match_and_background_pin():
     )
     assert "popup_v1" in props_bg
     assert "visited" in props_bg["popup_v1"]
-    assert len(framing) == 1
-    assert "Species" in roles
-    assert "Locations" in roles
+    assert framing == [[-33.0, 151.0]]
+    assert roles == {"Species", "Locations"}
+    assert _metrics["marker_count"] == 2
+    assert _metrics["popup_build_count"] == 2
+    assert _metrics["popup_build_total_ms"] >= 0.0
+
+
+def test_build_species_geojson_empty_selection_returns_empty_contract():
+    ctx = prepare_all_locations_map_context(_species_map_df(), full_df=_species_map_df())
+
+    revision, geojson, warning, framing, roles, metrics = (
+        build_species_locations_geojson_payload(
+            **_species_payload_kwargs(ctx, selected_species="")
+        )
+    )
+
+    assert revision is None
+    assert geojson is None
+    assert warning is None
+    assert framing == []
+    assert roles == set()
+    assert metrics == {
+        "marker_count": 0,
+        "popup_build_count": 0,
+        "popup_build_total_ms": 0.0,
+    }
+
+
+def test_build_species_geojson_unknown_species_explains_empty_result():
+    ctx = prepare_all_locations_map_context(_species_map_df(), full_df=_species_map_df())
+
+    revision, geojson, warning, framing, roles, metrics = (
+        build_species_locations_geojson_payload(
+            **_species_payload_kwargs(
+                ctx,
+                selected_species="Missingus birdii",
+            )
+        )
+    )
+
+    assert revision is None
+    assert geojson is None
+    assert warning == (
+        "⚠️ No sightings of 'Missingus birdii' in current data — "
+        "check date range or filters."
+    )
+    assert framing == []
+    assert roles == set()
+    assert metrics["marker_count"] == 0
+    assert metrics["popup_build_count"] == 0
 
 
 def _species_map_df() -> pd.DataFrame:

--- a/tests/explorer/test_species_search.py
+++ b/tests/explorer/test_species_search.py
@@ -27,8 +27,7 @@ def test_whoosh_suggestions_ranking():
         w.add_document(common_name=name, scientific_name="", taxonomy_group="")
     w.commit()
     out = whoosh_species_suggestions(ix, "gre", max_options=6, min_query_len=3)
-    assert len(out) >= 1
-    assert all(isinstance(s, str) for s in out)
+    assert out == ["Green Pygmy-goose", "Great Egret", "Great Cormorant"]
 
 
 def test_whoosh_species_suggestions_matches_scientific_name():
@@ -58,8 +57,7 @@ def test_whoosh_species_suggestions_uses_taxonomy_group_helper_weight():
     )
     w.commit()
     out = whoosh_species_suggestions(ix, "aus", min_query_len=3)
-    assert out
-    assert "Scarlet Robin" in out
+    assert out == ["Australian Pipit", "Scarlet Robin"]
 
 
 def test_whoosh_species_suggestions_has_no_synthetic_group_rows():
@@ -96,7 +94,6 @@ def test_whoosh_species_suggestions_prefers_multi_token_coverage():
     )
     w.commit()
     out = whoosh_species_suggestions(ix, "aus rob", min_query_len=3)
-    assert out
     assert out[0] == "Eastern Yellow Robin"
 
 
@@ -115,7 +112,6 @@ def test_whoosh_species_suggestions_prefers_common_name_token_over_sci_only():
     )
     w.commit()
     out = whoosh_species_suggestions(ix, "austr", min_query_len=3)
-    assert out
     assert out[0] == "Australian Pipit"
 
 
@@ -134,7 +130,6 @@ def test_whoosh_species_suggestions_deprioritizes_spuh_sp_suffix():
     )
     w.commit()
     out = whoosh_species_suggestions(ix, "aus tree", min_query_len=3)
-    assert out
     assert out[0] == "Brown Treecreeper"
 
 
@@ -153,7 +148,6 @@ def test_whoosh_species_suggestions_deprioritizes_trailing_paren_subspecies_form
     )
     w.commit()
     out = whoosh_species_suggestions(ix, "east yell rob", min_query_len=3)
-    assert out
     assert out[0] == "Eastern Yellow Robin"
 
 

--- a/tests/explorer/test_streamlit_journeys_e2e.py
+++ b/tests/explorer/test_streamlit_journeys_e2e.py
@@ -64,7 +64,11 @@ def test_journey_species_locations_mode_shows_awaiting_selection_banner(
         page.goto(streamlit_app_url, wait_until="domcontentloaded")
         page.get_by_text("Personal eBird Explorer").wait_for(timeout=20000)
         choose_map_view_mode(page, "Species locations")
-        wait_for_pebird_map_markup(
+        html = wait_for_pebird_map_markup(
             page,
-            must_contain=['class="pebird-map-banner__title">Species locations</span>'],
+            must_contain=[
+                'class="pebird-map-banner__title">Species locations</span>',
+                "Select a species in the sidebar to load the map data",
+            ],
         )
+        assert "Select a species in the sidebar to load the map data" in html

--- a/tests/explorer/test_streamlit_map_prep.py
+++ b/tests/explorer/test_streamlit_map_prep.py
@@ -37,9 +37,9 @@ def _tiny_df():
 def test_prepare_all_locations_map_context_has_location_totals():
     df = _tiny_df()
     ctx = prepare_all_locations_map_context(df)
-    assert ctx["effective_totals"][0] == 1
-    assert "records_by_loc" in ctx
-    assert "L1" in ctx["records_by_loc"]
+    assert ctx["effective_totals"] == (1, 1, 1, 3)
+    assert set(ctx["records_by_loc"]) == {"L1"}
+    pd.testing.assert_frame_equal(ctx["records_by_loc"]["L1"].reset_index(drop=True), df)
 
 
 def test_prepare_empty_raises():
@@ -73,9 +73,7 @@ def test_mean_center_from_location_data():
     df = _tiny_df()
     ctx = prepare_all_locations_map_context(df)
     c = mean_center_from_location_data(ctx["effective_location_data"])
-    assert c is not None
-    assert c[0] == pytest.approx(-35.0)
-    assert c[1] == pytest.approx(149.0)
+    assert c == pytest.approx((-35.0, 149.0))
 
 
 def test_mean_center_from_location_data_empty_returns_none():

--- a/tests/explorer/test_streamlit_map_working.py
+++ b/tests/explorer/test_streamlit_map_working.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from datetime import date
 from pathlib import Path
 
 import pandas as pd
@@ -31,19 +32,19 @@ def _fixture_csv_path() -> Path:
 @pytest.fixture
 def df() -> pd.DataFrame:
     path = _fixture_csv_path()
-    if not path.exists():
-        pytest.skip(f"Fixture not found: {path}")
+    assert path.is_file(), f"required integration fixture is missing: {path}"
     return load_dataset(path)
 
 
 def test_date_bounds_from_df(df: pd.DataFrame) -> None:
     lo, hi = date_bounds_from_df(df)
-    assert lo <= hi
+    assert (lo, hi) == (date(2022, 1, 16), date(2026, 2, 25))
 
 
 def test_date_inception_to_today_default(df: pd.DataFrame) -> None:
     a, b = date_inception_to_today_default(df)
-    assert a <= b
+    assert a == date(2022, 1, 16)
+    assert b == date.today()
 
 
 def test_streamlit_lifer_status(df: pd.DataFrame) -> None:
@@ -54,7 +55,8 @@ def test_streamlit_lifer_status(df: pd.DataFrame) -> None:
         date_range=None,
     )
     assert ws is not None
-    assert "Lifer" in status
+    assert len(ws.df) == len(df)
+    assert status == "Lifer view uses all-time data"
 
 
 def test_streamlit_date_filter_on(df: pd.DataFrame) -> None:
@@ -66,7 +68,8 @@ def test_streamlit_date_filter_on(df: pd.DataFrame) -> None:
         date_range=(lo, hi),
     )
     assert ws is not None
-    assert "Date filter:" in status
+    assert len(ws.df) == len(df)
+    assert status == f"Date filter: {lo.isoformat()} to {hi.isoformat()}"
 
 
 def test_streamlit_species_view_uses_same_date_filter_as_all(df: pd.DataFrame) -> None:
@@ -84,6 +87,6 @@ def test_streamlit_species_view_uses_same_date_filter_as_all(df: pd.DataFrame) -
         date_range=(lo, hi),
     )
     assert ws_all is not None and ws_sp is not None
-    assert len(ws_all.df) == len(ws_sp.df)
+    assert ws_all.df["Submission ID"].tolist() == ws_sp.df["Submission ID"].tolist()
     assert st_all == st_sp
 

--- a/tests/explorer/test_streamlit_settings_config.py
+++ b/tests/explorer/test_streamlit_settings_config.py
@@ -26,6 +26,8 @@ def test_load_yaml_settings_rejects_invalid_type(tmp_path):
     p.write_text("tables_lists:\n  rankings_top_n: nope\n", encoding="utf-8")
     cfg, warn = load_yaml_settings(str(p))
     assert warn is not None
+    assert warn.startswith("Invalid settings YAML; using defaults.")
+    assert "valid integer" in warn
     assert cfg["tables_lists"]["rankings_top_n"] == 200
 
 
@@ -59,6 +61,11 @@ def test_write_sparse_preserves_unknown_keys(tmp_path):
     assert raw["map_display"]["popup_sort_order"] == "descending"
     assert raw["map_display"]["map_marker_colour_scheme"] == 2
     assert "tables_lists" not in raw  # defaults omitted
+    assert set(raw) == {"custom", "version", "map_display"}
+    assert set(raw["map_display"]) == {
+        "popup_sort_order",
+        "map_marker_colour_scheme",
+    }
 
 
 def test_config_path_yaml_roundtrip(tmp_path):
@@ -99,6 +106,11 @@ def test_config_path_yaml_roundtrip(tmp_path):
     assert raw["data_folder"] == "/tmp/ebird"
     assert raw["deploy_destination"] == "/tmp/deploy.py"
     assert "explorer_settings" in raw
+    assert set(raw["explorer_settings"]) == {"version", "map_display"}
+    assert set(raw["explorer_settings"]["map_display"]) == {
+        "popup_sort_order",
+        "map_marker_colour_scheme",
+    }
 
     cfg, warn = load_settings_from_config_path(str(p))
     assert warn is None
@@ -147,8 +159,13 @@ def test_settings_data_path_html_includes_config_path_when_given():
         repo_root="/repo",
         config_yaml_abs_path="/repo/config/config_secret.yaml",
     )
-    assert "Configuration file path:" in html_out
-    assert "/repo/config/config_secret.yaml" in html_out
+    assert "<strong>Data file name:</strong> <code>MyEBirdData.csv</code>" in html_out
+    assert "<strong>Data file path:</strong> <code>/data/MyEBirdData.csv</code>" in html_out
+    assert "<strong>Data file loaded by:</strong> Configuration file" in html_out
+    assert (
+        "<strong>Configuration file path:</strong> "
+        "<code>/repo/config/config_secret.yaml</code>"
+    ) in html_out
 
 
 def test_settings_data_path_html_omits_config_path_when_not_passed():
@@ -161,4 +178,5 @@ def test_settings_data_path_html_omits_config_path_when_not_passed():
         repo_root="/repo",
     )
     assert "Configuration file path:" not in html_out
+    assert "<strong>Data file loaded by:</strong> Working directory" in html_out
 

--- a/tests/explorer/test_streamlit_ui_helpers.py
+++ b/tests/explorer/test_streamlit_ui_helpers.py
@@ -492,9 +492,13 @@ def test_load_dataframe_upload_happy_path(streamlit_stub) -> None:
             return raw
 
     df, prov, src_label, data_path, base = app_data_loading.load_dataframe(uploaded=_Up())
-    assert df is not None and len(df) > 0
-    assert prov and "Upload:" in prov and _Up.name in prov
-    assert src_label is None and data_path is None
+    assert df is not None
+    assert df.iloc[0]["Submission ID"] == "S100909607"
+    assert df.iloc[0]["Common Name"] == "Eastern Spinebill"
+    assert pd.api.types.is_datetime64_any_dtype(df["Date"])
+    assert prov == f"Upload: **{_Up.name}**"
+    assert src_label is None
+    assert data_path is None
     assert base == _Up.name
 
 
@@ -514,7 +518,7 @@ def test_load_dataframe_upload_error_surfaces_st_error(streamlit_stub, monkeypat
 
     df, *_rest = app_data_loading.load_dataframe(uploaded=_Bad())
     assert df is None
-    assert any("Could not load CSV" in msg for msg in streamlit_stub.error_calls)
+    assert streamlit_stub.error_calls == ["Could not load CSV: forced load failure"]
 
 
 def test_load_dataframe_disk_path_and_labels(streamlit_stub, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -537,7 +541,8 @@ def test_load_dataframe_disk_path_and_labels(streamlit_stub, monkeypatch: pytest
 
     df, prov, src_label, data_path, base = app_data_loading.load_dataframe()
     assert df is not None
-    assert prov and "Disk:" in prov and "/data/MyEBirdData.csv" in prov
+    assert df.to_dict(orient="records") == [{"Submission ID": "x"}]
+    assert prov == "Disk: `/data/MyEBirdData.csv` (_Config Yaml_)"
     assert src_label == "config_yaml"
     assert data_path == "/data/MyEBirdData.csv"
     assert base == "MyEBirdData.csv"
@@ -562,9 +567,15 @@ def test_load_dataframe_falls_back_to_upload_cache(streamlit_stub, monkeypatch: 
     )
 
     raw = _fixture_csv_bytes()
-    df, prov, *_rest = app_data_loading.load_dataframe(upload_cache=(raw, "cached.csv"))
+    df, prov, src_label, data_path, base = app_data_loading.load_dataframe(
+        upload_cache=(raw, "cached.csv")
+    )
     assert df is not None
-    assert prov and "Upload:" in prov and "cached.csv" in prov
+    assert df.to_dict(orient="records") == [{"Submission ID": "cache"}]
+    assert prov == "Upload: **cached.csv**"
+    assert src_label is None
+    assert data_path is None
+    assert base == "cached.csv"
 
 
 def test_load_dataframe_upload_cache_error_surfaces_st_error(
@@ -590,7 +601,7 @@ def test_load_dataframe_upload_cache_error_surfaces_st_error(
 
     df, *_rest = app_data_loading.load_dataframe(upload_cache=(b"not-valid-csv", "cached.csv"))
     assert df is None
-    assert any("Could not load CSV" in msg for msg in streamlit_stub.error_calls)
+    assert streamlit_stub.error_calls == ["Could not load CSV: forced cache load failure"]
 
 
 def test_ensure_streamlit_map_basemap_height_keys_seeds_and_repairs(streamlit_stub) -> None:

--- a/tests/explorer/test_verify_explorer_build_not_behind_github.py
+++ b/tests/explorer/test_verify_explorer_build_not_behind_github.py
@@ -34,16 +34,32 @@ def version_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def test_main_passes_when_embedded_matches_latest(
-    monkeypatch: pytest.MonkeyPatch, version_file
+    monkeypatch: pytest.MonkeyPatch, version_file, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("RELEASE_TODAY", "2026-04-24")
     version_file.write_text("2026-04-24\n", encoding="utf-8")
+    request_call: dict[str, object] = {}
 
-    def _open(*_a, **_k):
+    def _open(request, *, timeout):
+        request_call["url"] = request.full_url
+        request_call["user_agent"] = request.get_header("User-agent")
+        request_call["timeout"] = timeout
         return _FakeResp({"tag_name": "2026-04-24-Beta"})
 
     monkeypatch.setattr("urllib.request.urlopen", _open)
     assert subject.main() == 0
+    captured = capsys.readouterr()
+    assert request_call == {
+        "url": subject._GITHUB_LATEST_API,
+        "user_agent": subject._HTTP_USER_AGENT,
+        "timeout": subject._HTTP_TIMEOUT_SEC,
+    }
+    assert (
+        captured.out
+        == "OK: embedded '2026-04-24' is not behind GitHub latest '2026-04-24-Beta'; "
+        "base date matches RELEASE_TODAY '2026-04-24'\n"
+    )
+    assert captured.err == ""
 
 
 def test_main_passes_same_day_suffix_when_release_today_matches_base(
@@ -60,7 +76,7 @@ def test_main_passes_same_day_suffix_when_release_today_matches_base(
 
 
 def test_main_fails_when_embedded_behind_latest(
-    monkeypatch: pytest.MonkeyPatch, version_file
+    monkeypatch: pytest.MonkeyPatch, version_file, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setenv("RELEASE_TODAY", "2026-04-22")
     version_file.write_text("2026-04-22\n", encoding="utf-8")
@@ -70,6 +86,11 @@ def test_main_fails_when_embedded_behind_latest(
 
     monkeypatch.setattr("urllib.request.urlopen", _open)
     assert subject.main() == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "embedded: '2026-04-22'" in captured.err
+    assert "GitHub:   '2026-04-24-Beta'" in captured.err
+    assert "Bump explorer/app/streamlit/explorer_build_version.txt" in captured.err
 
 
 def test_main_fails_when_release_today_mismatch_before_github(
@@ -92,7 +113,11 @@ def test_main_fails_on_invalid_release_today_env(
     assert subject.main() == 1
 
 
-def test_main_fails_on_missing_tag_name(monkeypatch: pytest.MonkeyPatch, version_file) -> None:
+def test_main_fails_on_missing_tag_name(
+    monkeypatch: pytest.MonkeyPatch,
+    version_file,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     monkeypatch.setenv("RELEASE_TODAY", "2026-04-24")
     version_file.write_text("2026-04-24\n", encoding="utf-8")
 
@@ -101,9 +126,16 @@ def test_main_fails_on_missing_tag_name(monkeypatch: pytest.MonkeyPatch, version
 
     monkeypatch.setattr("urllib.request.urlopen", _open)
     assert subject.main() == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "ERROR: GitHub releases/latest response missing tag_name\n"
 
 
-def test_main_fails_on_http_error(monkeypatch: pytest.MonkeyPatch, version_file) -> None:
+def test_main_fails_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+    version_file,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     monkeypatch.setenv("RELEASE_TODAY", "2026-04-24")
     version_file.write_text("2026-04-24\n", encoding="utf-8")
     monkeypatch.setattr(
@@ -111,6 +143,9 @@ def test_main_fails_on_http_error(monkeypatch: pytest.MonkeyPatch, version_file)
         MagicMock(side_effect=OSError("network down")),
     )
     assert subject.main() == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "ERROR: could not fetch GitHub latest release: network down\n"
 
 
 def test_main_passes_without_release_today_skips_calendar_gate(

--- a/tests/scripts/test_build_all_locations_map_frontend.py
+++ b/tests/scripts/test_build_all_locations_map_frontend.py
@@ -10,11 +10,15 @@ from pathlib import Path
 _REPO = Path(__file__).resolve().parents[2]
 _SCRIPT = _REPO / "scripts/build_all_locations_map_frontend.py"
 _BUILD = _REPO / "explorer/components/all_locations_map/frontend/build"
+sys.path.insert(0, str(_REPO / "scripts"))
+
+import build_all_locations_map_frontend as mod  # noqa: E402
 
 
 def test_check_only_passes_on_current_build():
-    if not (_BUILD / "asset-manifest.json").is_file():
-        return
+    assert (_BUILD / "asset-manifest.json").is_file(), (
+        "committed frontend build is required"
+    )
     proc = subprocess.run(
         [sys.executable, str(_SCRIPT), "--check-only"],
         cwd=_REPO,
@@ -24,17 +28,48 @@ def test_check_only_passes_on_current_build():
     assert proc.returncode == 0, proc.stderr + proc.stdout
 
 
-def test_detects_macos_junk_dir(tmp_path):
+def test_manifest_paths_include_assets_but_exclude_source_maps(tmp_path: Path) -> None:
     build = tmp_path / "build"
-    (build / "static" / "css 4").mkdir(parents=True)
-    (build / "index.html").write_text("<html></html>", encoding="utf-8")
+    (build / "static" / "js").mkdir(parents=True)
+    (build / "static" / "js" / "main.abc.js").write_text("", encoding="utf-8")
     (build / "asset-manifest.json").write_text(
-        json.dumps({"files": {}, "entrypoints": []}),
+        json.dumps(
+            {
+                "files": {
+                    "main.js": "./static/js/main.abc.js",
+                    "main.js.map": "./static/js/main.abc.js.map",
+                },
+                "entrypoints": ["static/js/main.abc.js"],
+            }
+        ),
         encoding="utf-8",
     )
-    # Import helpers without running npm
-    sys.path.insert(0, str(_REPO / "scripts"))
-    import build_all_locations_map_frontend as mod  # noqa: E402
 
-    junk = mod._find_junk_dirs(build)
-    assert any(p.name == "css 4" for p in junk)
+    assert mod._manifest_paths(build) == {
+        Path("asset-manifest.json"),
+        Path("index.html"),
+        Path("static/js/main.abc.js"),
+    }
+
+
+def test_detects_only_macos_junk_dirs(tmp_path: Path) -> None:
+    build = tmp_path / "build"
+    (build / "static" / "css 4").mkdir(parents=True)
+    (build / "static" / "css").mkdir()
+    (build / "static" / "images 4").mkdir()
+
+    assert mod._find_junk_dirs(build) == [build / "static" / "css 4"]
+
+
+def test_unexpected_files_ignores_source_maps(tmp_path: Path) -> None:
+    build = tmp_path / "build"
+    (build / "static" / "js").mkdir(parents=True)
+    expected_file = build / "static" / "js" / "main.js"
+    expected_file.write_text("", encoding="utf-8")
+    (build / "static" / "js" / "main.js.map").write_text("", encoding="utf-8")
+    orphan = build / "static" / "js" / "old.js"
+    orphan.write_text("", encoding="utf-8")
+
+    assert mod._find_unexpected_files(build, {Path("static/js/main.js")}) == [
+        Path("static/js/old.js")
+    ]

--- a/tests/scripts/test_check_pip_audit.py
+++ b/tests/scripts/test_check_pip_audit.py
@@ -20,8 +20,10 @@ def test_evaluate_passes_with_no_vulnerabilities() -> None:
         [{"name": "pandas", "version": "3.0.3", "vulns": []}],
         ignore_until_fix={"PYSEC-2024-277": "joblib"},
     )
-    assert code == 0
-    assert any("OK" in line for line in lines)
+    assert (code, lines) == (
+        0,
+        ["pip-audit policy: OK", "No known vulnerabilities."],
+    )
 
 
 def test_defers_advisory_when_no_fix_versions() -> None:
@@ -42,7 +44,11 @@ def test_defers_advisory_when_no_fix_versions() -> None:
         ignore_until_fix={"PYSEC-2024-277": "joblib"},
     )
     assert code == 0
-    assert any("deferred" in line.lower() for line in lines)
+    assert lines == [
+        "pip-audit policy: OK",
+        "Deferred until fix available:",
+        "  - PYSEC-2024-277 (joblib): deferred — no fix version on PyPI (see SECURITY.md)",
+    ]
 
 
 def test_fails_when_deferred_advisory_has_fix_versions() -> None:
@@ -79,5 +85,35 @@ def test_fails_on_unlisted_vulnerability() -> None:
         ],
         ignore_until_fix={"PYSEC-2024-277": "joblib"},
     )
+    assert (code, lines) == (
+        1,
+        [
+            "pip-audit policy: FAILED",
+            "CVE-2099-0001 (example): reported vulnerability — fix versions: 1.0.1",
+        ],
+    )
+
+
+def test_reports_failures_and_still_deferred_advisories_together() -> None:
+    code, lines = mod.evaluate_audit_report(
+        [
+            {
+                "name": "joblib",
+                "vulns": [{"id": "PYSEC-2024-277", "fix_versions": []}],
+            },
+            {
+                "name": "example",
+                "vulns": [{"id": "CVE-2099-0002", "fix_versions": []}],
+            },
+        ],
+        ignore_until_fix={"PYSEC-2024-277": "joblib"},
+    )
+
     assert code == 1
-    assert any("CVE-2099-0001" in line for line in lines)
+    assert lines == [
+        "pip-audit policy: FAILED",
+        "CVE-2099-0002 (example): reported vulnerability",
+        "",
+        "Still deferred (no fix yet):",
+        "  - PYSEC-2024-277 (joblib): deferred — no fix version on PyPI (see SECURITY.md)",
+    ]

--- a/tests/scripts/test_ebird_checklist_name_from_gps.py
+++ b/tests/scripts/test_ebird_checklist_name_from_gps.py
@@ -1,0 +1,78 @@
+"""Offline tests for the standalone GPS checklist-name resolver."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO / "scripts"))
+
+import eBirdChecklistNameFromGPS as mod  # noqa: E402
+
+_FIXTURE = _REPO / "tests/fixtures/gps_checklistName_testing.json"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("-35.327454,148.860410", (-35.327454, 148.860410, 6, 6)),
+        ("Place ( -35.5, 149.1250 )", (-35.5, 149.125, 1, 4)),
+        ("149.1250 -35.5", (-35.5, 149.125, 1, 4)),
+    ],
+)
+def test_parse_coords_accepts_supported_formats(
+    text: str, expected: tuple[float, float, int, int]
+) -> None:
+    assert mod.parse_coords_from_text(text) == expected
+
+
+@pytest.mark.parametrize("text", ["", "latitude only: -35.2", "91, 181"])
+def test_parse_coords_rejects_missing_or_out_of_range_values(text: str) -> None:
+    with pytest.raises(ValueError):
+        mod.parse_coords_from_text(text)
+
+
+def test_fetch_geocode_sends_coordinates_and_rejects_api_failure(monkeypatch) -> None:
+    response = Mock()
+    response.json.return_value = {"status": "ZERO_RESULTS", "results": []}
+    get = Mock(return_value=response)
+    monkeypatch.setattr(mod.requests, "get", get)
+
+    with pytest.raises(RuntimeError, match="Geocode failed: ZERO_RESULTS"):
+        mod.fetch_geocode(-35.1, 149.2, "secret")
+
+    get.assert_called_once_with(
+        "https://maps.googleapis.com/maps/api/geocode/json",
+        params={"latlng": "-35.1,149.2", "key": "secret"},
+    )
+
+
+def test_embedded_geocode_cases_resolve_to_expected_names() -> None:
+    cases = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+    checked = 0
+
+    for case in cases:
+        if not case.get("expected") or not case.get("geocode_json"):
+            continue
+        actual = mod.resolve_location_from_data(
+            case["geocode_json"], float(case["lat"]), float(case["lng"])
+        )
+        assert actual.casefold() == case["expected"].strip().casefold(), case.get(
+            "name"
+        )
+        checked += 1
+
+    assert cases, "GPS fixture must contain offline cases"
+    assert checked == len(cases), "every GPS fixture case must be complete and asserted"
+
+
+def test_format_location_string_limits_precision_and_trims_zeroes() -> None:
+    assert (
+        mod.format_location_string("Canberra", -35.5000004, 149.125, 1, 3)
+        == "Canberra ( -35.5, 149.125 )"
+    )

--- a/tests/scripts/test_prune_finder_duplicates.py
+++ b/tests/scripts/test_prune_finder_duplicates.py
@@ -13,17 +13,22 @@ import prune_finder_duplicates as mod  # noqa: E402
 def test_find_finder_file_duplicate(tmp_path: Path) -> None:
     (tmp_path / "real.py").write_text("x", encoding="utf-8")
     (tmp_path / "real 2.py").write_text("y", encoding="utf-8")
+    (tmp_path / "chapter 2").write_text(
+        "not a Finder-style file copy", encoding="utf-8"
+    )
     dupes = mod.find_finder_duplicates(tmp_path)
-    assert len(dupes) == 1
-    assert dupes[0].name == "real 2.py"
+    assert dupes == [tmp_path / "real 2.py"]
 
 
 def test_prune_removes_duplicates(tmp_path: Path) -> None:
     junk = tmp_path / "notes 2.md"
     junk.write_text("dup", encoding="utf-8")
+    retained = tmp_path / "notes.md"
+    retained.write_text("original", encoding="utf-8")
     removed = mod.prune_finder_duplicates(tmp_path)
-    assert len(removed) == 1
+    assert removed == [junk]
     assert not junk.exists()
+    assert retained.read_text(encoding="utf-8") == "original"
 
 
 def test_build_static_junk_dir(tmp_path: Path) -> None:
@@ -31,4 +36,22 @@ def test_build_static_junk_dir(tmp_path: Path) -> None:
     (static / "css").mkdir(parents=True)
     (static / "css 4").mkdir(parents=True)
     dupes = mod.find_finder_duplicates(tmp_path)
-    assert any(p.name == "css 4" for p in dupes)
+    assert dupes == [static / "css 4"]
+
+
+def test_dependency_and_cache_trees_are_not_scanned(tmp_path: Path) -> None:
+    for skipped_name in ("node_modules", ".venv", ".venv-audit", "__pycache__"):
+        skipped = tmp_path / skipped_name
+        skipped.mkdir()
+        (skipped / "module 2.py").write_text("ignored", encoding="utf-8")
+
+    assert mod.find_finder_duplicates(tmp_path) == []
+
+
+def test_prune_removes_duplicate_directory_tree(tmp_path: Path) -> None:
+    duplicate_dir = tmp_path / "assets 2"
+    duplicate_dir.mkdir()
+    (duplicate_dir / "nested.txt").write_text("duplicate", encoding="utf-8")
+
+    assert mod.prune_finder_duplicates(tmp_path) == [duplicate_dir]
+    assert not duplicate_dir.exists()


### PR DESCRIPTION
## Summary
One-off engineering audit of the legacy test suite using the Test Integrity Sentinel mindset. Existing tests were reviewed by area and strengthened so they honestly validate behaviour rather than only checking for smoke/existence.

## Changes
- **Core data/model:** tighter fixture rankings, checklist stats content, lifer date/countable coverage, Whoosh suggestion results, integration species filters
- **Map/caching:** Leaflet payload/export LRU and invalidation, GeoJSON geometry/popup contracts, viewport/basemap/map-component render contracts, GPS parse edges, perf disabled path
- **Streamlit / share-adjacent:** cache compute args, path/settings contracts, dataframe load provenance, design preview GeoJSON, social-card scope keys, debug/release diagnostics
- **GPS / scripts:** new offline GPS resolver suite over embedded geocode fixtures; stronger frontend-build, pip-audit, and prune-duplicate assertions
- **Frontend Jest:** expanded Leaflet parser/component coverage
- **E2E / leftovers:** stronger species awaiting-selection and family journey contracts; remaining map GeoJSON/popup/colour assertions; config isolation and perf JSONL checks
- Fixed Leaflet legacy-cache migration test isolation after `app_prep` module drop/reimport

## Testing
- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q -m "not e2e"` — 920 passed, 4 skipped (PNG env-gated)
- `npm run test:ci` in `explorer/components/all_locations_map/frontend/` — 15 passed (when frontend tests changed)

## Issues
Fixes #290

Made with [Cursor](https://cursor.com)