### PR TITLE
Clarify Shared checklists as Checklists with others

### DIFF
--- a/docs/explorer/regression-checklist.md
+++ b/docs/explorer/regression-checklist.md
@@ -38,7 +38,7 @@ Run before merging refactor branches to `main`.
   - Traveling / stationary / incidental counts
   - Completed / incomplete checklists
   - Days with checklist / cumulative days eBird on
-  - Shared checklists / days birding with others
+  - Checklists with others / days birding with others
 
 ## Country
 - Per-country accordions load (export needs `Country` and/or `State/Province`); headings in **A–Z** order by display name (`Unknown` last)

--- a/explorer/core/stats.py
+++ b/explorer/core/stats.py
@@ -340,7 +340,7 @@ def shared_checklist_stats(
 
 
 def sum_shared_checklist_minutes(cl: pd.DataFrame, dur_col: str) -> float:
-    """Sum duration minutes for shared checklists (observers > 1)."""
+    """Sum duration minutes for checklists with others (observers > 1)."""
     shared_rows = shared_checklist_rows(cl)
     if shared_rows is None or shared_rows.empty:
         return 0.0

--- a/explorer/core/stats.py
+++ b/explorer/core/stats.py
@@ -301,6 +301,9 @@ def sum_timed_birding_minutes(cl: pd.DataFrame, dur_col: str) -> float:
 def shared_checklist_rows(cl: pd.DataFrame) -> pd.DataFrame | None:
     """Rows in deduped checklist *cl* where Number of Observers > 1.
 
+    This is "birding with others" in the export, not eBird's share-with-another-account
+    glyph (the MyEBirdData CSV has no column for that).
+
     Returns ``None`` when the observers column is missing; empty frame when none qualify.
     """
     if "Number of Observers" not in cl.columns:
@@ -1503,12 +1506,15 @@ def yearly_summary_stats(
     else:
         row_incidental_checklists = ("Incidental checklists", ["—"] * len(years_sorted))
 
-    # Shared checklists / Days birding with others
+    # Observers > 1 / Days birding with others (not eBird share-account glyph)
     shared_sub = shared_checklist_rows(cl)
     if shared_sub is not None and not shared_sub.empty:
         by_yr_shared = shared_sub.groupby("_year").size()
         vals_shared = [int(by_yr_shared.get(y, 0)) for y in years_sorted]
-        row_shared_checklists = ("Shared checklists", [f"{v:,}" for v in vals_shared])
+        row_shared_checklists = (
+            "Checklists with others",
+            [f"{v:,}" for v in vals_shared],
+        )
         shared_sub = shared_sub.copy()
         shared_sub["_date"] = shared_sub["Date"].dt.normalize()
         by_yr_days = shared_sub.groupby("_year")["_date"].nunique()
@@ -1518,7 +1524,10 @@ def yearly_summary_stats(
             [f"{v:,}" for v in vals_days_bo],
         )
     else:
-        row_shared_checklists = ("Shared checklists", ["—"] * len(years_sorted))
+        row_shared_checklists = (
+            "Checklists with others",
+            ["—"] * len(years_sorted),
+        )
         row_days_birding_with_others = (
             "Days birding with others",
             ["—"] * len(years_sorted),

--- a/explorer/presentation/checklist_stats_display.py
+++ b/explorer/presentation/checklist_stats_display.py
@@ -833,7 +833,7 @@ def checklist_stats_streamlit_tab_sections_html(payload: ChecklistStatsPayload) 
         ("Days with a checklist", f"{payload.n_days_with_checklist:,}"),
     ]
     others_rows: List[Tuple[str, str]] = [
-        ("Shared checklists", f"{payload.n_shared:,}"),
+        ("Checklists with others", f"{payload.n_shared:,}"),
         ("Minutes eBirding with others", f"{payload.shared_minutes:,.0f}"),
         ("Hours eBirding with others", f"{payload.shared_hours:,.2f}"),
         ("Days birding with others", f"{payload.n_days_birding_with_others:,}"),

--- a/explorer/presentation/share_summary_metrics.py
+++ b/explorer/presentation/share_summary_metrics.py
@@ -81,7 +81,8 @@ _STAT_SPECS: tuple[_StatSpec, ...] = (
     _StatSpec("longest_streak", "Longest streak (days)"),
     _StatSpec("birding_hours", "Birding hours", decimals=1),
     _StatSpec("distance_km", "Total distance (km)", decimals=1),
-    _StatSpec("shared_checklists", "Shared checklists", hide_if_zero=True),
+    # Observers > 1 in the CSV — not eBird's "shared with another account" glyph.
+    _StatSpec("shared_checklists", "Checklists with others", hide_if_zero=True),
     _StatSpec(
         "days_birding_with_others", "Days birding with others", hide_if_zero=True
     ),
@@ -161,7 +162,7 @@ _SUMMARY_STATUS_ORDER: tuple[str, ...] = (
     "Total checklists",
     "Completed checklists",
     "Incidental checklists",
-    "Shared checklists",
+    "Checklists with others",
     "Unique locations",
     "Countries",
     "Birding hours",

--- a/tests/explorer/test_checklist_stats.py
+++ b/tests/explorer/test_checklist_stats.py
@@ -51,6 +51,8 @@ def test_compute_checklist_stats_returns_expected_keys():
     assert "<tr><td>Total checklists</td><td>1</td></tr>" in html
     assert "<tr><td>Total species</td><td>1</td></tr>" in html
     assert "<tr><td>Total individuals</td><td>3</td></tr>" in html
+    assert "<tr><td>Checklists with others</td><td>1</td></tr>" in html
+    assert "Shared checklists" not in html
 
     # Total Distance table: single checklist with 1.5 km traveled
     assert "<tr><td>Kilometers traveled</td><td>1.50</td></tr>" in html

--- a/tests/explorer/test_share_summary_compute.py
+++ b/tests/explorer/test_share_summary_compute.py
@@ -342,6 +342,38 @@ def test_shared_checklists_and_days_birding_with_others():
     assert stats.days_birding_with_others == 2
 
 
+def test_checklists_with_others_counts_observers_gt_one_not_ebird_share_glyph():
+    """Solo-observer checklists are excluded even when eBird UI may show a share glyph.
+
+    MyEBirdData has no share-with-account column; the metric is observers > 1
+    and is labelled "Checklists with others" (see #373 / Warribee trip).
+    """
+    rows = [
+        _row(sid=f"S_shared_{i}", dt="2026-07-26", species=f"Sp {i}", observers=3)
+        for i in range(54)
+    ]
+    rows.extend(
+        [
+            _row(sid="S_solo_1", dt="2026-07-26", species="Solo a", observers=1),
+            _row(sid="S_solo_2", dt="2026-07-26", species="Solo b", observers=1),
+            _row(sid="S_solo_3", dt="2026-07-26", species="Solo c", observers=1),
+            _row(sid="S_solo_4", dt="2026-07-27", species="Solo d", observers=1),
+            _row(sid="S_solo_5", dt="2026-07-27", species="Solo e", observers=1),
+            _row(sid="S_solo_6", dt="2026-07-28", species="Solo f", observers=1),
+            _row(sid="S_solo_7", dt="2026-07-28", species="Solo g", observers=1),
+        ]
+    )
+    stats = compute_share_summary_stats(
+        pd.DataFrame(rows), period_for_custom(date(2026, 7, 26), date(2026, 7, 28))
+    )
+    assert stats is not None
+    assert stats.checklists == 61
+    assert stats.shared_checklists == 54
+    labels = dict(summary_status_metrics(stats))
+    assert labels["Checklists with others"] == "54"
+    assert "Shared checklists" not in labels
+
+
 def test_shared_stats_none_without_observers_column():
     row = _row(sid="S1", dt="2025-06-01", species="Species a")
     del row["Number of Observers"]

--- a/tests/explorer/test_share_summary_preview.py
+++ b/tests/explorer/test_share_summary_preview.py
@@ -144,7 +144,7 @@ def test_tiles_grid_uses_uniform_cell_sizing_across_formats():
     )
     labels_fourteen = labels_twelve + (
         "Total distance (km)",
-        "Shared checklists",
+        "Checklists with others",
     )
     square = render_share_summary_preview_html(
         stats, layout="tiles", fmt="square", card_stat_labels=labels_six
@@ -167,7 +167,7 @@ def test_tiles_grid_uses_uniform_cell_sizing_across_formats():
         assert "padding:32px 20px" in html
         assert "gap:20px" in html
     assert story_fourteen.count('font-size:52px;font-weight:700;">') == 14
-    assert "Shared checklists" in story_fourteen
+    assert "Checklists with others" in story_fourteen
     assert 'font-size:40px;font-weight:700;">' not in story_six
     assert 'font-size:40px;font-weight:700;">' not in story_twelve
 
@@ -299,7 +299,7 @@ def test_summary_status_metrics_preferred_order():
         "Total checklists",
         "Completed checklists",
         "Incidental checklists",
-        "Shared checklists",
+        "Checklists with others",
         "Unique locations",
         "Countries",
         "Birding hours",
@@ -814,7 +814,7 @@ def test_stat_pairs_hide_zero_shared_stats_and_geo_scope_countries():
     )
     world_labels = [label for label, _ in stat_pairs(stats)]
     assert "Countries" in world_labels
-    assert "Shared checklists" not in world_labels
+    assert "Checklists with others" not in world_labels
     assert "Days birding with others" not in world_labels
 
     regional_labels = [

--- a/tests/explorer/test_stats.py
+++ b/tests/explorer/test_stats.py
@@ -776,7 +776,7 @@ class TestYearlySummaryStats:
             "Traveling checklists",
             "Stationary checklists",
             "Incidental checklists",
-            "Shared checklists",
+            "Checklists with others",
             "Days with checklist",
             "Days birding with others",
             "Cumulative days eBird on",


### PR DESCRIPTION
## Summary

Rename the misleading **Shared checklists** label to **Checklists with others** so it matches what the Explorer actually counts (`Number of Observers > 1`), not eBird’s share-with-another-account glyph. The CSV has no share-account column; the Warribee trip “undercount” was a definition mismatch (and sometimes stale party size in eBird), not a calculation bug.

## Changes

- Relabel Social Cards / share-summary metrics, Checklist Statistics, and Yearly Summary to **Checklists with others**
- Document in `shared_checklist_rows` that this is observers > 1, not the eBird share glyph
- Add regression test for the Warribee-shaped 61/54 case and updated label assertions
- Update regression checklist wording

## Testing

- `python3 -m ruff check explorer/`
- `python3 -m pytest tests/ -q` (981 passed, 11 skipped)
- Verified against reporter CSV for 2026-07-26..2026-07-28: 61 checklists, 54 with observers > 1

## Notes

- Internal attribute names (`shared_checklists`, `n_shared`) unchanged
- Same shared computation path for Social Cards, Checklist Statistics, and Yearly Summary

## Issues

Fixes #373

Made with [Cursor](https://cursor.com)