### PR TITLE
Enable Social Cards PNG export on Streamlit Cloud

### DIFF
--- a/docs/explorer/issue-157-share-summary-tracker.md
+++ b/docs/explorer/issue-157-share-summary-tracker.md
@@ -405,7 +405,7 @@ Reasons:
 - Pillow export for **one fixed layout** only (more maintenance); or
 - Client-side export (browser canvas) — possible but awkward in Streamlit.
 
-**Decision:** ☑ Playwright  ☐ Pillow  ☐ Hybrid  ☐ Defer until Cloud checked *(Cloud verification still open)*
+**Decision:** ☑ Playwright  ☐ Pillow  ☐ Hybrid  ☐ Defer until Cloud checked *(Cloud verified — [#345](https://github.com/jimchurches/myebirdstuff/issues/345))*
 
 ---
 
@@ -564,7 +564,7 @@ The explorer is a **browser-based web app**, developed and optimised primarily f
 - **Weekly stats** use **Sun–Sat** calendar weeks (not ISO Mon–Sun).
 - **Empty periods** return zeroed stats object; cards may look sparse — may need “no data” state in UI.
 - Logo SVG is embedded via data URI; PNG export must bundle or inline the same asset.
-- **Playwright on Streamlit Cloud** — must verify headless Chromium in production; blocks Cloud PNG if unsupported — tracked in [#345](https://github.com/jimchurches/myebirdstuff/issues/345).
+- **Playwright on Streamlit Cloud** — verified on Community Cloud ([#345](https://github.com/jimchurches/myebirdstuff/issues/345)); `packages.txt` + lazy Chromium install. Re-test if Playwright or the Cloud Debian image changes.
 - **Chromium reuse across PNG exports** — each export launches a fresh browser today; warm/reuse is a perf follow-up — [#344](https://github.com/jimchurches/myebirdstuff/issues/344).
 - **Phone save behaviour** — long-press / share sheet varies by browser; design app ships secondary download button as fallback.
 
@@ -578,8 +578,8 @@ The explorer is a **browser-based web app**, developed and optimised primarily f
 |-------|----------|--------|
 | `pip install playwright` during app deploy | Succeeds (listed in `requirements.txt`) | Assumed OK |
 | System libraries for Chromium | Repo-root `packages.txt` (apt via Community Cloud; **package names only** — Cloud does not treat `#` lines as comments) | **Shipped** |
-| Chromium browser binaries | Lazy `python -m playwright install chromium` on first export when executable missing (`share_summary_png_export.py`) | **Shipped** — confirm on live Cloud after deploy |
-| PNG on Social Cards / design app | Download succeeds, or clear warning if still blocked | Error path now fragment-reruns so first click surfaces the message |
+| Chromium browser binaries | Lazy `python -m playwright install chromium` on first export when executable missing (`share_summary_png_export.py`) | **Verified** on live Cloud (author, #345) |
+| PNG on Social Cards / design app | Download succeeds, or clear warning if still blocked | **Verified** on live Cloud; error path fragment-reruns so first click surfaces the message |
 | iOS / Android save/share | Spot-check once Cloud PNG works | **Open** |
 
 **If Cloud still blocks Chromium** (e.g. newer Playwright needs apt packages unavailable on Community Cloud’s Debian image): show HTML preview only and document “PNG export requires local run” until a Pillow fallback or pinned Playwright version is added. Re-test save flow on iOS/Android once a Cloud deploy succeeds.
@@ -617,5 +617,6 @@ The explorer is a **browser-based web app**, developed and optimised primarily f
 | 2026-07-01 | **#275 closed** (PNG export design studio); **#276 closed** — superseded by [#323](https://github.com/jimchurches/myebirdstuff/issues/323) epic + port batches [#324](https://github.com/jimchurches/myebirdstuff/issues/324)–[#328](https://github.com/jimchurches/myebirdstuff/issues/328) |
 | 2026-07-14 | PNG Cloud verify + Chromium reuse follow-ups filed: [#345](https://github.com/jimchurches/myebirdstuff/issues/345), [#344](https://github.com/jimchurches/myebirdstuff/issues/344) (PR #343 review) |
 | 2026-07-14 | [#345](https://github.com/jimchurches/myebirdstuff/issues/345): `packages.txt` + lazy Chromium install on first PNG export; fix first-click export error UX |
+| 2026-07-14 | [#345](https://github.com/jimchurches/myebirdstuff/issues/345): Streamlit Cloud PNG export verified on live deploy (author) |
 | 2026-07-14 | Archived `social-cards-workflow.md` to [#157 comment](https://github.com/jimchurches/myebirdstuff/issues/157#issuecomment-4964282021); module map kept in this tracker |
 | 2026-07-14 | Archived early prototype notes to [#157 comment](https://github.com/jimchurches/myebirdstuff/issues/157#issuecomment-4964295174); removed stale `issue-157-social-summary-prototype.md` |

--- a/docs/explorer/issue-157-share-summary-tracker.md
+++ b/docs/explorer/issue-157-share-summary-tracker.md
@@ -577,7 +577,7 @@ The explorer is a **browser-based web app**, developed and optimised primarily f
 | Check | Expected | Status |
 |-------|----------|--------|
 | `pip install playwright` during app deploy | Succeeds (listed in `requirements.txt`) | Assumed OK |
-| System libraries for Chromium | Repo-root `packages.txt` (apt via Community Cloud) | **Shipped** |
+| System libraries for Chromium | Repo-root `packages.txt` (apt via Community Cloud; **package names only** — Cloud does not treat `#` lines as comments) | **Shipped** |
 | Chromium browser binaries | Lazy `python -m playwright install chromium` on first export when executable missing (`share_summary_png_export.py`) | **Shipped** — confirm on live Cloud after deploy |
 | PNG on Social Cards / design app | Download succeeds, or clear warning if still blocked | Error path now fragment-reruns so first click surfaces the message |
 | iOS / Android save/share | Spot-check once Cloud PNG works | **Open** |

--- a/docs/explorer/issue-157-share-summary-tracker.md
+++ b/docs/explorer/issue-157-share-summary-tracker.md
@@ -572,16 +572,17 @@ The explorer is a **browser-based web app**, developed and optimised primarily f
 
 **Local / CI:** `playwright` is a runtime dependency in `requirements.txt`. After `pip install -r requirements.txt`, run `python -m playwright install chromium`. Unit tests in `test_share_summary_png_export.py` assert PNG width/height; CI installs Chromium in the `unit-tests` job.
 
-**Streamlit Cloud (not yet verified on a live deploy) — open checklist lives on [#345](https://github.com/jimchurches/myebirdstuff/issues/345):**
+**Streamlit Cloud — setup shipped for [#345](https://github.com/jimchurches/myebirdstuff/issues/345):**
 
 | Check | Expected | Status |
 |-------|----------|--------|
 | `pip install playwright` during app deploy | Succeeds (listed in `requirements.txt`) | Assumed OK |
-| `playwright install chromium` on Cloud builder | May **not** run automatically — Cloud only runs `pip install` from requirements | **Open — [#345](https://github.com/jimchurches/myebirdstuff/issues/345)** |
-| Headless Chromium launch at runtime | Needs browser binaries on the container filesystem (~100MB+) | **Open — [#345](https://github.com/jimchurches/myebirdstuff/issues/345)** |
-| PNG on Social Cards / design app | Download succeeds, or warning if Chromium missing | Graceful `RuntimeError` message implemented |
+| System libraries for Chromium | Repo-root `packages.txt` (apt via Community Cloud) | **Shipped** |
+| Chromium browser binaries | Lazy `python -m playwright install chromium` on first export when executable missing (`share_summary_png_export.py`) | **Shipped** — confirm on live Cloud after deploy |
+| PNG on Social Cards / design app | Download succeeds, or clear warning if still blocked | Error path now fragment-reruns so first click surfaces the message |
+| iOS / Android save/share | Spot-check once Cloud PNG works | **Open** |
 
-**If Cloud blocks Chromium:** show HTML preview only on Cloud (current behaviour for scaled mockup) and document “PNG export requires local run” until a Pillow fallback or custom Cloud build step is added. Re-test save flow on iOS/Android once a Cloud deploy exists.
+**If Cloud still blocks Chromium** (e.g. newer Playwright needs apt packages unavailable on Community Cloud’s Debian image): show HTML preview only and document “PNG export requires local run” until a Pillow fallback or pinned Playwright version is added. Re-test save flow on iOS/Android once a Cloud deploy succeeds.
 
 ---
 
@@ -615,5 +616,6 @@ The explorer is a **browser-based web app**, developed and optimised primarily f
 | 2026-06-29 | **#285 Interesting Insights:** separate layout for species/checklist facts; Spotlight restored to stat-only (Classic/Circle); design studio insights + species pickers; countable species picker deferred to main-app port ([#328](https://github.com/jimchurches/myebirdstuff/issues/328)) |
 | 2026-07-01 | **#275 closed** (PNG export design studio); **#276 closed** — superseded by [#323](https://github.com/jimchurches/myebirdstuff/issues/323) epic + port batches [#324](https://github.com/jimchurches/myebirdstuff/issues/324)–[#328](https://github.com/jimchurches/myebirdstuff/issues/328) |
 | 2026-07-14 | PNG Cloud verify + Chromium reuse follow-ups filed: [#345](https://github.com/jimchurches/myebirdstuff/issues/345), [#344](https://github.com/jimchurches/myebirdstuff/issues/344) (PR #343 review) |
+| 2026-07-14 | [#345](https://github.com/jimchurches/myebirdstuff/issues/345): `packages.txt` + lazy Chromium install on first PNG export; fix first-click export error UX |
 | 2026-07-14 | Archived `social-cards-workflow.md` to [#157 comment](https://github.com/jimchurches/myebirdstuff/issues/157#issuecomment-4964282021); module map kept in this tracker |
 | 2026-07-14 | Archived early prototype notes to [#157 comment](https://github.com/jimchurches/myebirdstuff/issues/157#issuecomment-4964295174); removed stale `issue-157-social-summary-prototype.md` |

--- a/explorer/app/streamlit/social_cards_png_export_ui.py
+++ b/explorer/app/streamlit/social_cards_png_export_ui.py
@@ -230,6 +230,9 @@ def render_lazy_png_export_controls(
                 st.session_state[SOCIAL_CARDS_PNG_EXPORT_ERROR_KEY] = str(exc)
                 st.session_state.pop(SOCIAL_CARDS_PNG_EXPORT_BYTES_KEY, None)
                 st.session_state.pop(SOCIAL_CARDS_PNG_EXPORT_FINGERPRINT_KEY, None)
+                # Fragment must rerun so the warning at the top is painted; without
+                # this, a failed first click looks like a no-op (#345).
+                _rerun_social_cards_fragment()
                 return
             st.session_state[SOCIAL_CARDS_PNG_EXPORT_BYTES_KEY] = png_bytes
             st.session_state[SOCIAL_CARDS_PNG_EXPORT_FINGERPRINT_KEY] = fingerprint

--- a/explorer/presentation/share_summary_png_export.py
+++ b/explorer/presentation/share_summary_png_export.py
@@ -120,8 +120,8 @@ def _chromium_missing_message() -> str:
     return (
         "Playwright Chromium is not available for PNG export. "
         "Locally run: python -m playwright install chromium. "
-        "On Streamlit Cloud, confirm packages.txt system libraries are "
-        "installed and redeploy after merging Cloud PNG support (#345)."
+        "On Streamlit Cloud, confirm packages.txt is at the repo root "
+        "and redeploy the app if PNG export was recently enabled."
     )
 
 
@@ -135,8 +135,8 @@ def _raise_launch_failure(exc: BaseException) -> None:
     if _system_deps_missing(exc):
         raise RuntimeError(
             "PNG export needs system libraries for Chromium. "
-            "On Streamlit Cloud, ensure packages.txt is present at the "
-            "repo root and redeploy (#345)."
+            "On Streamlit Cloud, ensure packages.txt is at the repo root "
+            "and redeploy the app after updating system dependencies."
         ) from exc
     if _chromium_executable_missing(exc):
         raise RuntimeError(_chromium_missing_message()) from exc

--- a/explorer/presentation/share_summary_png_export.py
+++ b/explorer/presentation/share_summary_png_export.py
@@ -3,13 +3,21 @@ PNG export for share-summary cards (#275) — HTML layouts → Playwright screen
 
 Requires the ``playwright`` package and Chromium binaries
 (``python -m playwright install chromium``).
+
+On Streamlit Community Cloud, ``pip install`` alone does not download browsers.
+This module installs Chromium into the user cache on first use when the
+executable is missing (#345). System libraries still need ``packages.txt``.
 """
 
 from __future__ import annotations
 
 import contextlib
+import logging
 import re
 import struct
+import subprocess
+import sys
+import threading
 from typing import TYPE_CHECKING
 
 from explorer.core.share_summary_insight_facts import ShareSummaryInsightFact
@@ -31,6 +39,11 @@ if TYPE_CHECKING:
 
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
+_logger = logging.getLogger(__name__)
+
+# One install attempt per process — avoids install loops if download fails.
+_chromium_install_lock = threading.Lock()
+_chromium_install_attempted = False
 
 
 def png_dimensions(png_bytes: bytes) -> tuple[int, int]:
@@ -62,13 +75,84 @@ def share_summary_png_filename(
     return f"{base}-birding-summary.png"
 
 
+def _chromium_executable_missing(exc: BaseException) -> bool:
+    """True when Playwright reports browsers were never installed."""
+    return "Executable doesn't exist" in str(exc)
+
+
+def _install_chromium() -> None:
+    """Download Playwright Chromium into the user cache (no apt / no sudo)."""
+    _logger.info("Installing Playwright Chromium for share-summary PNG export")
+    result = subprocess.run(
+        [sys.executable, "-m", "playwright", "install", "chromium"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        # Prefer the last Error: line from Playwright's downloader over full logs.
+        for line in reversed(detail.splitlines()):
+            stripped = line.strip()
+            if stripped.startswith("Error:"):
+                detail = stripped
+                break
+        else:
+            if len(detail) > 280:
+                detail = detail[-280:]
+        raise RuntimeError(
+            "Failed to install Playwright Chromium for PNG export. "
+            f"{detail or 'Unknown error.'}"
+        )
+
+
+def _ensure_chromium_installed() -> None:
+    """Install Chromium once per process if launch reported it missing."""
+    global _chromium_install_attempted
+    with _chromium_install_lock:
+        if _chromium_install_attempted:
+            return
+        _chromium_install_attempted = True
+        _install_chromium()
+
+
+def _chromium_missing_message() -> str:
+    return (
+        "Playwright Chromium is not available for PNG export. "
+        "Locally run: python -m playwright install chromium. "
+        "On Streamlit Cloud, confirm packages.txt system libraries are "
+        "installed and redeploy after merging Cloud PNG support (#345)."
+    )
+
+
+def _system_deps_missing(exc: BaseException) -> bool:
+    """True when Chromium cannot start due to missing OS libraries."""
+    return "Host system is missing dependencies" in str(exc)
+
+
+def _raise_launch_failure(exc: BaseException) -> None:
+    """Translate Playwright launch failures into user-facing RuntimeError."""
+    if _system_deps_missing(exc):
+        raise RuntimeError(
+            "PNG export needs system libraries for Chromium. "
+            "On Streamlit Cloud, ensure packages.txt is present at the "
+            "repo root and redeploy (#345)."
+        ) from exc
+    if _chromium_executable_missing(exc):
+        raise RuntimeError(_chromium_missing_message()) from exc
+    raise exc
+
+
 @contextlib.contextmanager
 def _launch_chromium():
     """Launch a short-lived Chromium for one PNG export.
 
     A fresh browser per export keeps shutdown simple and avoids leaked
     headless processes across Streamlit reruns. Warm reuse across exports
-    can land later if batch or rapid-fire export becomes common.
+    can land later if batch or rapid-fire export becomes common (#344).
+
+    When binaries are missing (typical after Cloud ``pip install`` only),
+    download Chromium once into the user cache, then retry launch.
     """
     try:
         from playwright.sync_api import sync_playwright
@@ -81,13 +165,15 @@ def _launch_chromium():
         try:
             browser = playwright.chromium.launch()
         except Exception as exc:
-            msg = str(exc)
-            if "Executable doesn't exist" in msg:
-                raise RuntimeError(
-                    "Playwright Chromium is not installed. Run: "
-                    "python -m playwright install chromium"
-                ) from exc
-            raise
+            if not _chromium_executable_missing(exc):
+                _raise_launch_failure(exc)
+            try:
+                _ensure_chromium_installed()
+                browser = playwright.chromium.launch()
+            except RuntimeError:
+                raise
+            except Exception as retry_exc:
+                _raise_launch_failure(retry_exc)
         try:
             yield browser
         finally:

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,22 @@
+# System libraries for Playwright Chromium (Streamlit Community Cloud apt-get).
+# Cloud does not run `playwright install`; browser binaries are downloaded at
+# first PNG export (see share_summary_png_export.py). These packages satisfy
+# Chromium's shared-library deps on Debian (Community Cloud).
+# See: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/app-dependencies
+libnss3
+libnspr4
+libatk1.0-0
+libatk-bridge2.0-0
+libcups2
+libdrm2
+libatspi2.0-0
+libxcomposite1
+libxdamage1
+libxfixes3
+libxrandr2
+libgbm1
+libxkbcommon0
+libpango-1.0-0
+libcairo2
+libasound2
+libwayland-client0

--- a/packages.txt
+++ b/packages.txt
@@ -1,8 +1,3 @@
-# System libraries for Playwright Chromium (Streamlit Community Cloud apt-get).
-# Cloud does not run `playwright install`; browser binaries are downloaded at
-# first PNG export (see share_summary_png_export.py). These packages satisfy
-# Chromium's shared-library deps on Debian (Community Cloud).
-# See: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/app-dependencies
 libnss3
 libnspr4
 libatk1.0-0

--- a/tests/explorer/test_share_summary_png_export.py
+++ b/tests/explorer/test_share_summary_png_export.py
@@ -1,6 +1,8 @@
 """Tests for :mod:`explorer.presentation.share_summary_png_export`."""
 
 from contextlib import contextmanager
+import sys
+import types
 
 import pytest
 
@@ -23,7 +25,14 @@ def chromium_available():
             fmt="square",
         )
     except RuntimeError as exc:
-        if "Chromium is not installed" in str(exc) or "Playwright is not installed" in str(exc):
+        msg = str(exc)
+        if (
+            "Chromium is not installed" in msg
+            or "Chromium is not available" in msg
+            or "Playwright is not installed" in msg
+            or "Failed to install Playwright Chromium" in msg
+            or "packages.txt" in msg
+        ):
             pytest.skip(str(exc))
         raise
 
@@ -104,6 +113,78 @@ def test_share_summary_to_png_bytes_builds_full_size_screenshot(monkeypatch):
         "type": "png",
         "clip": {"x": 0, "y": 0, "width": 1080, "height": 1350},
     }
+
+
+def test_launch_chromium_installs_when_executable_missing(monkeypatch):
+    """Cloud pip-only deploys need a one-shot ``playwright install chromium`` (#345)."""
+    launches = {"n": 0}
+    installs = {"n": 0}
+
+    class _Browser:
+        def close(self):
+            pass
+
+    class _Chromium:
+        def launch(self):
+            launches["n"] += 1
+            if launches["n"] == 1:
+                raise RuntimeError(
+                    "Executable doesn't exist at /tmp/ms-playwright/chromium/chrome"
+                )
+            return _Browser()
+
+    class _Playwright:
+        chromium = _Chromium()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        share_summary_png_export,
+        "_chromium_install_attempted",
+        False,
+    )
+    monkeypatch.setattr(
+        share_summary_png_export,
+        "_install_chromium",
+        lambda: installs.__setitem__("n", installs["n"] + 1),
+    )
+
+    fake_sync_api = types.SimpleNamespace(sync_playwright=lambda: _Playwright())
+    monkeypatch.setitem(sys.modules, "playwright", types.ModuleType("playwright"))
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", fake_sync_api)
+
+    with share_summary_png_export._launch_chromium() as browser:
+        assert isinstance(browser, _Browser)
+
+    assert installs["n"] == 1
+    assert launches["n"] == 2
+
+
+def test_launch_chromium_maps_missing_system_deps(monkeypatch):
+    class _Chromium:
+        def launch(self):
+            raise RuntimeError("Host system is missing dependencies to run browsers.")
+
+    class _Playwright:
+        chromium = _Chromium()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    fake_sync_api = types.SimpleNamespace(sync_playwright=lambda: _Playwright())
+    monkeypatch.setitem(sys.modules, "playwright", types.ModuleType("playwright"))
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", fake_sync_api)
+
+    with pytest.raises(RuntimeError, match="packages.txt"):
+        with share_summary_png_export._launch_chromium():
+            pass
 
 
 @pytest.mark.parametrize(

--- a/tests/explorer/test_share_summary_png_export.py
+++ b/tests/explorer/test_share_summary_png_export.py
@@ -1,8 +1,8 @@
 """Tests for :mod:`explorer.presentation.share_summary_png_export`."""
 
-from contextlib import contextmanager
 import sys
 import types
+from contextlib import contextmanager
 
 import pytest
 
@@ -113,6 +113,35 @@ def test_share_summary_to_png_bytes_builds_full_size_screenshot(monkeypatch):
         "type": "png",
         "clip": {"x": 0, "y": 0, "width": 1080, "height": 1350},
     }
+
+
+def test_install_chromium_runs_playwright_module(monkeypatch):
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def _fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(share_summary_png_export.subprocess, "run", _fake_run)
+
+    share_summary_png_export._install_chromium()
+
+    assert calls == [
+        (
+            [
+                sys.executable,
+                "-m",
+                "playwright",
+                "install",
+                "chromium",
+            ],
+            {
+                "capture_output": True,
+                "text": True,
+                "check": False,
+            },
+        )
+    ]
 
 
 def test_launch_chromium_installs_when_executable_missing(monkeypatch):

--- a/tests/explorer/test_streamlit_ui_helpers.py
+++ b/tests/explorer/test_streamlit_ui_helpers.py
@@ -719,6 +719,55 @@ def test_lazy_png_export_cache_clears_stale_bytes(streamlit_stub) -> None:
     assert ui.SOCIAL_CARDS_PNG_AUTO_DOWNLOAD_KEY not in st.session_state
 
 
+def test_lazy_png_export_failure_reruns_to_show_warning(
+    streamlit_stub,
+    monkeypatch,
+) -> None:
+    ui = importlib.import_module("explorer.app.streamlit.social_cards_png_export_ui")
+    fingerprint = ("current-card",)
+    rerun_calls: list[None] = []
+
+    def _raise_export_error(**_kwargs) -> None:
+        raise RuntimeError("Chromium unavailable")
+
+    monkeypatch.setattr(ui, "png_export_fingerprint", lambda **_kwargs: fingerprint)
+    monkeypatch.setattr(streamlit_stub, "button", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        ui,
+        "_generate_share_summary_png_bytes",
+        _raise_export_error,
+    )
+    monkeypatch.setattr(
+        ui,
+        "_rerun_social_cards_fragment",
+        lambda: rerun_calls.append(None),
+    )
+
+    ui.render_lazy_png_export_controls(
+        stats=object(),
+        layout="tiles",
+        fmt="square",
+        card_stat_labels=(),
+        spotlight_label="Lifers",
+        all_time=None,
+        color_scheme_index=0,
+        scope_label="All records",
+        geo_scope=object(),
+        tiles_presentation="grid",
+        spotlight_presentation="classic",
+        resolved_fact=None,
+        export_button_label="Export PNG",
+        png_filename="summary.png",
+    )
+
+    assert streamlit_stub.session_state[ui.SOCIAL_CARDS_PNG_EXPORT_ERROR_KEY] == (
+        "Chromium unavailable"
+    )
+    assert rerun_calls == [None]
+    assert ui.SOCIAL_CARDS_PNG_EXPORT_BYTES_KEY not in streamlit_stub.session_state
+    assert ui.SOCIAL_CARDS_PNG_EXPORT_FINGERPRINT_KEY not in streamlit_stub.session_state
+
+
 def test_inject_streamlit_checklist_css_composes_table_and_surface(streamlit_stub) -> None:
     from explorer.app.streamlit import streamlit_theme
     from explorer.presentation.checklist_stats_display import CHECKLIST_STATS_TABLE_CSS


### PR DESCRIPTION
## Summary

Streamlit Cloud shipped Playwright via `pip` but never installed Chromium browsers, so Social Cards PNG export failed after “Generating PNG…”. This adds Cloud apt libs, lazy Chromium install on first export, and surfaces export errors on the first click.

## Changes

- Add repo-root `packages.txt` (package names only — Cloud does not treat `#` as comments)
- Lazy `playwright install chromium` when the executable is missing
- Fragment-rerun on PNG export failure so the warning shows on the first click
- Unit tests for install-on-missing and missing-system-deps messaging
- Update share-summary tracker Cloud verification notes

## Testing

- [x] `python3 -m ruff check explorer/`
- [x] `python3 -m pytest tests/ -q` (931 passed, 2 skipped)
- [x] Streamlit Cloud deploy on this branch — Social Cards PNG export succeeds after comment-free `packages.txt` fix

## Issues

Fixes #345


Made with [Cursor](https://cursor.com)