### PR TITLE
Restore species search controls on Map tab

### DIFF
--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -117,9 +117,9 @@ def _all_locations_leaflet_embed_active(session_state: Any) -> bool:
 def invalidate_map_embed_cache(*, bump_mount_nonce: bool = True) -> None:
     """Bump Leaflet component mount nonce and clear export HTML when map chrome changes."""
     if bump_mount_nonce:
-        st.session_state[LEAFLET_MAP_MOUNT_NONCE_KEY] = int(
-            st.session_state.get(LEAFLET_MAP_MOUNT_NONCE_KEY, 0)
-        ) + 1
+        st.session_state[LEAFLET_MAP_MOUNT_NONCE_KEY] = (
+            int(st.session_state.get(LEAFLET_MAP_MOUNT_NONCE_KEY, 0)) + 1
+        )
     st.session_state.pop(EXPLORER_MAP_HTML_BYTES_KEY, None)
     st.session_state.pop(LEAFLET_EXPORT_RECIPE_KEY, None)
     st.session_state.pop(LEAFLET_EXPORT_BUILT_CACHE_KEY, None)
@@ -150,7 +150,9 @@ class MapWorkingContext:
 
 def _effective_map_style() -> str:
     """Basemap key from session, falling back to saved/default when invalid."""
-    saved_basemap = st.session_state.get(STREAMLIT_MAP_BASEMAP_SAVED_KEY, MAP_BASEMAP_OPTIONS[0])
+    saved_basemap = st.session_state.get(
+        STREAMLIT_MAP_BASEMAP_SAVED_KEY, MAP_BASEMAP_OPTIONS[0]
+    )
     if saved_basemap not in MAP_BASEMAP_OPTIONS:
         saved_basemap = MAP_BASEMAP_OPTIONS[0]
     override = st.session_state.get(STREAMLIT_MAP_BASEMAP_KEY, saved_basemap)
@@ -161,7 +163,9 @@ def _effective_map_style() -> str:
 
 def _map_view_from_session() -> tuple[str, str, bool, bool]:
     """Map view label/mode and lifer/family flags from session (legacy label migration)."""
-    map_view_label = st.session_state.get(STREAMLIT_MAP_VIEW_LABEL_KEY, MAP_VIEW_LABELS[0])
+    map_view_label = st.session_state.get(
+        STREAMLIT_MAP_VIEW_LABEL_KEY, MAP_VIEW_LABELS[0]
+    )
     if map_view_label == "Selected species":
         map_view_label = "Species locations"
     map_view_mode = MAP_VIEW_LABEL_TO_MODE.get(map_view_label, "all")
