### PR TITLE
Refactor: Move most-frequent parent common helper into species_logic

### DIFF
--- a/explorer/core/share_summary_insight_facts.py
+++ b/explorer/core/share_summary_insight_facts.py
@@ -206,10 +206,8 @@ def species_common_names_in_period(
     countable = frame.dropna(subset=["_base"])
     if countable.empty:
         return ()
-    countable = countable.copy()
-    countable["_parent_common"] = countable["Common Name"].map(parent_common_name)
     names = (
-        countable.groupby("_base", sort=False)["_parent_common"]
+        countable.groupby("_base", sort=False)["Common Name"]
         .agg(most_frequent_parent_common)
         .dropna()
         .astype(str)

--- a/explorer/core/share_summary_insight_facts.py
+++ b/explorer/core/share_summary_insight_facts.py
@@ -23,9 +23,12 @@ from explorer.core.share_summary_compute import (
     _fmt_short_date,
     _mask_in_period,
 )
-from explorer.core.species_logic import countable_species_vectorized, parent_common_name
+from explorer.core.species_logic import (
+    countable_species_vectorized,
+    most_frequent_parent_common,
+    parent_common_name,
+)
 from explorer.core.stats import (
-    _most_frequent_parent_common,
     rankings_by_checklists,
     rankings_by_individuals,
     rankings_high_counts,
@@ -207,7 +210,7 @@ def species_common_names_in_period(
     countable["_parent_common"] = countable["Common Name"].map(parent_common_name)
     names = (
         countable.groupby("_base", sort=False)["_parent_common"]
-        .agg(_most_frequent_parent_common)
+        .agg(most_frequent_parent_common)
         .dropna()
         .astype(str)
         .str.strip()

--- a/explorer/core/species_logic.py
+++ b/explorer/core/species_logic.py
@@ -1,9 +1,9 @@
 """
 Species-related pure logic for Personal eBird Explorer.
 
-Functions for species filtering, countable-species normalisation, and
-base-species extraction. All functions are pure (explicit inputs/outputs,
-no widget or UI state dependencies).
+Functions for species filtering, countable-species normalisation,
+base-species extraction, and parent common-name roll-up. All functions are pure
+(explicit inputs/outputs, no widget or UI state dependencies).
 """
 
 import pandas as pd
@@ -86,6 +86,13 @@ def most_frequent_parent_common(common_names: pd.Series) -> str:
     Each value is stripped to its parent via :func:`parent_common_name` (so
     subspecies labels roll up), then empty strings are dropped. Used by
     rankings aggregations and Interesting Insights display names.
+
+    Args:
+        common_names: Raw or parent-level common name values.
+
+    Returns:
+        The mode parent-level name, or ``""`` when the series is empty or
+        every value strips to empty.
     """
     parents = common_names.map(parent_common_name)
     parents = parents.astype(str).str.strip()

--- a/explorer/core/species_logic.py
+++ b/explorer/core/species_logic.py
@@ -80,6 +80,21 @@ def parent_common_name(common_name: object) -> str:
     return s[:idx] if idx != -1 else s
 
 
+def most_frequent_parent_common(common_names: pd.Series) -> str:
+    """Return the most frequent parent-species common name in a series.
+
+    Each value is stripped to its parent via :func:`parent_common_name` (so
+    subspecies labels roll up), then empty strings are dropped. Used by
+    rankings aggregations and Interesting Insights display names.
+    """
+    parents = common_names.map(parent_common_name)
+    parents = parents.astype(str).str.strip()
+    parents = parents[parents != ""]
+    if parents.empty:
+        return ""
+    return str(parents.value_counts().index[0])
+
+
 def base_species_for_lifer(sci_name):
     """Extract base species (genus + species, lowercased) from a scientific name.
 

--- a/explorer/core/stats.py
+++ b/explorer/core/stats.py
@@ -15,7 +15,11 @@ import pandas as pd
 
 from explorer.core.settings_schema_defaults import TAXONOMY_LOCALE_DEFAULT
 from explorer.core.species_family import build_base_species_to_family_map
-from explorer.core.species_logic import countable_species_vectorized, parent_common_name
+from explorer.core.species_logic import (
+    countable_species_vectorized,
+    most_frequent_parent_common,
+    parent_common_name,
+)
 
 # ---------------------------------------------------------------------------
 # Shared utility
@@ -37,16 +41,6 @@ def safe_count(x):
         return int(x)
     except (ValueError, TypeError):
         return 0
-
-
-def _most_frequent_parent_common(common_names: pd.Series) -> str:
-    """Most frequent parent-species common name (subspecies labels strip to parent)."""
-    parents = common_names.map(parent_common_name)
-    parents = parents.astype(str).str.strip()
-    parents = parents[parents != ""]
-    if parents.empty:
-        return ""
-    return str(parents.value_counts().index[0])
 
 
 def format_observed_count_for_map_popup(raw) -> str:
@@ -516,7 +510,7 @@ def rankings_by_individuals(df_obs, limit):
         df_s.groupby("_base")
         .agg(
             total=("_count", "sum"),
-            common_name=("Common Name", _most_frequent_parent_common),
+            common_name=("Common Name", most_frequent_parent_common),
         )
         .reset_index()
     )
@@ -545,7 +539,7 @@ def rankings_by_checklists(df_obs, limit):
         df_s.groupby("_base")
         .agg(
             n_checklists=("Submission ID", "nunique"),
-            common_name=("Common Name", _most_frequent_parent_common),
+            common_name=("Common Name", most_frequent_parent_common),
         )
         .reset_index()
     )
@@ -742,7 +736,7 @@ def rankings_seen_once(df_obs, limit=None):
         .agg(
             n_checklists=("Submission ID", "nunique"),
             checklist_count=("_count", "sum"),
-            common_name=("Common Name", _most_frequent_parent_common),
+            common_name=("Common Name", most_frequent_parent_common),
             Location=("Location", "first"),
             Location_ID=("Location ID", "first"),
             Submission_ID=("Submission ID", "first"),

--- a/tests/explorer/test_species_normalisation.py
+++ b/tests/explorer/test_species_normalisation.py
@@ -7,6 +7,7 @@ from explorer.core.species_logic import (
     is_countable,
     countable_species_vectorized,
     base_species_for_lifer,
+    most_frequent_parent_common,
     parent_common_name,
 )
 
@@ -27,6 +28,27 @@ def test_parent_common_name_strips_subspecies_qualifier():
     assert parent_common_name("Australian Boobook (Australian)") == "Australian Boobook"
     assert parent_common_name("Australian Boobook") == "Australian Boobook"
     assert parent_common_name("") == ""
+
+
+def test_most_frequent_parent_common_rolls_up_subspecies():
+    names = pd.Series(
+        [
+            "Australian Boobook (Australian)",
+            "Australian Boobook (Tasmanian)",
+            "Australian Boobook",
+            "Grey Teal",
+        ]
+    )
+    assert most_frequent_parent_common(names) == "Australian Boobook"
+
+
+def test_most_frequent_parent_common_ignores_empty():
+    names = pd.Series(["", "   ", "Grey Teal", None])
+    assert most_frequent_parent_common(names) == "Grey Teal"
+
+
+def test_most_frequent_parent_common_empty_series():
+    assert most_frequent_parent_common(pd.Series(dtype=object)) == ""
 
 
 def test_base_species_name_none():


### PR DESCRIPTION
## Summary

Moves the subspecies → parent common-name aggregator into `explorer.core.species_logic` as a public helper, so Insights and other callers no longer import a private symbol from `stats`.

## Changes

- Add public `most_frequent_parent_common` next to `parent_common_name` in `species_logic`
- Update `stats.py` rankings aggregations to use the public helper
- Update `share_summary_insight_facts.py` to import from `species_logic` instead of private `stats` API
- Add unit tests for rollup / empty / blank handling

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (945 passed, 11 skipped)

## Notes

Behaviour unchanged — boundary/cleanup only (Nit-Fixer follow-up from #334 / PR #353).

## Issues

Fixes #355

Made with [Cursor](https://cursor.com)