### PR TITLE
Add Species: Only heard but never seen to Interesting Lists

### DIFF
--- a/docs/explorer/regression-checklist.md
+++ b/docs/explorer/regression-checklist.md
@@ -49,7 +49,8 @@ Run before merging refactor branches to `main`.
 ## Ranking & Lists
 - Ranking & Lists load (nested **Top Lists** / **Interesting Lists** only)
 - **Interesting Lists:** **Species: Coverage** is the first expander (#262); table shows species in eBird taxonomy, observed species, and observed %; footnote mentions extinct-species handling
-- Species tables (Most individuals, Most checklists, Subspecies occurrence, Seen only once) render correctly
+- Species tables (Most individuals, Most checklists, Subspecies occurrence, High counts, Seen only once, Heard-only species, Not seen in the past year) render correctly
+- **Heard-only species:** blue banner under the table explains standalone “Heard only” matching; only species with that note on every record appear
 - Links work (locations and checklists)
 
 ## Bird Families

--- a/docs/explorer/regression-checklist.md
+++ b/docs/explorer/regression-checklist.md
@@ -49,8 +49,8 @@ Run before merging refactor branches to `main`.
 ## Ranking & Lists
 - Ranking & Lists load (nested **Top Lists** / **Interesting Lists** only)
 - **Interesting Lists:** **Species: Coverage** is the first expander (#262); table shows species in eBird taxonomy, observed species, and observed %; footnote mentions extinct-species handling
-- Species tables (Most individuals, Most checklists, Subspecies occurrence, High counts, Seen only once, Heard-only species, Not seen in the past year) render correctly
-- **Heard-only species:** blue banner under the table explains standalone “Heard only” matching; only species with that note on every record appear
+- Species tables (Most individuals, Most checklists, Subspecies occurrence, High counts, Seen only once, Only heard but never seen, Not seen in the past year) render correctly
+- **Species: Only heard but never seen:** muted caption after the table rows (scrolls with the list; same style as Species: Coverage footnotes) explains standalone “Heard only” matching; only species with that note on every record appear
 - Links work (locations and checklists)
 
 ## Bird Families

--- a/explorer/app/streamlit/rankings_streamlit_html.py
+++ b/explorer/app/streamlit/rankings_streamlit_html.py
@@ -13,10 +13,12 @@ Species-group coverage lives on the **Bird Families** main tab
 **Top N** and **visible rows** come from **Settings → Tables & lists** (session keys
 ``streamlit_rankings_top_n``, ``streamlit_rankings_visible_rows``). **Top Lists** tables
 include a narrow leading **Rank** column with soft accent styling. **Species: Coverage**
-is the first expander under **Interesting Lists**. **Species: Not seen in the past year** is the
-last expander under Interesting Lists; it lists countable species with no observation in the trailing
-twelve months on the **full export** and is not Top-N–capped. A hint points to the **Country** tab
-for the in-country, working-set–scoped variant.
+is the first expander under **Interesting Lists**. **Heard-only species** lists countable
+species whose every Observation Details note is a standalone ``Heard only`` (#370).
+**Species: Not seen in the past year** is the last expander under Interesting Lists; it
+lists countable species with no observation in the trailing twelve months on the **full
+export** and is not Top-N–capped. A hint points to the **Country** tab for the in-country,
+working-set–scoped variant.
 """
 
 from __future__ import annotations

--- a/explorer/app/streamlit/rankings_streamlit_html.py
+++ b/explorer/app/streamlit/rankings_streamlit_html.py
@@ -13,8 +13,8 @@ Species-group coverage lives on the **Bird Families** main tab
 **Top N** and **visible rows** come from **Settings → Tables & lists** (session keys
 ``streamlit_rankings_top_n``, ``streamlit_rankings_visible_rows``). **Top Lists** tables
 include a narrow leading **Rank** column with soft accent styling. **Species: Coverage**
-is the first expander under **Interesting Lists**. **Heard-only species** lists countable
-species whose every Observation Details note is a standalone ``Heard only`` (#370).
+is the first expander under **Interesting Lists**. **Species: Only heard but never seen** lists
+countable species whose every Observation Details note is a standalone ``Heard only`` (#370).
 **Species: Not seen in the past year** is the last expander under Interesting Lists; it
 lists countable species with no observation in the trailing twelve months on the **full
 export** and is not Top-N–capped. A hint points to the **Country** tab for the in-country,

--- a/explorer/core/stats.py
+++ b/explorer/core/stats.py
@@ -808,17 +808,89 @@ def observation_details_has_heard_only(text) -> bool:
     period, follows another sentence, or is followed by further sentences. Does not
     match when the words appear mid-sentence (e.g. ``mostly heard only``).
     """
-    if text is None or (isinstance(text, float) and pd.isna(text)):
-        return False
     try:
         if pd.isna(text):
             return False
     except (TypeError, ValueError):
-        pass
+        if text is None:
+            return False
     s = str(text).strip()
     if not s or s.lower() == "nan":
         return False
     return bool(_HEARD_ONLY_STANDALONE_RE.search(s))
+
+
+def _heard_only_species_totals(df_s):
+    """Return base-species aggregates where every observation row is standalone ``Heard only``."""
+    df_s["_heard_only"] = df_s["Observation Details"].map(observation_details_has_heard_only)
+    by_base = (
+        df_s.groupby("_base", sort=False)
+        .agg(
+            n_records=("_base", "size"),
+            n_heard=("_heard_only", "sum"),
+            common_name=("Common Name", most_frequent_parent_common),
+        )
+        .reset_index()
+    )
+    return by_base[by_base["n_records"] == by_base["n_heard"]].copy()
+
+
+def _last_observation_by_base(df_s, dt_col):
+    """Pick the most recent observation row per base species (by datetime when available)."""
+    if dt_col in df_s.columns:
+        df_s = df_s.assign(_dt=pd.to_datetime(df_s[dt_col], errors="coerce"))
+        last_idx = df_s.groupby("_base")["_dt"].idxmax().dropna()
+        last_rows = df_s.loc[last_idx] if len(last_idx) else df_s.iloc[0:0]
+    else:
+        last_rows = df_s.groupby("_base", sort=False).first().reset_index()
+
+    last_by_base = last_rows.set_index("_base") if not last_rows.empty else pd.DataFrame()
+    if not last_by_base.empty and last_by_base.index.has_duplicates:
+        last_by_base = last_by_base[~last_by_base.index.duplicated(keep="last")]
+    return df_s, last_by_base
+
+
+def _last_observation_row_for_base(base, last_by_base, df_s):
+    """Return one observation row for *base* (most recent when indexed, else first match)."""
+    if base in last_by_base.index:
+        last = last_by_base.loc[base]
+        if isinstance(last, pd.DataFrame):
+            return last.iloc[-1]
+        return last
+    return df_s.loc[df_s["_base"] == base].iloc[0]
+
+
+def _rankings_row_links_from_observation(last, dt_col, reg_col):
+    """Build location/date HTML links and region strings from one observation row."""
+    lid = last.get("Location ID")
+    loc = last.get("Location", "")
+    sid = last.get("Submission ID")
+    if isinstance(last, pd.Series) and "_dt" in last.index:
+        dt = last.get("_dt")
+    else:
+        dt = last.get(dt_col) if dt_col in getattr(last, "index", []) else None
+    dt_str = (
+        pd.Timestamp(dt).strftime("%d %b %Y %H:%M")
+        if dt is not None and pd.notna(dt)
+        else "—"
+    )
+    loc_link = (
+        f'<a href="https://ebird.org/lifelist/{lid}" target="_blank">{loc}</a>'
+        if lid
+        else loc
+    )
+    dt_link = (
+        f'<a href="https://ebird.org/checklist/{sid}" target="_blank">{dt_str}</a>'
+        if sid
+        else dt_str
+    )
+    state_str = ""
+    country_str = ""
+    if reg_col and reg_col in getattr(last, "index", []):
+        country, state = format_region_parts(last.get(reg_col))
+        state_str = state if state else ""
+        country_str = country if country else ""
+    return loc_link, state_str, country_str, dt_link
 
 
 def rankings_heard_only_species(df_obs):
@@ -840,75 +912,23 @@ def rankings_heard_only_species(df_obs):
     if df_s.empty:
         return []
 
-    details = df_s["Observation Details"]
-    df_s["_heard_only"] = details.map(observation_details_has_heard_only)
-    by_base = (
-        df_s.groupby("_base", sort=False)
-        .agg(
-            n_records=("_base", "size"),
-            n_heard=("_heard_only", "sum"),
-            common_name=("Common Name", most_frequent_parent_common),
-        )
-        .reset_index()
-    )
-    heard_only = by_base[by_base["n_records"] == by_base["n_heard"]].copy()
+    heard_only = _heard_only_species_totals(df_s)
     if heard_only.empty:
         return []
 
     dt_col = "datetime" if "datetime" in df_s.columns else "Date"
-    if dt_col in df_s.columns:
-        df_s = df_s.assign(_dt=pd.to_datetime(df_s[dt_col], errors="coerce"))
-        last_idx = df_s.groupby("_base")["_dt"].idxmax().dropna()
-        last_rows = df_s.loc[last_idx] if len(last_idx) else df_s.iloc[0:0]
-    else:
-        last_rows = df_s.groupby("_base", sort=False).first().reset_index()
-
-    last_by_base = last_rows.set_index("_base") if not last_rows.empty else pd.DataFrame()
-    if not last_by_base.empty and last_by_base.index.has_duplicates:
-        last_by_base = last_by_base[~last_by_base.index.duplicated(keep="last")]
-    heard_only = heard_only.sort_values("common_name", kind="mergesort")
-
+    df_s, last_by_base = _last_observation_by_base(df_s, dt_col)
     reg_col = region_column(df_s, prefer_country=True)
+    heard_only = heard_only.sort_values("common_name", kind="mergesort")
 
     rows = []
     for _, r in heard_only.iterrows():
         base = r["_base"]
         name = r["common_name"] if pd.notna(r["common_name"]) else base
-        if base in last_by_base.index:
-            last = last_by_base.loc[base]
-            if isinstance(last, pd.DataFrame):
-                last = last.iloc[-1]
-        else:
-            last = df_s.loc[df_s["_base"] == base].iloc[0]
-
-        lid = last.get("Location ID")
-        loc = last.get("Location", "")
-        sid = last.get("Submission ID")
-        if isinstance(last, pd.Series) and "_dt" in last.index:
-            dt = last.get("_dt")
-        else:
-            dt = last.get(dt_col) if dt_col in getattr(last, "index", []) else None
-        dt_str = (
-            pd.Timestamp(dt).strftime("%d %b %Y %H:%M")
-            if dt is not None and pd.notna(dt)
-            else "—"
+        last = _last_observation_row_for_base(base, last_by_base, df_s)
+        loc_link, state_str, country_str, dt_link = _rankings_row_links_from_observation(
+            last, dt_col, reg_col
         )
-        loc_link = (
-            f'<a href="https://ebird.org/lifelist/{lid}" target="_blank">{loc}</a>'
-            if lid
-            else loc
-        )
-        dt_link = (
-            f'<a href="https://ebird.org/checklist/{sid}" target="_blank">{dt_str}</a>'
-            if sid
-            else dt_str
-        )
-        state_str = ""
-        country_str = ""
-        if reg_col and reg_col in getattr(last, "index", []):
-            country, state = format_region_parts(last.get(reg_col))
-            state_str = state if state else ""
-            country_str = country if country else ""
         rows.append(
             (
                 str(name),

--- a/explorer/core/stats.py
+++ b/explorer/core/stats.py
@@ -9,6 +9,7 @@ contract the UI expects; separating them would be a redesign.
 """
 
 import html as _html
+import re
 
 import numpy as np
 import pandas as pd
@@ -793,6 +794,134 @@ def rankings_seen_once(df_obs, limit=None):
     return rows
 
 
+# Standalone sentence: "Heard only" / "Heard only." — not mid-sentence phrases (#370).
+_HEARD_ONLY_STANDALONE_RE = re.compile(
+    r"(?:^|(?<=[.!?])\s+)heard only(?:\.(?=\s|$)|(?=\s*$))",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def observation_details_has_heard_only(text) -> bool:
+    """True when Observation Details contains a standalone ``Heard only`` sentence.
+
+    Matches case-insensitively when ``Heard only`` is the whole comment, ends with a
+    period, follows another sentence, or is followed by further sentences. Does not
+    match when the words appear mid-sentence (e.g. ``mostly heard only``).
+    """
+    if text is None or (isinstance(text, float) and pd.isna(text)):
+        return False
+    try:
+        if pd.isna(text):
+            return False
+    except (TypeError, ValueError):
+        pass
+    s = str(text).strip()
+    if not s or s.lower() == "nan":
+        return False
+    return bool(_HEARD_ONLY_STANDALONE_RE.search(s))
+
+
+def rankings_heard_only_species(df_obs):
+    """Countable species where every observation record is marked standalone ``Heard only``.
+
+    Uses the eBird export ``Observation Details`` column. A species appears only when
+    it has at least one record and **every** countable record for that base species
+    matches :func:`observation_details_has_heard_only`.
+
+    Returns rows ``(species, location_link, state, country, last_heard_link, records)``
+    sorted by common name. *last_heard_link* is the most recent observation date/time
+    linking to that checklist; *records* is the observation-row count.
+    """
+    if df_obs.empty or "Observation Details" not in df_obs.columns:
+        return []
+    df_s = df_obs.copy()
+    df_s["_base"] = countable_species_vectorized(df_s)
+    df_s = df_s.dropna(subset=["_base"])
+    if df_s.empty:
+        return []
+
+    details = df_s["Observation Details"]
+    df_s["_heard_only"] = details.map(observation_details_has_heard_only)
+    by_base = (
+        df_s.groupby("_base", sort=False)
+        .agg(
+            n_records=("_base", "size"),
+            n_heard=("_heard_only", "sum"),
+            common_name=("Common Name", most_frequent_parent_common),
+        )
+        .reset_index()
+    )
+    heard_only = by_base[by_base["n_records"] == by_base["n_heard"]].copy()
+    if heard_only.empty:
+        return []
+
+    dt_col = "datetime" if "datetime" in df_s.columns else "Date"
+    if dt_col in df_s.columns:
+        df_s = df_s.assign(_dt=pd.to_datetime(df_s[dt_col], errors="coerce"))
+        last_idx = df_s.groupby("_base")["_dt"].idxmax().dropna()
+        last_rows = df_s.loc[last_idx] if len(last_idx) else df_s.iloc[0:0]
+    else:
+        last_rows = df_s.groupby("_base", sort=False).first().reset_index()
+
+    last_by_base = last_rows.set_index("_base") if not last_rows.empty else pd.DataFrame()
+    if not last_by_base.empty and last_by_base.index.has_duplicates:
+        last_by_base = last_by_base[~last_by_base.index.duplicated(keep="last")]
+    heard_only = heard_only.sort_values("common_name", kind="mergesort")
+
+    reg_col = region_column(df_s, prefer_country=True)
+
+    rows = []
+    for _, r in heard_only.iterrows():
+        base = r["_base"]
+        name = r["common_name"] if pd.notna(r["common_name"]) else base
+        if base in last_by_base.index:
+            last = last_by_base.loc[base]
+            if isinstance(last, pd.DataFrame):
+                last = last.iloc[-1]
+        else:
+            last = df_s.loc[df_s["_base"] == base].iloc[0]
+
+        lid = last.get("Location ID")
+        loc = last.get("Location", "")
+        sid = last.get("Submission ID")
+        if isinstance(last, pd.Series) and "_dt" in last.index:
+            dt = last.get("_dt")
+        else:
+            dt = last.get(dt_col) if dt_col in getattr(last, "index", []) else None
+        dt_str = (
+            pd.Timestamp(dt).strftime("%d %b %Y %H:%M")
+            if dt is not None and pd.notna(dt)
+            else "—"
+        )
+        loc_link = (
+            f'<a href="https://ebird.org/lifelist/{lid}" target="_blank">{loc}</a>'
+            if lid
+            else loc
+        )
+        dt_link = (
+            f'<a href="https://ebird.org/checklist/{sid}" target="_blank">{dt_str}</a>'
+            if sid
+            else dt_str
+        )
+        state_str = ""
+        country_str = ""
+        if reg_col and reg_col in getattr(last, "index", []):
+            country, state = format_region_parts(last.get(reg_col))
+            state_str = state if state else ""
+            country_str = country if country else ""
+        rows.append(
+            (
+                str(name),
+                loc_link,
+                state_str,
+                country_str,
+                dt_link,
+                f"{int(r['n_records']):,}",
+            )
+        )
+    return rows
+
+
 def rankings_high_counts(df_obs, tie_break="last", sort_mode="total_count"):
     """Highest checklist count per countable species.
 
@@ -1099,6 +1228,7 @@ def compute_rankings(
                 "species_checklists",
                 "species_high_counts",
                 "seen_once",
+                "heard_only",
                 "subspecies",
                 "not_seen_recently",
             )
@@ -1172,6 +1302,7 @@ def compute_rankings(
             sort_mode=high_count_sort,
         ),
         "seen_once": rankings_seen_once(df, limit=None),
+        "heard_only": rankings_heard_only_species(df),
         "subspecies": rankings_subspecies_hierarchical(df, limit=None),
         "not_seen_recently": rankings_not_seen_recently(df),
     }

--- a/explorer/presentation/checklist_stats_display.py
+++ b/explorer/presentation/checklist_stats_display.py
@@ -20,6 +20,7 @@ from explorer.core.constants import (
 )
 from explorer.core.region_display import country_for_display
 from explorer.presentation.rankings_display import (
+    rankings_heard_only_species_table,
     rankings_high_counts_table,
     rankings_not_seen_recently_table,
     rankings_seen_once_table,
@@ -37,6 +38,19 @@ _NOT_SEEN_RECENTLY_COUNTRY_TAB_HINT_HTML = (
     f'<p style="margin:0 0 10px;font-size:12px;line-height:1.5;max-width:52rem;color:{THEME_PRIMARY_HEX};">'
     "An equivalent country-specific list can be found on the <strong>Country</strong> tab."
     "</p>"
+)
+
+# Explains matching rules under the Heard-only species table (#370). Blue info-style banner.
+_HEARD_ONLY_SPECIES_BANNER_HTML = (
+    '<div style="margin:12px 0 0;padding:10px 14px;background:#e8f4fc;'
+    "border-left:4px solid #1c83e1;border-radius:4px;font-size:12px;line-height:1.5;"
+    'color:#0c4a6e;max-width:52rem;">'
+    "<strong>About this list:</strong> "
+    "These are birds you’ve heard but never seen. A species is included when every "
+    "observation in eBird has ‘Heard only’ written as a separate note in the observation "
+    "details (e.g. ‘Heard only’ or ‘Six birds calling. Heard only’).  "
+    "Phrases such as ‘mostly heard only’ and abbreviations such as “H” or “HO” don’t count."
+    "</div>"
 )
 
 
@@ -1483,6 +1497,17 @@ def format_checklist_stats_bundle(
                 visible_rows=visible_rows,
                 link_urls_fn=link_urls_fn,
             ),
+        ),
+        (
+            "Heard-only species",
+            rankings_heard_only_species_table(
+                rankings["heard_only"],
+                include_heading=False,
+                scroll_hint=scroll_hint,
+                visible_rows=visible_rows,
+                link_urls_fn=link_urls_fn,
+            )
+            + _HEARD_ONLY_SPECIES_BANNER_HTML,
         ),
         (
             "Species: Not seen in the past year",

--- a/explorer/presentation/checklist_stats_display.py
+++ b/explorer/presentation/checklist_stats_display.py
@@ -40,17 +40,18 @@ _NOT_SEEN_RECENTLY_COUNTRY_TAB_HINT_HTML = (
     "</p>"
 )
 
-# Explains matching rules under the Heard-only species table (#370). Blue info-style banner.
-_HEARD_ONLY_SPECIES_BANNER_HTML = (
-    '<div style="margin:12px 0 0;padding:10px 14px;background:#e8f4fc;'
-    "border-left:4px solid #1c83e1;border-radius:4px;font-size:12px;line-height:1.5;"
-    'color:#0c4a6e;max-width:52rem;">'
+# Explains matching rules under the Only heard but never seen table (#370).
+# Same muted caption style as Species: Coverage / yearly footnotes (not a blue info banner).
+# Placed inside the table scroll area (after rows) so it scrolls with content.
+_HEARD_ONLY_SPECIES_NOTE_HTML = (
+    '<p class="heard-only-about-note" style="margin:10px 0 8px;color:#6b7280;font-size:12px;'
+    'line-height:1.5;max-width:52rem;">'
     "<strong>About this list:</strong> "
     "These are birds you’ve heard but never seen. A species is included when every "
     "observation in eBird has ‘Heard only’ written as a separate note in the observation "
     "details (e.g. ‘Heard only’ or ‘Six birds calling. Heard only’).  "
     "Phrases such as ‘mostly heard only’ and abbreviations such as “H” or “HO” don’t count."
-    "</div>"
+    "</p>"
 )
 
 
@@ -1499,15 +1500,15 @@ def format_checklist_stats_bundle(
             ),
         ),
         (
-            "Heard-only species",
+            "Species: Only heard but never seen",
             rankings_heard_only_species_table(
                 rankings["heard_only"],
                 include_heading=False,
                 scroll_hint=scroll_hint,
                 visible_rows=visible_rows,
                 link_urls_fn=link_urls_fn,
-            )
-            + _HEARD_ONLY_SPECIES_BANNER_HTML,
+                footer_html=_HEARD_ONLY_SPECIES_NOTE_HTML,
+            ),
         ),
         (
             "Species: Not seen in the past year",

--- a/explorer/presentation/checklist_stats_display.py
+++ b/explorer/presentation/checklist_stats_display.py
@@ -49,7 +49,7 @@ _HEARD_ONLY_SPECIES_NOTE_HTML = (
     "<strong>About this list:</strong> "
     "These are birds you’ve heard but never seen. A species is included when every "
     "observation in eBird has ‘Heard only’ written as a separate note in the observation "
-    "details (e.g. ‘Heard only’ or ‘Six birds calling. Heard only’).  "
+    "details (e.g. ‘Heard only’ or ‘Six birds calling. Heard only’). "
     "Phrases such as ‘mostly heard only’ and abbreviations such as “H” or “HO” don’t count."
     "</p>"
 )
@@ -705,7 +705,8 @@ def _streamlit_checklist_html_tab_css(*, blue_theme: bool) -> str:
   text-align: right !important;
   font-variant-numeric: tabular-nums;
 }}
-.streamlit-checklist-html-ab .stats-tbl.seen-once-tbl td:last-child {{
+.streamlit-checklist-html-ab .stats-tbl.seen-once-tbl td:last-child,
+.streamlit-checklist-html-ab .stats-tbl.heard-only-tbl td:last-child {{
   text-align: right;
   font-weight: 600;
 }}

--- a/explorer/presentation/rankings_display.py
+++ b/explorer/presentation/rankings_display.py
@@ -397,6 +397,7 @@ def rankings_heard_only_species_table(
     include_heading=True,
     scroll_hint="shading",
     visible_rows=16,
+    species_url_fn=None,
     link_urls_fn=None,
     footer_html="",
 ):
@@ -416,7 +417,12 @@ def rankings_heard_only_species_table(
         return empty + (footer_html or "")
     rows_html = []
     for r in rows:
-        species_url = link_urls_fn(r[0])[0] if link_urls_fn else None
+        if link_urls_fn:
+            species_url = link_urls_fn(r[0])[0]
+        elif species_url_fn:
+            species_url = species_url_fn(r[0])
+        else:
+            species_url = None
         species_cell = (
             td_html(a_external(species_url, r[0], rel="noopener"))
             if species_url
@@ -450,9 +456,10 @@ def rankings_heard_only_species_table(
         + "</tr></thead><tbody>"
         f"{body}</tbody></table>"
     )
-    return rankings_scroll_wrapper(
+    scroll_wrapper = rankings_scroll_wrapper(
         tbl, scroll_hint, visible_rows, after_table_html=footer_html or ""
     )
+    return scroll_wrapper
 
 
 def rankings_high_counts_table(

--- a/explorer/presentation/rankings_display.py
+++ b/explorer/presentation/rankings_display.py
@@ -54,12 +54,15 @@ def _omit_placeholder_middle_column(headers_3col, rows_3col) -> bool:
     return True
 
 
-def rankings_scroll_wrapper(table_html, scroll_hint, visible_rows):
+def rankings_scroll_wrapper(table_html, scroll_hint, visible_rows, after_table_html=""):
     """Wrap table HTML in scrollable div with shading hints. Pure CSS (ipywidgets HTML does not run scripts).
 
     Top and bottom fades when ``scroll_hint`` is ``"shading"`` or ``"both"``. Padding on
     ``.rankings-scroll-inner`` (CSS) offsets the table slightly so the top gradient is less harsh on
     the header row. Scroll-position–aware shading would need JavaScript.
+
+    *after_table_html*: optional markup placed after the table **inside** the scroll area so it
+    scrolls with the rows (e.g. a footnote), rather than staying pinned under the viewport.
     """
     max_h = visible_rows * 38  # ~38px per row
     shade_css = "position:absolute;left:0;right:0;height:24px;pointer-events:none;z-index:5;"
@@ -67,10 +70,12 @@ def rankings_scroll_wrapper(table_html, scroll_hint, visible_rows):
     bot_shade = f'<div class="rankings-scroll-shade-bot" style="{shade_css}bottom:0;background:linear-gradient(to top,rgba(255,255,255,0.95),transparent);"></div>'
     show_shade = scroll_hint in ("shading", "both")
     shades = (top_shade + bot_shade) if show_shade else ""
+    after = after_table_html or ""
     return f"""
 <div class="rankings-scroll-wrapper" style="position:relative;">
   <div class="rankings-scroll-inner" style="max-height:{max_h}px;overflow-y:auto;">
     {table_html}
+    {after}
   </div>
   {shades}
 </div>"""
@@ -393,18 +398,22 @@ def rankings_heard_only_species_table(
     scroll_hint="shading",
     visible_rows=16,
     link_urls_fn=None,
+    footer_html="",
 ):
     """6-column table: Species | Location | State | Country | Last heard | Records.
 
     Rows come from :func:`explorer.core.stats.rankings_heard_only_species`.
+    *footer_html* is rendered after the table inside the scroll area so it scrolls with
+    the rows instead of staying pinned under the viewport.
     """
     if not rows:
         no_data = "<p style='margin:4px 0;color:#666;'>No data.</p>"
-        return (
-            f"<h4 style='margin:0 0 8px;'>Heard-only species</h4>{no_data}"
+        empty = (
+            f"<h4 style='margin:0 0 8px;'>Species: Only heard but never seen</h4>{no_data}"
             if include_heading
             else no_data
         )
+        return empty + (footer_html or "")
     rows_html = []
     for r in rows:
         species_url = link_urls_fn(r[0])[0] if link_urls_fn else None
@@ -441,7 +450,9 @@ def rankings_heard_only_species_table(
         + "</tr></thead><tbody>"
         f"{body}</tbody></table>"
     )
-    return rankings_scroll_wrapper(tbl, scroll_hint, visible_rows)
+    return rankings_scroll_wrapper(
+        tbl, scroll_hint, visible_rows, after_table_html=footer_html or ""
+    )
 
 
 def rankings_high_counts_table(

--- a/explorer/presentation/rankings_display.py
+++ b/explorer/presentation/rankings_display.py
@@ -387,6 +387,63 @@ def rankings_seen_once_table(
     return scroll_wrapper
 
 
+def rankings_heard_only_species_table(
+    rows,
+    include_heading=True,
+    scroll_hint="shading",
+    visible_rows=16,
+    link_urls_fn=None,
+):
+    """6-column table: Species | Location | State | Country | Last heard | Records.
+
+    Rows come from :func:`explorer.core.stats.rankings_heard_only_species`.
+    """
+    if not rows:
+        no_data = "<p style='margin:4px 0;color:#666;'>No data.</p>"
+        return (
+            f"<h4 style='margin:0 0 8px;'>Heard-only species</h4>{no_data}"
+            if include_heading
+            else no_data
+        )
+    rows_html = []
+    for r in rows:
+        species_url = link_urls_fn(r[0])[0] if link_urls_fn else None
+        species_cell = (
+            td_html(a_external(species_url, r[0], rel="noopener"))
+            if species_url
+            else td_plain(r[0])
+        )
+        rows_html.append(
+            tr_row(
+                species_cell,
+                _td_trusted_html(r[1]),
+                td_plain(_region_state(r[3], r[2])),
+                td_plain(_region_country(r[3])),
+                _td_trusted_html(r[4]),
+                td_plain(r[5], style=METRIC_CELL_STYLE),
+            )
+        )
+    body = "".join(rows_html)
+    tbl = (
+        "<table class='stats-tbl rankings-tbl heard-only-tbl'>"
+        "<thead><tr>"
+        + "".join(
+            th_plain(h)
+            for h in (
+                "Species",
+                "Location",
+                "State",
+                "Country",
+                "Last heard",
+                "Records",
+            )
+        )
+        + "</tr></thead><tbody>"
+        f"{body}</tbody></table>"
+    )
+    return rankings_scroll_wrapper(tbl, scroll_hint, visible_rows)
+
+
 def rankings_high_counts_table(
     rows,
     include_heading=True,

--- a/tests/explorer/test_checklist_stats.py
+++ b/tests/explorer/test_checklist_stats.py
@@ -62,15 +62,26 @@ def test_rankings_interesting_lists_includes_high_counts_before_seen_once():
     titles = [t for t, _ in stats["rankings_sections_other"]]
     assert "Species: High counts" in titles
     assert "Species: Seen only once" in titles
-    assert "Heard-only species" in titles
+    assert "Species: Only heard but never seen" in titles
     assert titles.index("Species: High counts") < titles.index("Species: Seen only once")
-    assert titles.index("Species: Seen only once") < titles.index("Heard-only species")
-    assert titles.index("Heard-only species") < titles.index("Species: Not seen in the past year")
-    heard_html = next(html for t, html in stats["rankings_sections_other"] if t == "Heard-only species")
+    assert titles.index("Species: Seen only once") < titles.index(
+        "Species: Only heard but never seen"
+    )
+    assert titles.index("Species: Only heard but never seen") < titles.index(
+        "Species: Not seen in the past year"
+    )
+    heard_html = next(
+        html
+        for t, html in stats["rankings_sections_other"]
+        if t == "Species: Only heard but never seen"
+    )
     assert "About this list:" in heard_html
     assert "<strong>About this list:</strong>" in heard_html
     assert "Heard only" in heard_html
     assert "don’t count" in heard_html
+    assert "heard-only-about-note" in heard_html
+    assert "background:#e8f4fc" not in heard_html
+    assert "border-left:4px solid #1c83e1" not in heard_html
 
 
 def test_compute_checklist_stats_repeated_species_and_multi_year():

--- a/tests/explorer/test_checklist_stats.py
+++ b/tests/explorer/test_checklist_stats.py
@@ -62,7 +62,15 @@ def test_rankings_interesting_lists_includes_high_counts_before_seen_once():
     titles = [t for t, _ in stats["rankings_sections_other"]]
     assert "Species: High counts" in titles
     assert "Species: Seen only once" in titles
+    assert "Heard-only species" in titles
     assert titles.index("Species: High counts") < titles.index("Species: Seen only once")
+    assert titles.index("Species: Seen only once") < titles.index("Heard-only species")
+    assert titles.index("Heard-only species") < titles.index("Species: Not seen in the past year")
+    heard_html = next(html for t, html in stats["rankings_sections_other"] if t == "Heard-only species")
+    assert "About this list:" in heard_html
+    assert "<strong>About this list:</strong>" in heard_html
+    assert "Heard only" in heard_html
+    assert "don’t count" in heard_html
 
 
 def test_compute_checklist_stats_repeated_species_and_multi_year():

--- a/tests/explorer/test_checklist_stats_compute.py
+++ b/tests/explorer/test_checklist_stats_compute.py
@@ -128,6 +128,7 @@ def test_compute_and_format_returns_expected_summary_and_sections():
         "Species: Subspecies occurrence",
         "Species: High counts",
         "Species: Seen only once",
+        "Heard-only species",
         "Species: Not seen in the past year",
     ]
 

--- a/tests/explorer/test_checklist_stats_compute.py
+++ b/tests/explorer/test_checklist_stats_compute.py
@@ -128,7 +128,7 @@ def test_compute_and_format_returns_expected_summary_and_sections():
         "Species: Subspecies occurrence",
         "Species: High counts",
         "Species: Seen only once",
-        "Heard-only species",
+        "Species: Only heard but never seen",
         "Species: Not seen in the past year",
     ]
 

--- a/tests/explorer/test_integration_fixture.py
+++ b/tests/explorer/test_integration_fixture.py
@@ -339,6 +339,7 @@ def test_integration_compute_rankings_returns_expected_structure(fixture_df, fix
         "individuals_loc",
         "visited",
         "seen_once",
+        "heard_only",
         "species_individuals",
         "species_checklists",
         "species_high_counts",

--- a/tests/explorer/test_rankings_display.py
+++ b/tests/explorer/test_rankings_display.py
@@ -7,6 +7,7 @@ from explorer.presentation.rankings_display import (
     rankings_table_with_rank,
     rankings_visited_table,
     rankings_seen_once_table,
+    rankings_heard_only_species_table,
     rankings_subspecies_hierarchical_table,
 )
 
@@ -152,6 +153,29 @@ def test_rankings_seen_once_table_empty_no_data():
     out = rankings_seen_once_table([], include_heading=True)
     assert "No data." in out
     assert "Seen only once" in out
+
+
+def test_rankings_heard_only_species_table_headers_and_links():
+    """Heard-only table includes expected headers and species link."""
+    out = rankings_heard_only_species_table(
+        [
+            (
+                "Southern Boobook",
+                '<a href="https://ebird.org/lifelist/L1">Park</a>',
+                "NSW",
+                "AU",
+                '<a href="https://ebird.org/checklist/S1">01 Jan 2025 06:00</a>',
+                "2",
+            )
+        ],
+        include_heading=False,
+        link_urls_fn=lambda _name: ("https://ebird.org/species/souboo1", None),
+    )
+    assert "Last heard" in out
+    assert "Records" in out
+    assert "Southern Boobook" in out
+    assert 'href="https://ebird.org/species/souboo1"' in out
+    assert "heard-only-tbl" in out
 
 
 def test_rankings_table_with_rank_species_url_fn_injects_links():

--- a/tests/explorer/test_rankings_display.py
+++ b/tests/explorer/test_rankings_display.py
@@ -195,14 +195,12 @@ def test_rankings_heard_only_footer_scrolls_inside_table_area():
         include_heading=False,
         footer_html=footer,
     )
-    assert "rankings-scroll-inner" in out
-    assert out.index("heard-only-tbl") < out.index("heard-only-about-note")
-    assert out.index("rankings-scroll-inner") < out.index("heard-only-about-note")
-    # Note precedes the closing of the scroll-inner div (before absolute shades).
     inner_start = out.index("rankings-scroll-inner")
+    inner_end = out.index("</div>", inner_start)
+    table_at = out.index("heard-only-tbl", inner_start)
     note_at = out.index("heard-only-about-note")
-    assert "</div>" in out[note_at:]
-    assert note_at < out.index("rankings-scroll-shade", inner_start)
+
+    assert inner_start < table_at < note_at < inner_end
 
 
 def test_rankings_table_with_rank_species_url_fn_injects_links():

--- a/tests/explorer/test_rankings_display.py
+++ b/tests/explorer/test_rankings_display.py
@@ -178,6 +178,33 @@ def test_rankings_heard_only_species_table_headers_and_links():
     assert "heard-only-tbl" in out
 
 
+def test_rankings_heard_only_footer_scrolls_inside_table_area():
+    """About-note footer is inside the scroll area after the table rows."""
+    footer = '<p class="heard-only-about-note">About this list:</p>'
+    out = rankings_heard_only_species_table(
+        [
+            (
+                "Southern Boobook",
+                "Park",
+                "NSW",
+                "AU",
+                "01 Jan 2025 06:00",
+                "1",
+            )
+        ],
+        include_heading=False,
+        footer_html=footer,
+    )
+    assert "rankings-scroll-inner" in out
+    assert out.index("heard-only-tbl") < out.index("heard-only-about-note")
+    assert out.index("rankings-scroll-inner") < out.index("heard-only-about-note")
+    # Note precedes the closing of the scroll-inner div (before absolute shades).
+    inner_start = out.index("rankings-scroll-inner")
+    note_at = out.index("heard-only-about-note")
+    assert "</div>" in out[note_at:]
+    assert note_at < out.index("rankings-scroll-shade", inner_start)
+
+
 def test_rankings_table_with_rank_species_url_fn_injects_links():
     """When species_url_fn is provided and returns a URL, species name is linked."""
     def url_fn(name):

--- a/tests/explorer/test_stats.py
+++ b/tests/explorer/test_stats.py
@@ -453,6 +453,26 @@ class TestRankingsHeardOnlySpecies:
         )
         assert rankings_heard_only_species(df) == []
 
+    def test_seen_subspecies_record_excludes_parent_species(self):
+        """All records for a base species include its subspecies observations."""
+        df = _obs_df(
+            [
+                {
+                    "Submission ID": "S1",
+                    "Scientific Name": "Gymnorhina tibicen",
+                    "Common Name": "Australian Magpie",
+                    "Observation Details": "Heard only",
+                },
+                {
+                    "Submission ID": "S2",
+                    "Scientific Name": "Gymnorhina tibicen tibicen",
+                    "Common Name": "Australian Magpie (Black-backed)",
+                    "Observation Details": "Seen well",
+                },
+            ]
+        )
+        assert rankings_heard_only_species(df) == []
+
     def test_mid_sentence_heard_only_does_not_qualify_record(self):
         df = _obs_df(
             [

--- a/tests/explorer/test_stats.py
+++ b/tests/explorer/test_stats.py
@@ -1,6 +1,7 @@
 """Tests for explorer.core.stats module."""
 
 import pandas as pd
+import pytest
 
 from explorer.core.stats import (
     checklist_country_keys,
@@ -16,6 +17,8 @@ from explorer.core.stats import (
     rankings_by_checklists,
     rankings_subspecies_hierarchical,
     rankings_seen_once,
+    rankings_heard_only_species,
+    observation_details_has_heard_only,
     rankings_by_visits,
     rankings_not_seen_recently,
     rankings_not_seen_recently_in_country,
@@ -364,6 +367,126 @@ class TestRankingsSeenOnce:
         assert "Chestnut Teal" in rows[0][0]
 
 
+class TestHeardOnlyMatching:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Heard only",
+            "Heard only.",
+            "heard only",
+            "HEARD ONLY.",
+            "Six birds calling and counted. Heard only",
+            "Six birds calling and counted. Heard only.",
+            "Heard only. Count is an estimate based on birds that could be clearly separated by time and location.",
+        ],
+    )
+    def test_standalone_heard_only_matches(self, text):
+        assert observation_details_has_heard_only(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Several birds seen, mostly heard only.",
+            "H",
+            "HO",
+            "Heard",
+            "heard only sometimes",
+            "",
+            None,
+        ],
+    )
+    def test_non_standalone_or_abbreviation_does_not_match(self, text):
+        assert observation_details_has_heard_only(text) is False
+
+
+class TestRankingsHeardOnlySpecies:
+    def test_missing_observation_details_column_returns_empty(self):
+        df = _obs_df([{"Scientific Name": "Anas gracilis", "Common Name": "Grey Teal"}])
+        assert rankings_heard_only_species(df) == []
+
+    def test_species_included_when_every_record_is_heard_only(self):
+        df = _obs_df(
+            [
+                {
+                    "Submission ID": "S1",
+                    "Scientific Name": "Ninox novaeseelandiae",
+                    "Common Name": "Southern Boobook",
+                    "Observation Details": "Heard only",
+                    "Date": pd.Timestamp("2024-01-01"),
+                    "Location": "Park A",
+                    "Location ID": "L_A",
+                },
+                {
+                    "Submission ID": "S2",
+                    "Scientific Name": "Ninox novaeseelandiae",
+                    "Common Name": "Southern Boobook",
+                    "Observation Details": "Six birds calling. Heard only.",
+                    "Date": pd.Timestamp("2025-06-01"),
+                    "Location": "Park B",
+                    "Location ID": "L_B",
+                },
+            ]
+        )
+        rows = rankings_heard_only_species(df)
+        assert len(rows) == 1
+        assert rows[0][0] == "Southern Boobook"
+        assert "Park B" in rows[0][1]
+        assert "S2" in rows[0][4]
+        assert rows[0][5] == "2"
+
+    def test_species_excluded_when_any_record_lacks_notation(self):
+        df = _obs_df(
+            [
+                {
+                    "Submission ID": "S1",
+                    "Scientific Name": "Ninox novaeseelandiae",
+                    "Common Name": "Southern Boobook",
+                    "Observation Details": "Heard only",
+                },
+                {
+                    "Submission ID": "S2",
+                    "Scientific Name": "Ninox novaeseelandiae",
+                    "Common Name": "Southern Boobook",
+                    "Observation Details": "Seen well",
+                },
+            ]
+        )
+        assert rankings_heard_only_species(df) == []
+
+    def test_mid_sentence_heard_only_does_not_qualify_record(self):
+        df = _obs_df(
+            [
+                {
+                    "Scientific Name": "Ninox novaeseelandiae",
+                    "Common Name": "Southern Boobook",
+                    "Observation Details": "Several birds seen, mostly heard only.",
+                },
+            ]
+        )
+        assert rankings_heard_only_species(df) == []
+
+    def test_seen_species_does_not_block_unrelated_heard_only_species(self):
+        df = _obs_df(
+            [
+                {
+                    "Submission ID": "S1",
+                    "Scientific Name": "Anas gracilis",
+                    "Common Name": "Grey Teal",
+                    "Observation Details": "",
+                },
+                {
+                    "Submission ID": "S2",
+                    "Scientific Name": "Ninox novaeseelandiae",
+                    "Common Name": "Southern Boobook",
+                    "Observation Details": "Heard only.",
+                },
+            ]
+        )
+        rows = rankings_heard_only_species(df)
+        assert len(rows) == 1
+        assert rows[0][0] == "Southern Boobook"
+
+
 class TestRankingsByVisits:
     def test_most_visited(self):
         cl = pd.DataFrame({
@@ -568,7 +691,8 @@ class TestComputeRankings:
         cl["Date"] = pd.to_datetime(cl["Date"])
         result = compute_rankings(df, cl, limit=10, dur_col=None, dist_col=None)
         expected_keys = {"time", "dist", "species", "individuals", "species_loc", "individuals_loc",
-                         "visited", "species_individuals", "species_checklists", "species_high_counts", "seen_once", "subspecies",
+                         "visited", "species_individuals", "species_checklists", "species_high_counts", "seen_once",
+                         "heard_only", "subspecies",
                          "not_seen_recently"}
         assert set(result.keys()) == expected_keys
 


### PR DESCRIPTION
## Summary
Adds an Interesting Lists expander that surfaces countable species whose every eBird observation is marked with a standalone **Heard only** note in Observation Details — useful for spotting birds heard but never seen.

## Changes
- Core matching and species-level rollup in `stats.py` (`observation_details_has_heard_only`, `rankings_heard_only_species`)
- Rankings table with Species / Location / State / Country / Last heard / Records
- Expander title: **Species: Only heard but never seen**
- Muted caption under the table (same style as Species: Coverage footnotes); scrolls with the list
- Wired into rankings compute/format bundle and regression checklist
- Unit and integration tests for match rules, include/exclude logic, and section order

## Testing
- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q -m "not e2e"` (979 passed, 4 skipped)
- Manual: Rankings → Interesting Lists → open the new expander with a real export

## Notes
- Matching is deliberately strict (standalone “Heard only” only; no H / HO / mid-sentence phrases)
- A species is listed only when **every** record for that base species matches

## Issues
Fixes #370

Made with [Cursor](https://cursor.com)