@@ -183,7 +187,9 @@ def _date_filter_from_session(
         st.session_state[STREAMLIT_MAP_DATE_FILTER_KEY] = bool(
             st.session_state.get(PERSIST_MAP_DATE_FILTER_KEY, MAP_DATE_FILTER_DEFAULT)
         )
-    date_filter_on_effective = bool(st.session_state.get(STREAMLIT_MAP_DATE_FILTER_KEY, False))
+    date_filter_on_effective = bool(
+        st.session_state.get(STREAMLIT_MAP_DATE_FILTER_KEY, False)
+    )
     if not date_filter_on_effective:
         return False, None
     d_inception, today = date_inception_to_today_default(df_full)
@@ -225,7 +231,9 @@ def render_map_sidebar(df_full: Any, *, work_df: Any) -> None:
         else:
             if STREAMLIT_MAP_DATE_FILTER_KEY not in st.session_state:
                 st.session_state[STREAMLIT_MAP_DATE_FILTER_KEY] = bool(
-                    st.session_state.get(PERSIST_MAP_DATE_FILTER_KEY, MAP_DATE_FILTER_DEFAULT)
+                    st.session_state.get(
+                        PERSIST_MAP_DATE_FILTER_KEY, MAP_DATE_FILTER_DEFAULT
+                    )
                 )
             if st.session_state.get(STREAMLIT_MAP_DATE_FILTER_KEY, False):
                 if STREAMLIT_MAP_DATE_RANGE_KEY not in st.session_state:
@@ -243,10 +251,16 @@ def render_map_sidebar(df_full: Any, *, work_df: Any) -> None:
             if date_filter_on_effective:
                 d_inception, today = date_inception_to_today_default(df_full)
                 if STREAMLIT_MAP_DATE_RANGE_KEY not in st.session_state:
-                    st.session_state[STREAMLIT_MAP_DATE_RANGE_KEY] = (d_inception, today)
+                    st.session_state[STREAMLIT_MAP_DATE_RANGE_KEY] = (
+                        d_inception,
+                        today,
+                    )
                 rng = st.session_state[STREAMLIT_MAP_DATE_RANGE_KEY]
                 if not isinstance(rng, tuple) or len(rng) != 2:
-                    st.session_state[STREAMLIT_MAP_DATE_RANGE_KEY] = (d_inception, today)
+                    st.session_state[STREAMLIT_MAP_DATE_RANGE_KEY] = (
+                        d_inception,
+                        today,
+                    )
                 else:
                     r0 = max(min(rng[0], today), d_inception)
                     r1 = max(min(rng[1], today), d_inception)
@@ -265,14 +279,20 @@ def render_map_sidebar(df_full: Any, *, work_df: Any) -> None:
                 else:
                     st.caption(MAP_DATE_FILTER_ALL_LOCATIONS_CAPTION)
 
-            date_filter_on_effective = bool(st.session_state.get(STREAMLIT_MAP_DATE_FILTER_KEY, False))
+            date_filter_on_effective = bool(
+                st.session_state.get(STREAMLIT_MAP_DATE_FILTER_KEY, False)
+            )
             date_range_sel = (
                 st.session_state.get(STREAMLIT_MAP_DATE_RANGE_KEY)
                 if date_filter_on_effective
                 else None
             )
             st.session_state[PERSIST_MAP_DATE_FILTER_KEY] = date_filter_on_effective
-            if date_filter_on_effective and isinstance(date_range_sel, tuple) and len(date_range_sel) == 2:
+            if (
+                date_filter_on_effective
+                and isinstance(date_range_sel, tuple)
+                and len(date_range_sel) == 2
+            ):
                 st.session_state[PERSIST_MAP_DATE_RANGE_KEY] = date_range_sel
 
         if map_view_mode == "all":
@@ -289,7 +309,9 @@ def render_map_sidebar(df_full: Any, *, work_df: Any) -> None:
             _scope_opts = all_locations_scope_option_values(work_df)
             _cur_scope = st.session_state.get(STREAMLIT_ALL_LOCATIONS_SCOPE_KEY)
             if _cur_scope not in _scope_opts:
-                st.session_state[STREAMLIT_ALL_LOCATIONS_SCOPE_KEY] = ALL_LOCATIONS_SCOPE_FOCUSED
+                st.session_state[STREAMLIT_ALL_LOCATIONS_SCOPE_KEY] = (
+                    ALL_LOCATIONS_SCOPE_FOCUSED
+                )
             st.selectbox(
                 "Map focus",
                 options=_scope_opts,
@@ -322,7 +344,9 @@ def render_map_sidebar(df_full: Any, *, work_df: Any) -> None:
             st.markdown("**Species**")
             species_searchbox_fragment()
             if STREAMLIT_SPECIES_HIDE_ONLY_KEY not in st.session_state:
-                st.session_state[STREAMLIT_SPECIES_HIDE_ONLY_KEY] = MAP_SPECIES_HIDE_ONLY_DEFAULT
+                st.session_state[STREAMLIT_SPECIES_HIDE_ONLY_KEY] = (
+                    MAP_SPECIES_HIDE_ONLY_DEFAULT
+                )
             st.toggle(
                 "Show only selected species",
                 key=STREAMLIT_SPECIES_HIDE_ONLY_KEY,
@@ -366,9 +390,11 @@ def render_map_sidebar(df_full: Any, *, work_df: Any) -> None:
                     st.selectbox(
                         "Highlight species (optional)",
                         options=[""] + bases,
-                        format_func=lambda b: "— None —"
-                        if b == ""
-                        else (base_to_common.get(str(b).strip().lower()) or b),
+                        format_func=lambda b: (
+                            "— None —"
+                            if b == ""
+                            else (base_to_common.get(str(b).strip().lower()) or b)
+                        ),
                         key=STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY,
                     )
                 else:
@@ -441,7 +467,9 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         render_social_cards_main_sidebar(df_full)
 
     map_style = _effective_map_style()
-    _map_view_label, map_view_mode, is_lifer_view, is_family_view = _map_view_from_session()
+    _map_view_label, map_view_mode, is_lifer_view, is_family_view = (
+        _map_view_from_session()
+    )
     date_filter_on_effective, date_range_sel = _date_filter_from_session(
         df_full,
         is_lifer_view=is_lifer_view,
@@ -469,36 +497,42 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
     # fragment renders nothing when SESSION_SPECIES_IX_KEY is absent, and the
     # stale-search-key clearing must not run under an already-rendered fragment
     # (#362 — species search controls disappeared in the 2026-07-17 release).
-    _prev_mv = st.session_state.get(SESSION_PREV_MAP_VIEW_KEY)
-    if map_view_mode == "species" and _prev_mv is not None and _prev_mv != "species":
-        st.session_state.pop(SESSION_SPECIES_SEARCH_KEY, None)
-        _n = int(st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0))
-        st.session_state.pop(f"{SESSION_SPECIES_SEARCH_KEY}__v{_n}", None)
-        st.session_state.pop(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, None)
-
+    prev_map_view_mode = st.session_state.get(SESSION_PREV_MAP_VIEW_KEY)
     if map_view_mode == "species":
+        if prev_map_view_mode is not None and prev_map_view_mode != "species":
+            st.session_state.pop(SESSION_SPECIES_SEARCH_KEY, None)
+            remount_nonce = int(
+                st.session_state.get(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, 0)
+            )
+            st.session_state.pop(
+                f"{SESSION_SPECIES_SEARCH_KEY}__v{remount_nonce}", None
+            )
+            st.session_state.pop(SESSION_SPECIES_SEARCH_REMOUNT_NONCE_KEY, None)
+
         if not st.session_state.get(SESSION_SPECIES_PICK_KEY):
-            _pc = st.session_state.get(PERSIST_SPECIES_COMMON_KEY)
-            if _pc:
-                st.session_state[SESSION_SPECIES_PICK_KEY] = str(_pc).strip()
+            persisted_common = st.session_state.get(PERSIST_SPECIES_COMMON_KEY)
+            if persisted_common:
+                st.session_state[SESSION_SPECIES_PICK_KEY] = str(
+                    persisted_common
+                ).strip()
 
         tax_loc = (
             str(st.session_state.get(STREAMLIT_TAXONOMY_LOCALE_KEY, "")).strip()
             or DEFAULT_TAXONOMY_LOCALE
         )
-        _ix_sig = (
+        index_signature = (
             SPECIES_WHOOSH_INDEX_VERSION,
             len(ws.species_list),
             st.session_state.get(EBIRD_DATA_SIG_KEY),
             tax_loc,
         )
-        if st.session_state.get(SESSION_SPECIES_IX_SIG_KEY) != _ix_sig:
+        if st.session_state.get(SESSION_SPECIES_IX_SIG_KEY) != index_signature:
             st.session_state[SESSION_SPECIES_IX_KEY] = build_ram_species_whoosh_index(
                 ws.species_list,
                 ws.name_map,
                 taxonomy_locale=tax_loc,
             )
-            st.session_state[SESSION_SPECIES_IX_SIG_KEY] = _ix_sig
+            st.session_state[SESSION_SPECIES_IX_SIG_KEY] = index_signature
         st.session_state[SESSION_SPECIES_WS_KEY] = ws
 
     if not social_cards_tab:
@@ -511,11 +545,15 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
     family_highlight_base = ""
     scheme_sel = st.session_state.get(STREAMLIT_MAP_MARKER_COLOUR_SCHEME_KEY, 1)
     family_colour_scheme = int(scheme_sel if scheme_sel is not None else 1)
-    map_height = int(st.session_state.get(STREAMLIT_MAP_HEIGHT_PX_KEY, MAP_HEIGHT_PX_DEFAULT))
+    map_height = int(
+        st.session_state.get(STREAMLIT_MAP_HEIGHT_PX_KEY, MAP_HEIGHT_PX_DEFAULT)
+    )
 
     if map_view_mode == "species":
         hide_non_matching_locations = bool(
-            st.session_state.get(STREAMLIT_SPECIES_HIDE_ONLY_KEY, MAP_SPECIES_HIDE_ONLY_DEFAULT)
+            st.session_state.get(
+                STREAMLIT_SPECIES_HIDE_ONLY_KEY, MAP_SPECIES_HIDE_ONLY_DEFAULT
+            )
         )
 
         species_pick_common = st.session_state.get(SESSION_SPECIES_PICK_KEY)
@@ -530,7 +568,9 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         st.session_state.pop(SESSION_SPECIES_PICK_KEY, None)
 
     if map_view_mode == "families":
-        family_name = str(st.session_state.get(STREAMLIT_FAMILY_MAP_FAMILY_KEY, "") or "")
+        family_name = str(
+            st.session_state.get(STREAMLIT_FAMILY_MAP_FAMILY_KEY, "") or ""
+        )
         family_highlight_base = str(
             st.session_state.get(STREAMLIT_FAMILY_MAP_HIGHLIGHT_KEY, "") or ""
         )
@@ -541,10 +581,10 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         if not _all_locations_leaflet_embed_active(st.session_state):
             invalidate_map_embed_cache()
 
-    if _prev_mv is not None and _prev_mv != map_view_mode:
-        st.session_state[LEAFLET_MAP_MOUNT_NONCE_KEY] = int(
-            st.session_state.get(LEAFLET_MAP_MOUNT_NONCE_KEY, 0)
-        ) + 1
+    if prev_map_view_mode is not None and prev_map_view_mode != map_view_mode:
+        st.session_state[LEAFLET_MAP_MOUNT_NONCE_KEY] = (
+            int(st.session_state.get(LEAFLET_MAP_MOUNT_NONCE_KEY, 0)) + 1
+        )
 
     st.session_state[SESSION_PREV_MAP_VIEW_KEY] = map_view_mode
 

--- a/explorer/app/streamlit/app_map_working_ui.py
+++ b/explorer/app/streamlit/app_map_working_ui.py
@@ -465,18 +465,10 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
         )
     work_df = ws.df
 
-    if not social_cards_tab:
-        render_map_sidebar(df_full, work_df=work_df)
-
-    hide_non_matching_locations = False
-    species_pick_common: str | None = None
-    species_pick_sci = ""
-    family_name = ""
-    family_highlight_base = ""
-    scheme_sel = st.session_state.get(STREAMLIT_MAP_MARKER_COLOUR_SCHEME_KEY, 1)
-    family_colour_scheme = int(scheme_sel if scheme_sel is not None else 1)
-    map_height = int(st.session_state.get(STREAMLIT_MAP_HEIGHT_PX_KEY, MAP_HEIGHT_PX_DEFAULT))
-
+    # Species session prep must run BEFORE the sidebar renders: the searchbox
+    # fragment renders nothing when SESSION_SPECIES_IX_KEY is absent, and the
+    # stale-search-key clearing must not run under an already-rendered fragment
+    # (#362 — species search controls disappeared in the 2026-07-17 release).
     _prev_mv = st.session_state.get(SESSION_PREV_MAP_VIEW_KEY)
     if map_view_mode == "species" and _prev_mv is not None and _prev_mv != "species":
         st.session_state.pop(SESSION_SPECIES_SEARCH_KEY, None)
@@ -509,6 +501,19 @@ def render_map_sidebar_and_working_set(df_full: Any) -> MapWorkingContext:
             st.session_state[SESSION_SPECIES_IX_SIG_KEY] = _ix_sig
         st.session_state[SESSION_SPECIES_WS_KEY] = ws
 
+    if not social_cards_tab:
+        render_map_sidebar(df_full, work_df=work_df)
+
+    hide_non_matching_locations = False
+    species_pick_common: str | None = None
+    species_pick_sci = ""
+    family_name = ""
+    family_highlight_base = ""
+    scheme_sel = st.session_state.get(STREAMLIT_MAP_MARKER_COLOUR_SCHEME_KEY, 1)
+    family_colour_scheme = int(scheme_sel if scheme_sel is not None else 1)
+    map_height = int(st.session_state.get(STREAMLIT_MAP_HEIGHT_PX_KEY, MAP_HEIGHT_PX_DEFAULT))
+
+    if map_view_mode == "species":
         hide_non_matching_locations = bool(
             st.session_state.get(STREAMLIT_SPECIES_HIDE_ONLY_KEY, MAP_SPECIES_HIDE_ONLY_DEFAULT)
         )

--- a/tests/explorer/test_app_map_working_ui.py
+++ b/tests/explorer/test_app_map_working_ui.py
@@ -1,0 +1,76 @@
+"""Tests for ``explorer.app.streamlit.app_map_working_ui`` orchestration (#362)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip(
+    "streamlit", reason="explorer.app.streamlit.app_map_working_ui is for Streamlit UI"
+)
+
+import streamlit as st  # noqa: E402
+
+from explorer.app.streamlit import app_map_working_ui as mwu  # noqa: E402
+from explorer.app.streamlit.app_constants import (  # noqa: E402
+    SESSION_SPECIES_IX_KEY,
+    SESSION_SPECIES_WS_KEY,
+    STREAMLIT_MAP_VIEW_LABEL_KEY,
+)
+
+
+def test_species_search_index_built_before_sidebar_renders(monkeypatch):
+    """Regression for #362: the species searchbox fragment renders nothing when
+    ``SESSION_SPECIES_IX_KEY`` is absent, so species session prep must complete
+    before ``render_map_sidebar`` runs.
+    """
+    state: dict = {STREAMLIT_MAP_VIEW_LABEL_KEY: "Species locations"}
+    monkeypatch.setattr(st, "session_state", state)
+
+    monkeypatch.setattr(mwu, "ensure_streamlit_map_basemap_height_keys", lambda: None)
+    monkeypatch.setattr(mwu, "ensure_streamlit_map_marker_colour_scheme_keys", lambda: None)
+    monkeypatch.setattr(mwu, "apply_pending_map_cluster_toggle", lambda _s: None)
+    monkeypatch.setattr(mwu, "apply_pending_map_basemap_override", lambda _s: None)
+    monkeypatch.setattr(mwu, "apply_pending_map_height_override", lambda _s: None)
+    monkeypatch.setattr(mwu, "apply_pending_map_marker_colour_scheme", lambda _s: None)
+    monkeypatch.setattr(mwu, "inject_spinner_theme_css", lambda: None)
+    monkeypatch.setattr(mwu, "is_social_cards_main_tab", lambda: False)
+    monkeypatch.setattr(mwu, "invalidate_map_embed_cache", lambda: None)
+    monkeypatch.setattr(mwu, "_all_locations_leaflet_embed_active", lambda _s: True)
+
+    df = pd.DataFrame({"Submission ID": ["s1"], "Date": ["2025-06-01"]})
+    ws = SimpleNamespace(
+        df=df,
+        species_list=["Grey Teal"],
+        name_map={"Grey Teal": "Anas gracilis"},
+    )
+    monkeypatch.setattr(
+        mwu,
+        "streamlit_working_set_and_status",
+        lambda *_a, **_k: (ws, None),
+    )
+    monkeypatch.setattr(
+        mwu, "build_ram_species_whoosh_index", lambda *_a, **_k: "SENTINEL_INDEX"
+    )
+
+    seen_at_sidebar_render: dict = {}
+
+    def _fake_render_map_sidebar(_df_full, *, work_df):
+        seen_at_sidebar_render["index"] = state.get(SESSION_SPECIES_IX_KEY)
+        seen_at_sidebar_render["ws"] = state.get(SESSION_SPECIES_WS_KEY)
+
+    monkeypatch.setattr(mwu, "render_map_sidebar", _fake_render_map_sidebar)
+
+    ctx = mwu.render_map_sidebar_and_working_set(df)
+
+    assert seen_at_sidebar_render["index"] == "SENTINEL_INDEX"
+    assert seen_at_sidebar_render["ws"] is ws
+    assert ctx.map_view_mode == "species"


### PR DESCRIPTION
## Summary

Restores the species search controls on the Map tab (Species locations view). Regression introduced in the 2026-07-17 release by the Social Cards sidebar split (#360): the sidebar began rendering before the species Whoosh index was built, and the searchbox fragment silently renders nothing when `SESSION_SPECIES_IX_KEY` is missing.

## Changes

- `explorer/app/streamlit/app_map_working_ui.py`: move species session prep (stale-search-key reset, species pick restore, Whoosh index build, working-set stash) ahead of the `render_map_sidebar` call in `render_map_sidebar_and_working_set`, so the index exists when the searchbox fragment renders.
- `tests/explorer/test_app_map_working_ui.py` (new): regression test asserting the species index and working set are in session state at the moment the sidebar renders. Verified it fails on the unfixed code.

## Testing

- `python3 -m ruff check explorer/` — passed
- `python3 -m pytest tests/ -q` — 958 passed, 11 skipped
- Regression test confirmed red on pre-fix code (via stash), green after fix

## Issues

Fixes #362
